### PR TITLE
[develop] Add support for Capacity Blocks for ML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ------
 
 **ENHANCEMENTS**
+- Add support for EC2 Capacity Blocks for ML.
 - Add support for Data Repository Associations when using PERSISTENT_2 as DeploymentType for a managed FSx for Lustre.
 - Add `Scheduling/SlurmSettings/Database/DatabaseName` parameter to allow users to specify a custom name for the database on the database server to be used for Slurm accounting.
 - Add `Monitoring/Alarms/Enabled` parameter to toggle Amazon CloudWatch Alarms for the cluster.

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -24,6 +24,7 @@ from pcluster.constants import (
 )
 
 CAPACITY_BLOCK_REQUESTED_QUANTITY_TAG_KEY = "aws:ec2capacityreservation:incrementalRequestedQuantity"
+CAPACITY_BLOCK_RESERVATION_TYPE_TAG_KEY = "aws:ec2capacityreservation:capacityReservationType"
 
 
 class StackInfo:
@@ -486,24 +487,37 @@ class CapacityReservationInfo:
     },
 
     # describe-capacity-reservations --capacity-type capacity-block
-    {   "CapacityReservationId": "cr-a1234567",
+    {
+        "CapacityReservationId": "cr-a1234567",
         "OwnerId": "123",
-        "CapacityReservationArn": "arn:aws:ec2:eu-west-1:123:capacity-reservation/cr-a123456",
-        "EndDateType": "limited",
-        "ReservationType": "capacity-block",
-        "AvailabilityZone": "eu-east-2a",
-        "InstanceMatchCriteria":  "targeted",
-        "EphemeralStorage": false,
-        "CreateDate": "2023-07-29T14:22:45Z  ",
-        “StartDate": "2023-08-15T12:00:00Z",
-        “EndDate": "2023-08-19T12:00:00Z",
+        "CapacityReservationArn": "arn:aws:ec2:us-east-2:123:capacity-reservation/cr-a123456",
+        "AvailabilityZoneId": "use2-az1",
+        "InstanceType": "p5.48xlarge",
+        "InstancePlatform": "Linux/UNIX",
+        "AvailabilityZone": "us-east-2a",
+        "Tenancy": "default",
+        "TotalInstanceCount": 0,
         "AvailableInstanceCount": 0,
-        "InstancePlatform":  "Linux/UNIX",
-        "TotalInstanceCount": 16,
-        “State": "payment-pending",
-        "Tenancy":  "default",
-        "EbsOptimized": true,
-        "InstanceType": "p5.48xlarge“
+        "EbsOptimized": false,
+        "EphemeralStorage": false,
+        "State": "scheduled",
+        "StartDate": "2023-11-20T11:30:00+00:00",
+        "EndDate": "2023-11-21T11:30:00+00:00",
+        "EndDateType": "limited",
+        "InstanceMatchCriteria": "targeted",
+        "CreateDate": "2023-11-06T12:03:21+00:00",
+        "Tags": [
+            {
+                "Key": "aws:ec2capacityreservation:incrementalRequestedQuantity",
+                "Value": "1"
+            },
+            {
+                "Key": "aws:ec2capacityreservation:capacityReservationType",
+                "Value": "capacity-block"
+            }
+        ],
+        "CapacityAllocations": [],
+        "ReservationType": "capacity-block"
     }
     """
 
@@ -535,8 +549,14 @@ class CapacityReservationInfo:
         return self.capacity_reservation_data.get("PlacementGroupArn")
 
     def reservation_type(self):
-        """Return the reservation type, if present, None otherwise."""
-        return self.capacity_reservation_data.get("ReservationType")
+        """
+        Return the reservation type, if present, None otherwise.
+
+        Return the value of the tag CAPACITY_BLOCK_RESERVATION_TYPE_TAG_KEY, if ReservationType tag is not valued.
+        """
+        return self.capacity_reservation_data.get(
+            "ReservationType", self.get_tag(CAPACITY_BLOCK_RESERVATION_TYPE_TAG_KEY)
+        )
 
     def total_instance_count(self):
         """Return the total instance count, if present, 0 otherwise."""

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -23,6 +23,8 @@ from pcluster.constants import (
     SUPPORTED_ARCHITECTURES,
 )
 
+CAPACITY_BLOCK_REQUESTED_QUANTITY_TAG_KEY = "aws:ec2capacityreservation:incrementalRequestedQuantity"
+
 
 class StackInfo:
     """Object to store Stack information, initialized with a describe_stacks call."""
@@ -539,6 +541,22 @@ class CapacityReservationInfo:
     def total_instance_count(self):
         """Return the total instance count, if present, 0 otherwise."""
         return self.capacity_reservation_data.get("TotalInstanceCount", 0)
+
+    def get_tag(self, tag_key: str):
+        """Get stack tag by tag key."""
+        return next(
+            iter([tag["Value"] for tag in self.capacity_reservation_data.get("Tags", []) if tag["Key"] == tag_key]),
+            None,
+        )
+
+    def incremental_requested_quantity(self):
+        """
+        Return the value of the tag CAPACITY_BLOCK_REQUESTED_QUANTITY_TAG_KEY, 0 otherwise.
+
+        This only exists for Capacity Blocks reservation.
+        """
+        requested_quantity = self.get_tag(CAPACITY_BLOCK_REQUESTED_QUANTITY_TAG_KEY)
+        return int(requested_quantity) if requested_quantity and isinstance(requested_quantity, str) else 0
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -449,3 +449,53 @@ class ImageInfo:
 
     def _get_tag(self, tag_key: str):
         return next(iter([tag["Value"] for tag in self.tags if tag["Key"] == tag_key]), None)
+
+
+class CapacityReservationInfo:
+    """
+    Data object wrapping the result of a describe-capacity-reservations call.
+
+    {
+        "CapacityReservationId": "cr-abcdEXAMPLE9876ef ",
+        "EndDateType": "unlimited",
+        "AvailabilityZone": "eu-west-1a",
+        "InstanceMatchCriteria": "open",
+        "Tags": [],
+        "EphemeralStorage": false,
+        "CreateDate": "2019-08-07T11:34:19.000Z",
+        "AvailableInstanceCount": 3,
+        "InstancePlatform": "Linux/UNIX",
+        "TotalInstanceCount": 3,
+        "State": "cancelled",
+        "Tenancy": "default",
+        "EbsOptimized": true,
+        "InstanceType": "m5.large"
+    }
+    """
+
+    def __init__(self, capacity_reservation_data):
+        self.capacity_reservation_data = capacity_reservation_data
+
+    def capacity_reservation_arn(self):
+        """Return the arn of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("CapacityReservationArn")
+
+    def capacity_reservation_id(self):
+        """Return the id of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("CapacityReservationId")
+
+    def state(self):
+        """Return the state of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("State")
+
+    def instance_type(self):
+        """Return the instance type associated to the Capacity Reservation."""
+        return self.capacity_reservation_data.get("InstanceType")
+
+    def availability_zone(self):
+        """Return the availability zone associated to the Capacity Reservation."""
+        return self.capacity_reservation_data.get("AvailabilityZone")
+
+    def placement_group_arn(self):
+        """Return the placement group arn of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("PlacementGroupArn")

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -536,5 +536,9 @@ class CapacityReservationInfo:
         """Return the reservation type, if present, None otherwise."""
         return self.capacity_reservation_data.get("ReservationType")
 
+    def total_instance_count(self):
+        """Return the total instance count, if present, 0 otherwise."""
+        return self.capacity_reservation_data.get("TotalInstanceCount", 0)
+
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -456,20 +456,52 @@ class CapacityReservationInfo:
     Data object wrapping the result of a describe-capacity-reservations call.
 
     {
-        "CapacityReservationId": "cr-abcdEXAMPLE9876ef ",
-        "EndDateType": "unlimited",
-        "AvailabilityZone": "eu-west-1a",
-        "InstanceMatchCriteria": "open",
-        "Tags": [],
-        "EphemeralStorage": false,
-        "CreateDate": "2019-08-07T11:34:19.000Z",
-        "AvailableInstanceCount": 3,
+        "CapacityReservationId": "cr-a1234567",
+        "OwnerId": "123",
+        "CapacityReservationArn": "arn:aws:ec2:eu-west-1:123:capacity-reservation/cr-a123456",
+        "AvailabilityZoneId": "euw1-az3",
+        "InstanceType": "t2.large",
         "InstancePlatform": "Linux/UNIX",
-        "TotalInstanceCount": 3,
-        "State": "cancelled",
+        "AvailabilityZone": "eu-west-1a",
         "Tenancy": "default",
+        "TotalInstanceCount": 1,
+        "AvailableInstanceCount": 0,
+        "EbsOptimized": false,
+        "EphemeralStorage": false,
+        "State": "active",
+        "StartDate": "2023-11-02T12:16:35+00:00",
+        "EndDate": "2023-11-03T09:00:00+00:00",
+        "EndDateType": "limited",
+        "InstanceMatchCriteria": "open",
+        "CreateDate": "2023-11-02T12:16:35+00:00",
+        "Tags": [],
+        "CapacityAllocations": [
+            {
+                "AllocationType": "used",
+                "Count": 1
+            }
+        ]
+    },
+
+    # describe-capacity-reservations --capacity-type capacity-block
+    {   "CapacityReservationId": "cr-a1234567",
+        "OwnerId": "123",
+        "CapacityReservationArn": "arn:aws:ec2:eu-west-1:123:capacity-reservation/cr-a123456",
+        "EndDateType": "limited",
+        "ReservationType": "capacity-block",
+        "AvailabilityZone": "eu-east-2a",
+        "InstanceMatchCriteria":  "targeted",
+        "EphemeralStorage": false,
+        "CreateDate": "2023-07-29T14:22:45Z  ",
+        “StartDate": "2023-08-15T12:00:00Z",
+        “EndDate": "2023-08-19T12:00:00Z",
+        "AvailableInstanceCount": 0,
+        "InstancePlatform":  "Linux/UNIX",
+        "TotalInstanceCount": 16,
+        “State": "payment-pending",
+        "Tenancy":  "default",
         "EbsOptimized": true,
-        "InstanceType": "m5.large"
+        "InstanceType": "p5.48xlarge“
     }
     """
 
@@ -499,3 +531,10 @@ class CapacityReservationInfo:
     def placement_group_arn(self):
         """Return the placement group arn of the Capacity Reservation."""
         return self.capacity_reservation_data.get("PlacementGroupArn")
+
+    def reservation_type(self):
+        """Return the reservation type, if present, None otherwise."""
+        return self.capacity_reservation_data.get("ReservationType")
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -16,7 +16,7 @@ from typing import Any, List, Tuple
 from botocore.exceptions import ClientError
 
 from pcluster import utils
-from pcluster.aws.aws_resources import ImageInfo, InstanceTypeInfo
+from pcluster.aws.aws_resources import CapacityReservationInfo, ImageInfo, InstanceTypeInfo
 from pcluster.aws.common import AWSClientError, AWSExceptionHandler, Boto3Client, Cache, ImageNotFoundError, get_region
 from pcluster.constants import (
     IMAGE_NAME_PART_TO_OS_MAP,
@@ -87,8 +87,8 @@ class Ec2Client(Boto3Client):
         return result
 
     @AWSExceptionHandler.handle_client_exception
-    def describe_capacity_reservations(self, capacity_reservation_ids):
-        """Return a list of Capacity Reservations."""
+    def describe_capacity_reservations(self, capacity_reservation_ids: List[str]) -> List[CapacityReservationInfo]:
+        """Accept a space separated list of ids. Return a list of CapacityReservationInfo."""
         result = []
         missed_capacity_reservations = []
         for capacity_reservation_id in capacity_reservation_ids:
@@ -106,8 +106,8 @@ class Ec2Client(Boto3Client):
             for capacity_reservation in response:
                 self.capacity_reservations_cache[
                     capacity_reservation.get("CapacityReservationId")
-                ] = capacity_reservation
-                result.append(capacity_reservation)
+                ] = CapacityReservationInfo(capacity_reservation)
+                result.append(CapacityReservationInfo(capacity_reservation))
         return result
 
     @AWSExceptionHandler.handle_client_exception

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -23,7 +23,7 @@ import pkg_resources
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.aws.common import AWSClientError, get_region
-from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, DeploymentSettings
+from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, CapacityType, DeploymentSettings
 from pcluster.config.common import Imds as TopLevelImds
 from pcluster.config.common import Resource
 from pcluster.constants import (
@@ -1440,14 +1440,6 @@ class BaseComputeResource(Resource):
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(NameValidator, name=self.name)
-
-
-class CapacityType(Enum):
-    """Enum to identify the type compute supported by the queues."""
-
-    CAPACITY_BLOCK = "CAPACITY_BLOCK"
-    ONDEMAND = "ONDEMAND"
-    SPOT = "SPOT"
 
 
 class ComputeSettings(Resource):
@@ -2909,6 +2901,7 @@ class SlurmClusterConfig(BaseClusterConfig):
                         capacity_reservation_id=cr_target.capacity_reservation_id,
                         instance_type=getattr(compute_resource, "instance_type", None),
                         subnet=queue.networking.subnet_ids[0],
+                        capacity_type=queue.capacity_type,
                     )
                     self._register_validator(
                         CapacityReservationResourceGroupValidator,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -3011,7 +3011,7 @@ class SlurmClusterConfig(BaseClusterConfig):
     def capacity_reservation_arns(self):
         """Return a list of capacity reservation ARNs specified in the config."""
         return [
-            capacity_reservation["CapacityReservationArn"]
+            capacity_reservation.capacity_reservation_arn()
             for capacity_reservation in AWSApi.instance().ec2.describe_capacity_reservations(
                 self.capacity_reservation_ids
             )

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2291,7 +2291,6 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
-        self._register_validator(ComputeResourceSizeValidator, min_count=self.min_count, max_count=self.max_count)
         self._register_validator(
             SchedulableMemoryValidator,
             schedulable_memory=self.schedulable_memory,
@@ -2547,6 +2546,12 @@ class SlurmQueue(_CommonQueue):
                 ).enabled
                 is False,
                 multi_az_enabled=self.multi_az_enabled,
+            )
+            self._register_validator(
+                ComputeResourceSizeValidator,
+                min_count=compute_resource.min_count,
+                max_count=compute_resource.max_count,
+                capacity_type=self.capacity_type,
             )
             if compute_resource.custom_slurm_settings:
                 self._register_validator(

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2899,7 +2899,7 @@ class SlurmClusterConfig(BaseClusterConfig):
                     self._register_validator(
                         CapacityReservationValidator,
                         capacity_reservation_id=cr_target.capacity_reservation_id,
-                        instance_type=getattr(compute_resource, "instance_type", None),
+                        instance_types=compute_resource.instance_types,
                         subnet=queue.networking.subnet_ids[0],
                         capacity_type=queue.capacity_type,
                     )

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1445,6 +1445,7 @@ class BaseComputeResource(Resource):
 class CapacityType(Enum):
     """Enum to identify the type compute supported by the queues."""
 
+    CAPACITY_BLOCK = "CAPACITY_BLOCK"
     ONDEMAND = "ONDEMAND"
     SPOT = "SPOT"
 
@@ -1463,12 +1464,20 @@ class BaseQueue(Resource):
     def __init__(self, name: str, capacity_type: str = None):
         super().__init__()
         self.name = Resource.init_param(name)
-        _capacity_type = CapacityType[capacity_type.upper()] if capacity_type else None
+        try:
+            _capacity_type = CapacityType[capacity_type.upper()] if isinstance(capacity_type, str) else None
+        except KeyError as e:
+            LOGGER.error("%s is not a valid CapacityType value, setting ONDEMAND", e)
+            _capacity_type = None
         self.capacity_type = Resource.init_param(_capacity_type, default=CapacityType.ONDEMAND)
 
     def is_spot(self):
         """Return True if the queue has SPOT capacity."""
         return self.capacity_type == CapacityType.SPOT
+
+    def is_capacity_block(self):
+        """Return True if the queue has CAPACITY_BLOCK capacity."""
+        return self.capacity_type == CapacityType.CAPACITY_BLOCK
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(NameValidator, name=self.name)
@@ -2444,6 +2453,7 @@ class AllocationStrategy(Enum):
 
     LOWEST_PRICE = "lowest-price"
     CAPACITY_OPTIMIZED = "capacity-optimized"
+    USE_CAPACITY_RESERVATIONS_FIRST = "use-capacity-reservations-first"
 
 
 class SlurmQueue(_CommonQueue):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2453,7 +2453,6 @@ class AllocationStrategy(Enum):
 
     LOWEST_PRICE = "lowest-price"
     CAPACITY_OPTIMIZED = "capacity-optimized"
-    USE_CAPACITY_RESERVATIONS_FIRST = "use-capacity-reservations-first"
 
 
 class SlurmQueue(_CommonQueue):
@@ -2476,10 +2475,11 @@ class SlurmQueue(_CommonQueue):
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources
         ):
+            default_allocation_strategy = None if self.is_capacity_block() else AllocationStrategy.LOWEST_PRICE
             self.allocation_strategy = (
                 AllocationStrategy[to_snake_case(allocation_strategy).upper()]
                 if allocation_strategy
-                else AllocationStrategy.LOWEST_PRICE
+                else default_allocation_strategy
             )
 
     @property

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import logging
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import List, Set
 
 from pcluster.validators.common import AsyncValidator, FailureLevel, ValidationResult, Validator, ValidatorContext
@@ -25,6 +26,14 @@ from pcluster.validators.networking_validators import LambdaFunctionsVpcConfigVa
 from pcluster.validators.s3_validators import UrlValidator
 
 LOGGER = logging.getLogger(__name__)
+
+
+class CapacityType(Enum):
+    """Enum to identify the type compute supported by the queues."""
+
+    CAPACITY_BLOCK = "CAPACITY_BLOCK"
+    ONDEMAND = "ONDEMAND"
+    SPOT = "SPOT"
 
 
 class ValidatorSuppressor(ABC):

--- a/cli/src/pcluster/launch_template_utils.py
+++ b/cli/src/pcluster/launch_template_utils.py
@@ -16,15 +16,18 @@ class _LaunchTemplateBuilder(ABC):
         return block_device_mappings
 
     def get_instance_market_options(self, queue, compute_resource):
-        """Return the instance market options for spot instances."""
+        """Return the instance market options for no on-demand instances."""
         instance_market_options = None
         if queue.is_spot():
-            instance_market_options = self._instance_market_option(
+            instance_market_options = self._spot_instance_market_option(
                 market_type="spot",
                 spot_instance_type="one-time",
                 instance_interruption_behavior="terminate",
                 max_price=None if compute_resource.spot_price is None else str(compute_resource.spot_price),
             )
+        elif queue.is_capacity_block():
+            instance_market_options = self._capacity_block_instance_market_option(market_type="capacity-block")
+
         return instance_market_options
 
     def get_capacity_reservation(self, queue, compute_resource):
@@ -44,7 +47,11 @@ class _LaunchTemplateBuilder(ABC):
         pass
 
     @abstractmethod
-    def _instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+    def _spot_instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+        pass
+
+    @abstractmethod
+    def _capacity_block_instance_market_option(self, market_type):
         pass
 
     @abstractmethod

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -33,7 +33,6 @@ from pcluster.config.cluster_config import (
     AwsBatchScheduling,
     AwsBatchSettings,
     CapacityReservationTarget,
-    CapacityType,
     CloudWatchDashboards,
     CloudWatchLogs,
     ClusterDevSettings,
@@ -94,7 +93,7 @@ from pcluster.config.cluster_config import (
     SlurmSettings,
     Timeouts,
 )
-from pcluster.config.common import BaseTag
+from pcluster.config.common import BaseTag, CapacityType
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.constants import (
     DELETION_POLICIES,

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -1046,7 +1046,7 @@ class CdkLaunchTemplateBuilder(_LaunchTemplateBuilder):
     def _block_device_mapping_for_virt(self, device_name, virtual_name):
         return ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(device_name=device_name, virtual_name=virtual_name)
 
-    def _instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+    def _spot_instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
         return ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(
             market_type=market_type,
             spot_options=ec2.CfnLaunchTemplate.SpotOptionsProperty(
@@ -1055,6 +1055,9 @@ class CdkLaunchTemplateBuilder(_LaunchTemplateBuilder):
                 max_price=max_price,
             ),
         )
+
+    def _capacity_block_instance_market_option(self, market_type):
+        return ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(market_type=market_type)
 
     def _capacity_reservation(self, cr_target):
         return ec2.CfnLaunchTemplate.CapacityReservationSpecificationProperty(

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -1416,7 +1416,7 @@ class DictLaunchTemplateBuilder(_LaunchTemplateBuilder):
     def _block_device_mapping_for_virt(self, device_name, virtual_name):
         return {"DeviceName": device_name, "VirtualName": virtual_name}
 
-    def _instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+    def _spot_instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
         return {
             "MarketType": market_type,
             "SpotOptions": remove_none_values(
@@ -1427,6 +1427,9 @@ class DictLaunchTemplateBuilder(_LaunchTemplateBuilder):
                 }
             ),
         }
+
+    def _capacity_block_instance_market_option(self, market_type):
+        return {"MarketType": market_type}
 
     def _capacity_reservation(self, cr_target):
         return {

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -20,6 +20,7 @@ from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.aws.common import AWSClientError
 from pcluster.cli.commands.dcv_util import get_supported_dcv_os
+from pcluster.config.common import CapacityType
 from pcluster.constants import (
     CIDR_ALL_IPS,
     DELETE_POLICY,
@@ -202,9 +203,19 @@ class ComputeResourceSizeValidator(Validator):
     Validate min count and max count combinations.
     """
 
-    def _validate(self, min_count, max_count):
+    def _validate(self, min_count: int, max_count: int, capacity_type: CapacityType):
         if max_count < min_count:
             self._add_failure("Max count must be greater than or equal to min count.", FailureLevel.ERROR)
+        if capacity_type == CapacityType.CAPACITY_BLOCK:
+            if max_count != min_count:
+                self._add_failure(
+                    "Max count must be set to the same value of min count when using Capacity Block reservation.",
+                    FailureLevel.ERROR,
+                )
+            if min_count == 0:
+                self._add_failure(
+                    "Min count must be a value > 0 when using Capacity Block reservation.", FailureLevel.ERROR
+                )
 
 
 class EfaOsArchitectureValidator(Validator):

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -15,6 +15,7 @@ from typing import Dict, List
 
 from pcluster import imagebuilder_utils
 from pcluster.aws.aws_api import AWSApi, KeyPairInfo
+from pcluster.aws.aws_resources import CapacityReservationInfo
 from pcluster.aws.common import AWSClientError
 from pcluster.utils import get_resource_name_from_resource_arn
 from pcluster.validators.common import FailureLevel, Validator
@@ -220,8 +221,18 @@ class PlacementGroupNamingValidator(Validator):
 class CapacityTypeValidator(Validator):
     """Compute type validator. Verify that specified compute type is compatible with specified instance type."""
 
+    @staticmethod
+    def _get_supported_usage_class_from_capacity_type(capacity_type):
+        """
+        Return value to search in SupportedUsageClasses according to capacity type.
+
+        SupportedUsageClasses is an attribute of instance type that can be retrieved by describe-instance-types call.
+        """
+        capacity_type_to_supported_usage_class_map = {"CAPACITY_BLOCK": "capacity-block"}
+        return capacity_type_to_supported_usage_class_map.get(capacity_type.value, capacity_type.value.lower())
+
     def _validate(self, capacity_type, instance_type):
-        compute_type_value = capacity_type.value.lower()
+        compute_type_value = self._get_supported_usage_class_from_capacity_type(capacity_type)
         supported_usage_classes = AWSApi.instance().ec2.get_instance_type_info(instance_type).supported_usage_classes()
 
         if not supported_usage_classes:
@@ -276,13 +287,13 @@ class CapacityReservationValidator(Validator):
                 capacity_reservation = AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation_id])[
                     0
                 ]
-                if capacity_reservation["InstanceType"] != instance_type:
+                if capacity_reservation.instance_type() != instance_type:
                     self._add_failure(
                         f"Capacity reservation {capacity_reservation_id} must have the same instance type "
                         f"as {instance_type}.",
                         FailureLevel.ERROR,
                     )
-                if capacity_reservation["AvailabilityZone"] != AWSApi.instance().ec2.get_subnet_avail_zone(subnet):
+                if capacity_reservation.availability_zone() != AWSApi.instance().ec2.get_subnet_avail_zone(subnet):
                     self._add_failure(
                         f"Capacity reservation {capacity_reservation_id} must use the same availability zone "
                         f"as subnet {subnet}.",
@@ -290,19 +301,20 @@ class CapacityReservationValidator(Validator):
                     )
 
 
-def get_capacity_reservations(capacity_reservation_resource_group_arn):
+def get_capacity_reservations(capacity_reservation_resource_group_arn: str):
+    """Get capacity reservations info for a given Reservation Resource Group Arn."""
     capacity_reservation_ids = AWSApi.instance().resource_groups.get_capacity_reservation_ids_from_group_resources(
         capacity_reservation_resource_group_arn
     )
     return AWSApi.instance().ec2.describe_capacity_reservations(capacity_reservation_ids)
 
 
-def capacity_reservation_matches_instance(capacity_reservation: Dict, instance_type: str) -> bool:
-    return capacity_reservation["InstanceType"] == instance_type
+def capacity_reservation_matches_instance(capacity_reservation: CapacityReservationInfo, instance_type: str) -> bool:
+    return capacity_reservation.instance_type() == instance_type
 
 
-def capacity_reservation_matches_subnet(capacity_reservation: Dict, subnet_id: str) -> bool:
-    return capacity_reservation["AvailabilityZone"] == AWSApi.instance().ec2.get_subnet_avail_zone(subnet_id)
+def capacity_reservation_matches_avail_zone(capacity_reservation: CapacityReservationInfo, subnet_id: str) -> bool:
+    return capacity_reservation.availability_zone() == AWSApi.instance().ec2.get_subnet_avail_zone(subnet_id)
 
 
 def capacity_reservation_resource_group_is_service_linked_group(capacity_reservation_resource_group_arn: str):
@@ -319,11 +331,13 @@ def capacity_reservation_resource_group_is_service_linked_group(capacity_reserva
         return False
 
 
-def get_capacity_reservations_per_az(capacity_reservations: List) -> Dict:
+def get_capacity_reservations_per_az(
+    capacity_reservations: List[CapacityReservationInfo],
+) -> Dict[str, List[CapacityReservationInfo]]:
     """Create a mapping of an AZ and its related Capacity Reservations."""
     capacity_reservations_per_az = defaultdict(list)
     for capacity_reservation in capacity_reservations:
-        capacity_reservations_per_az[capacity_reservation["AvailabilityZone"]].append(capacity_reservation)
+        capacity_reservations_per_az[capacity_reservation.availability_zone()].append(capacity_reservation)
     return capacity_reservations_per_az
 
 
@@ -348,7 +362,7 @@ class CapacityReservationResourceGroupValidator(Validator):
             if not capacity_reservation_resource_group_is_service_linked_group(capacity_reservation_resource_group_arn):
                 self._add_failure(
                     f"Capacity reservation resource group ({capacity_reservation_resource_group_arn}) must be a "
-                    f"Service Linked Group created from the AWS CLI.  See "
+                    "Service Linked Group created from the AWS CLI.  See "
                     f"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-cr-group.html for more details.",
                     FailureLevel.ERROR,
                 )
@@ -369,7 +383,11 @@ class CapacityReservationResourceGroupValidator(Validator):
                 )
 
     def _validate_unreserved_instance_types_for_azs(
-        self, capacity_reservations, capacity_reservation_resource_group_arn, availability_zones, instance_types
+        self,
+        capacity_reservations: List[CapacityReservationInfo],
+        capacity_reservation_resource_group_arn,
+        availability_zones,
+        instance_types,
     ):
         capacity_reservations_per_az = get_capacity_reservations_per_az(capacity_reservations)
         unreserved_instance_types_per_az = defaultdict(list)
@@ -398,7 +416,7 @@ class CapacityReservationResourceGroupValidator(Validator):
                 "instance types: '{unreserved_instance_types}'.".format(
                     crrg_arn=capacity_reservation_resource_group_arn,
                     cr_instance_az=", ".join(
-                        ["(%s: %s)" % (cr["InstanceType"], cr["AvailabilityZone"]) for cr in capacity_reservations]
+                        ["(%s: %s)" % (cr.instance_type(), cr.availability_zone()) for cr in capacity_reservations]
                     ),
                     unreserved_instance_types=", ".join(
                         "{%s: %s}" % (az, instance_types)
@@ -409,13 +427,18 @@ class CapacityReservationResourceGroupValidator(Validator):
             )
 
     def _validate_with_subnets(
-        self, queue_name, cr_group_arn, capacity_reservations, subnet_ids, subnet_id_az_mapping: Dict[str, str]
+        self,
+        queue_name,
+        cr_group_arn,
+        capacity_reservations: List[CapacityReservationInfo],
+        subnet_ids,
+        subnet_id_az_mapping: Dict[str, str],
     ):
         subnets_without_reservations = []
         found_qualified_capacity_reservation = False
 
         capacity_reservation_availability_zones = [
-            capacity_reservation["AvailabilityZone"] for capacity_reservation in capacity_reservations
+            capacity_reservation.availability_zone() for capacity_reservation in capacity_reservations
         ]
         for subnet_id in subnet_ids:
             subnet_az = subnet_id_az_mapping[subnet_id]
@@ -461,14 +484,18 @@ class CapacityReservationResourceGroupValidator(Validator):
 class PlacementGroupCapacityReservationValidator(Validator):
     """Validate the placement group is compatible with the capacity reservation target."""
 
-    def _validate_chosen_pg(self, subnet, instance_types, odcr_list, chosen_pg):
+    def _validate_chosen_pg(
+        self, subnet, instance_types, capacity_reservations: List[CapacityReservationInfo], chosen_pg
+    ):
         pg_match, open_or_targeted = False, False
         for instance_type in instance_types:
-            for odcr in odcr_list:
+            for capacity_reservation in capacity_reservations:
                 if capacity_reservation_matches_instance(
-                    capacity_reservation=odcr, instance_type=instance_type
-                ) and capacity_reservation_matches_subnet(capacity_reservation=odcr, subnet_id=subnet):
-                    odcr_pg = get_resource_name_from_resource_arn(odcr.get("PlacementGroupArn", None))
+                    capacity_reservation=capacity_reservation, instance_type=instance_type
+                ) and capacity_reservation_matches_avail_zone(
+                    capacity_reservation=capacity_reservation, subnet_id=subnet
+                ):
+                    odcr_pg = get_resource_name_from_resource_arn(capacity_reservation.placement_group_arn())
                     if odcr_pg:
                         if odcr_pg == chosen_pg:
                             pg_match = True
@@ -490,14 +517,21 @@ class PlacementGroupCapacityReservationValidator(Validator):
                     FailureLevel.WARNING,
                 )
 
-    def _validate_no_pg(self, instance_types, odcr_list, subnet, subnet_id_az_mapping):
+    def _validate_no_pg(
+        self, instance_types, capacity_reservations: List[CapacityReservationInfo], subnet, subnet_id_az_mapping
+    ):
         for instance_type in instance_types:
             odcr_without_pg = False
-            for odcr in odcr_list:
-                odcr_pg = get_resource_name_from_resource_arn(getattr(odcr, "PlacementGroupArn", None))
+            for capacity_reservation in capacity_reservations:
+                odcr_pg = get_resource_name_from_resource_arn(capacity_reservation.placement_group_arn())
+                # search for a capacity reservation without a placement group and matching instance type and avail zone
                 if not odcr_pg and (
-                    capacity_reservation_matches_instance(capacity_reservation=odcr, instance_type=instance_type)
-                    and capacity_reservation_matches_subnet(capacity_reservation=odcr, subnet_id=subnet)
+                    capacity_reservation_matches_instance(
+                        capacity_reservation=capacity_reservation, instance_type=instance_type
+                    )
+                    and capacity_reservation_matches_avail_zone(
+                        capacity_reservation=capacity_reservation, subnet_id=subnet
+                    )
                 ):
                     odcr_without_pg = True
             if not odcr_without_pg:
@@ -514,20 +548,23 @@ class PlacementGroupCapacityReservationValidator(Validator):
             odcr_id = getattr(odcr, "capacity_reservation_id", None)
             odcr_arn = getattr(odcr, "capacity_reservation_resource_group_arn", None)
             if odcr_id:
-                odcr_list = AWSApi.instance().ec2.describe_capacity_reservations([odcr_id])
+                capacity_reservations = AWSApi.instance().ec2.describe_capacity_reservations([odcr_id])
             elif odcr_arn:
-                odcr_list = get_capacity_reservations(odcr_arn)
+                capacity_reservations = get_capacity_reservations(odcr_arn)
             else:
-                odcr_list = None
-            if odcr_list:
+                capacity_reservations = None
+            if capacity_reservations:
                 if placement_group:
                     self._validate_chosen_pg(
-                        subnet=subnet, instance_types=instance_types, odcr_list=odcr_list, chosen_pg=placement_group
+                        subnet=subnet,
+                        instance_types=instance_types,
+                        capacity_reservations=capacity_reservations,
+                        chosen_pg=placement_group,
                     )
                 else:
                     self._validate_no_pg(
                         subnet=subnet,
                         instance_types=instance_types,
-                        odcr_list=odcr_list,
+                        capacity_reservations=capacity_reservations,
                         subnet_id_az_mapping=subnet_id_az_mapping,
                     )

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -337,6 +337,24 @@ class CapacityReservationValidator(Validator):
                 )
 
 
+class CapacityReservationSizeValidator(Validator):
+    """Validate capacity reservation size is not overloaded by max count in the queues/compute resource settings."""
+
+    def _validate(self, capacity_reservation_id: str, num_of_instances: int):
+        if capacity_reservation_id:
+            capacity_reservation = AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation_id])[0]
+
+            if num_of_instances > capacity_reservation.total_instance_count():
+                self._add_failure(
+                    (
+                        f"Number of instances configured for Capacity Reservation {capacity_reservation_id}: "
+                        f"{num_of_instances} is exceeding the total instances count available for the "
+                        f"Capacity Reservation: {capacity_reservation.total_instance_count()}"
+                    ),
+                    FailureLevel.ERROR,
+                )
+
+
 def get_capacity_reservations(capacity_reservation_resource_group_arn: str):
     """Get capacity reservations info for a given Reservation Resource Group Arn."""
     capacity_reservation_ids = AWSApi.instance().resource_groups.get_capacity_reservation_ids_from_group_resources(

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -226,10 +226,18 @@ class InstancesAllocationStrategyValidator(Validator, _FlexibleInstanceTypesVali
             capacity_type == cluster_config.CapacityType.ONDEMAND
             and allocation_strategy != cluster_config.AllocationStrategy.LOWEST_PRICE
         ):
+            alloc_strategy_msg = allocation_strategy.value if allocation_strategy else "not set"
             self._add_failure(
                 f"Compute Resource {compute_resource_name} is using an OnDemand CapacityType but the Allocation "
-                f"Strategy specified is {allocation_strategy.value}. OnDemand CapacityType can only use '"
+                f"Strategy specified is {alloc_strategy_msg}. OnDemand CapacityType can only use '"
                 f"{cluster_config.AllocationStrategy.LOWEST_PRICE.value}' allocation strategy.",
+                FailureLevel.ERROR,
+            )
+        if capacity_type == cluster_config.CapacityType.CAPACITY_BLOCK and allocation_strategy:
+            self._add_failure(
+                f"Compute Resource {compute_resource_name} is using a CAPACITY_BLOCK CapacityType but the "
+                f"Allocation Strategy specified is {allocation_strategy.value}. "
+                "When using CAPACITY_BLOCK CapacityType, allocation strategy should not be set.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -224,6 +224,7 @@ class InstancesAllocationStrategyValidator(Validator, _FlexibleInstanceTypesVali
         """On-demand Capacity type only supports "lowest-price" allocation strategy."""
         if (
             capacity_type == cluster_config.CapacityType.ONDEMAND
+            and allocation_strategy
             and allocation_strategy != cluster_config.AllocationStrategy.LOWEST_PRICE
         ):
             alloc_strategy_msg = allocation_strategy.value if allocation_strategy else "not set"

--- a/cli/tests/pcluster/aws/test_aws_resources.py
+++ b/cli/tests/pcluster/aws/test_aws_resources.py
@@ -55,3 +55,25 @@ class TestCapacityReservationInfo:
         assert_that(CapacityReservationInfo(capacity_reservation_data).incremental_requested_quantity()).is_equal_to(
             expected_value
         )
+
+    @pytest.mark.parametrize(
+        ("capacity_reservation_data", "expected_value"),
+        [
+            ({}, None),
+            ({"ReservationType": "capacity-block"}, "capacity-block"),
+            (
+                {"Tags": [{"Key": "aws:ec2capacityreservation:capacityReservationType", "Value": "capacity-block"}]},
+                "capacity-block",
+            ),
+            # The following should not happen, anyway is just to confirm that ReservationType value is preferred
+            (
+                {
+                    "ReservationType": "on-demand",
+                    "Tags": [{"Key": "aws:ec2capacityreservation:capacityReservationType", "Value": "capacity-block"}],
+                },
+                "on-demand",
+            ),
+        ],
+    )
+    def test_reservation_type(self, capacity_reservation_data, expected_value):
+        assert_that(CapacityReservationInfo(capacity_reservation_data).reservation_type()).is_equal_to(expected_value)

--- a/cli/tests/pcluster/aws/test_aws_resources.py
+++ b/cli/tests/pcluster/aws/test_aws_resources.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+#
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.aws.aws_resources import CapacityReservationInfo
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.aws.common.boto3"
+
+
+class TestCapacityReservationInfo:
+    @pytest.mark.parametrize(
+        ("capacity_reservation_data", "expected_value"),
+        [
+            ({}, None),
+            ({"Tags": []}, None),
+            ({"Tags": [{"Key": "test", "Value": "value"}]}, "value"),
+            ({"Tags": [{"Key": "test2", "Value": "value2"}, {"Key": "test", "Value": "value"}]}, "value"),
+        ],
+    )
+    def test_get_tags(self, capacity_reservation_data, expected_value):
+        assert_that(CapacityReservationInfo(capacity_reservation_data).get_tag("test")).is_equal_to(expected_value)
+
+    @pytest.mark.parametrize(("capacity_reservation_data", "expected_value"), [({}, 0), ({"TotalInstanceCount": 1}, 1)])
+    def test_total_instance_count(self, capacity_reservation_data, expected_value):
+        assert_that(CapacityReservationInfo(capacity_reservation_data).total_instance_count()).is_equal_to(
+            expected_value
+        )
+
+    @pytest.mark.parametrize(
+        ("capacity_reservation_data", "expected_value"),
+        [
+            ({}, 0),
+            ({"Tags": []}, 0),
+            ({"Tags": [{"Key": "aws:ec2capacityreservation:incrementalRequestedQuantity", "Value": "2"}]}, 2),
+        ],
+    )
+    def test_incremental_requested_quantity(self, capacity_reservation_data, expected_value):
+        assert_that(CapacityReservationInfo(capacity_reservation_data).incremental_requested_quantity()).is_equal_to(
+            expected_value
+        )

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -524,7 +524,7 @@ def get_describe_capacity_reservation_mocked_request(capacity_reservations, stat
                 for capacity_reservation in capacity_reservations
             ]
         },
-        expected_params={"CapacityReservationIds": capacity_reservations},  # TODO add: "ReservationType": None},
+        expected_params={"CapacityReservationIds": capacity_reservations},
     )
 
 

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -524,7 +524,7 @@ def get_describe_capacity_reservation_mocked_request(capacity_reservations, stat
                 for capacity_reservation in capacity_reservations
             ]
         },
-        expected_params={"CapacityReservationIds": capacity_reservations},
+        expected_params={"CapacityReservationIds": capacity_reservations},  # TODO add: "ReservationType": None},
     )
 
 
@@ -540,7 +540,7 @@ def test_describe_capacity_reservations_cache(boto3_stubber):
         get_describe_capacity_reservation_mocked_request([capacity_reservation], "active"),
     ]
     boto3_stubber("ec2", mocked_requests)
-    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0]["State"]).is_equal_to(
+    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0].state()).is_equal_to(
         "pending"
     )
 
@@ -551,13 +551,13 @@ def test_describe_capacity_reservations_cache(boto3_stubber):
     assert_that(response).is_length(2)
 
     # Third boto3 call. The result should be from cache even if the state of the cr is different
-    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0]["State"]).is_equal_to(
+    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0].state()).is_equal_to(
         "pending"
     )
 
     # Fourth boto3 call after resetting the AWSApi instance. The latest cr state should be retrieved from boto3
     AWSApi.reset()
-    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0]["State"]).is_equal_to(
+    assert_that(AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation])[0].state()).is_equal_to(
         "active"
     )
 

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -92,9 +92,10 @@ def test_root_volume_size_validator(size, expected_message):
     "capacity_type, expected_message",
     [
         ("ONDEMAND", None),
-        ("", "Must be one of: ONDEMAND, SPOT"),
-        ("wrong_value", "Must be one of: ONDEMAND, SPOT"),
-        ("NONE", "Must be one of: ONDEMAND, SPOT"),
+        ("CAPACITY_BLOCK", None),
+        ("", "Must be one of: CAPACITY_BLOCK, ONDEMAND, SPOT"),
+        ("wrong_value", "Must be one of: CAPACITY_BLOCK, ONDEMAND, SPOT"),
+        ("NONE", "Must be one of: CAPACITY_BLOCK, ONDEMAND, SPOT"),
         ("SPOT", None),
     ],
 )

--- a/cli/tests/pcluster/templates/test_capacity_reservation.py
+++ b/cli/tests/pcluster/templates/test_capacity_reservation.py
@@ -14,6 +14,7 @@ import json
 import pytest
 from assertpy import assert_that
 
+from pcluster.aws.aws_resources import CapacityReservationInfo
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from pcluster.utils import load_yaml_dict
@@ -33,11 +34,13 @@ def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_n
     mocker.patch(
         "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
         return_value=[
-            {
-                "CapacityReservationArn": "arn:partition:service:region:account-id:capacity-reservation/cr-12345",
-                "InstanceType": "c5.xlarge",
-                "AvailabilityZone": "us-east-1a",
-            }
+            CapacityReservationInfo(
+                {
+                    "CapacityReservationArn": "arn:partition:service:region:account-id:capacity-reservation/cr-12345",
+                    "InstanceType": "c5.xlarge",
+                    "AvailabilityZone": "us-east-1a",
+                }
+            )
         ],
     )
 
@@ -69,10 +72,12 @@ def test_capacity_reservation_group_arns_permissions(mocker, test_datadir, confi
     mocker.patch(
         "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
         return_value=[
-            {
-                "InstanceType": "c5.xlarge",
-                "AvailabilityZone": "us-east-1a",
-            }
+            CapacityReservationInfo(
+                {
+                    "InstanceType": "c5.xlarge",
+                    "AvailabilityZone": "us-east-1a",
+                }
+            )
         ],
     )
 

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils.py
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils.py
@@ -337,6 +337,12 @@ class TestCdkLaunchTemplateBuilder:
                 None,
                 id="test without spot capacity",
             ),
+            pytest.param(
+                BaseQueue(name="queue2", capacity_type="capacity_block"),
+                SlurmComputeResource(name="compute2", instance_type="t2.medium"),
+                ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(market_type="capacity-block"),
+                id="test with capacity block",
+            ),
         ],
     )
     def test_get_instance_market_options(self, queue, compute_resource, expected_response):

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -289,10 +289,10 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     compute_resource_size_validator.assert_has_calls(
         [
             # Defaults of min_count=0, max_count=10
-            call(min_count=0, max_count=5),
-            call(min_count=0, max_count=10),
-            call(min_count=0, max_count=10),
-            call(min_count=0, max_count=10),
+            call(min_count=0, max_count=5, capacity_type=CapacityType.ONDEMAND),
+            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
+            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
+            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
         ],
         any_order=True,
     )

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -13,6 +13,7 @@ from unittest.mock import PropertyMock, call
 from assertpy import assert_that
 
 from pcluster.aws.aws_resources import ImageInfo
+from pcluster.config.common import CapacityType
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.utils import load_yaml_dict
 from pcluster.validators import (
@@ -279,6 +280,10 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         "pcluster.aws.ec2.Ec2Client.describe_image",
         return_value=ImageInfo({"BlockDeviceMappings": [{"Ebs": {"VolumeSize": 35}}]}),
     )
+    mocker.patch("pcluster.aws.ec2.Ec2Client.describe_capacity_reservations", return_value=[])
+    capacity_reservation_validator = mocker.patch(
+        ec2_validators + ".CapacityReservationValidator._validate", return_value=[]
+    )
 
     mock_aws_api(mocker)
 
@@ -289,18 +294,22 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     compute_resource_size_validator.assert_has_calls(
         [
             # Defaults of min_count=0, max_count=10
+            call(min_count=0, max_count=10, capacity_type=CapacityType.SPOT),
+            call(min_count=0, max_count=10, capacity_type=CapacityType.SPOT),
             call(min_count=0, max_count=5, capacity_type=CapacityType.ONDEMAND),
             call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
             call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
-            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
+            call(min_count=5, max_count=5, capacity_type=CapacityType.CAPACITY_BLOCK),
+            call(min_count=3, max_count=3, capacity_type=CapacityType.CAPACITY_BLOCK),
         ],
         any_order=True,
     )
     max_count_validator.assert_has_calls(
         [
-            call(resources_length=2, max_length=50, resource_name="SlurmQueues"),
-            call(resources_length=5, max_length=50, resource_name="ComputeResources per Cluster"),
+            call(resources_length=3, max_length=50, resource_name="SlurmQueues"),
+            call(resources_length=7, max_length=50, resource_name="ComputeResources per Cluster"),
             call(resources_length=3, max_length=50, resource_name="ComputeResources per Queue"),
+            call(resources_length=2, max_length=50, resource_name="ComputeResources per Queue"),
             call(resources_length=2, max_length=50, resource_name="ComputeResources per Queue"),
         ],
         any_order=True,
@@ -315,20 +324,15 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
             call(instance_type="c5.4xlarge", image="ami-12345678"),
             call(instance_type="c5d.xlarge", image="ami-12345678"),
             call(instance_type="t2.large", image="ami-12345678"),
+            call(instance_type="t2.xlarge", image="ami-12345678"),
         ],
         any_order=True,
     )
     subnets_validator.assert_has_calls([call(subnet_ids=["subnet-12345678", "subnet-23456789", "subnet-12345678"])])
     single_instance_type_subnet_validator.assert_has_calls(
         [
-            call(
-                queue_name="queue1",
-                subnet_ids=["subnet-23456789"],
-            ),
-            call(
-                queue_name="queue2",
-                subnet_ids=["subnet-23456789"],
-            ),
+            call(queue_name="queue1", subnet_ids=["subnet-23456789"]),
+            call(queue_name="queue2", subnet_ids=["subnet-23456789"]),
         ]
     )
     security_groups_validator.assert_has_calls(
@@ -344,12 +348,14 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
             {"instance_types": ["c5.4xlarge"], "architecture": "x86_64"},
             {"instance_types": ["c5d.xlarge"], "architecture": "x86_64"},
             {"instance_types": ["t2.large"], "architecture": "x86_64"},
+            {"instance_types": ["t2.xlarge"], "architecture": "x86_64"},
+            {"instance_types": ["t2.xlarge"], "architecture": "x86_64"},
         ],
         validator=instance_architecture_compatibility_validator,
     )
 
     root_volume_encryption_consistency_validator.assert_has_calls(
-        [call(encryption_settings=[("queue1", True), ("queue2", True)])]
+        [call(encryption_settings=[("queue1", True), ("queue2", True), ("queue3", True)])]
     )
     ebs_volume_type_size_validator.assert_has_calls([call(volume_type="gp3", volume_size=35)])
     kms_key_validator.assert_has_calls([call(kms_key_id="1234abcd-12ab-34cd-56ef-1234567890ab")])
@@ -383,6 +389,30 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         ],
         any_order=True,
     )
+    # capacity reservation validators
+    capacity_reservation_validator.assert_has_calls(
+        [
+            call(
+                capacity_reservation_id="cr-34567",
+                instance_types=["t2.large"],
+                subnet="subnet-23456789",
+                capacity_type=CapacityType.ONDEMAND,
+            ),
+            call(
+                capacity_reservation_id="cr-12345",
+                instance_types=["t2.xlarge"],
+                subnet="subnet-23456789",
+                capacity_type=CapacityType.CAPACITY_BLOCK,
+            ),
+            call(
+                capacity_reservation_id="cr-23456",
+                instance_types=["t2.xlarge"],
+                subnet="subnet-23456789",
+                capacity_type=CapacityType.CAPACITY_BLOCK,
+            ),
+        ]
+    )
+
     # No assertion on the argument for minor validators
     name_validator.assert_called()
     fsx_s3_validator.assert_called()

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
@@ -62,6 +62,8 @@ Scheduling:
           Value: String
     - Name: queue3
       CapacityType: CAPACITY_BLOCK
+      CapacityReservationTarget:
+        CapacityReservationId: "cr-12345"
       Networking:
         SubnetIds:
           - subnet-23456789
@@ -70,8 +72,6 @@ Scheduling:
           InstanceType: t2.xlarge
           MinCount: 5
           MaxCount: 5
-          CapacityReservationTarget:
-            CapacityReservationId: "cr-12345"
         - Name: compute_resource2
           InstanceType: t2.xlarge
           MinCount: 3

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
@@ -24,6 +24,7 @@ Scheduling:
   Scheduler: slurm
   SlurmQueues:
     - Name: queue1
+      CapacityType: SPOT
       Networking:
         SubnetIds:
           - subnet-23456789
@@ -52,11 +53,31 @@ Scheduling:
         - Name: compute_resource3
           InstanceType: t2.large
           DisableSimultaneousMultithreading: true
+          CapacityReservationTarget:
+            CapacityReservationId: "cr-34567"
       Tags:
         - Key: queue_tag1
           Value: String
         - Key: queue_tag2
           Value: String
+    - Name: queue3
+      CapacityType: CAPACITY_BLOCK
+      Networking:
+        SubnetIds:
+          - subnet-23456789
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: t2.xlarge
+          MinCount: 5
+          MaxCount: 5
+          CapacityReservationTarget:
+            CapacityReservationId: "cr-12345"
+        - Name: compute_resource2
+          InstanceType: t2.xlarge
+          MinCount: 3
+          MaxCount: 3
+          CapacityReservationTarget:
+            CapacityReservationId: "cr-23456"
 SharedStorage:
   - MountDir: /my/mount/point1
     Name: name1

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -30,6 +30,7 @@ from pcluster.config.cluster_config import (
     SlurmSettings,
     Tag,
 )
+from pcluster.config.common import CapacityType
 from pcluster.constants import PCLUSTER_NAME_MAX_LENGTH, PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING
 from pcluster.validators.cluster_validators import (
     FSX_MESSAGES,
@@ -481,16 +482,47 @@ def test_scheduler_os_validator(os, scheduler, expected_message):
 
 
 @pytest.mark.parametrize(
-    "min_count, max_count, expected_message",
+    "min_count, max_count, capacity_type, expected_messages",
     [
-        (1, 2, None),
-        (1, 1, None),
-        (2, 1, "Max count must be greater than or equal to min count"),
+        (0, 0, None, None),
+        (1, 2, None, None),
+        (1, 1, None, None),
+        (1, 2, CapacityType.ONDEMAND, None),
+        (1, 1, CapacityType.ONDEMAND, None),
+        (1, 2, CapacityType.SPOT, None),
+        (1, 1, CapacityType.SPOT, None),
+        (
+            1,
+            2,
+            CapacityType.CAPACITY_BLOCK,
+            "Max count must be set to the same value of min count when using Capacity Block reservation",
+        ),
+        (
+            0,
+            2,
+            CapacityType.CAPACITY_BLOCK,
+            [
+                "Max count must be set to the same value of min count when using Capacity Block reservation",
+                "Min count must be a value > 0 when using Capacity Block reservation.",
+            ],
+        ),
+        (0, 0, CapacityType.CAPACITY_BLOCK, "Min count must be a value > 0 when using Capacity Block reservation."),
+        (1, 1, CapacityType.CAPACITY_BLOCK, None),
+        (2, 1, None, "Max count must be greater than or equal to min count"),
+        (
+            2,
+            1,
+            CapacityType.CAPACITY_BLOCK,
+            [
+                "Max count must be greater than or equal to min count",
+                "Max count must be set to the same value of min count when using Capacity Block reservation",
+            ],
+        ),
     ],
 )
-def test_compute_resource_size_validator(min_count, max_count, expected_message):
-    actual_failures = ComputeResourceSizeValidator().execute(min_count, max_count)
-    assert_failure_messages(actual_failures, expected_message)
+def test_compute_resource_size_validator(min_count, max_count, capacity_type, expected_messages):
+    actual_failures = ComputeResourceSizeValidator().execute(min_count, max_count, capacity_type)
+    assert_failure_messages(actual_failures, expected_messages)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -747,6 +747,11 @@ def test_capacity_reservation_validator(
             ["Number of instances .* cr-123: 2 is exceeding .* instances count .* for the Capacity Reservation: 1"],
         ),
         (
+            CapacityReservationInfo({"Tags": []}),
+            1,
+            ["Number of instances .* cr-123: 1 is exceeding .* instances count .* for the Capacity Reservation: 0"],
+        ),
+        (
             CapacityReservationInfo(
                 {
                     "TotalInstanceCount": 0,

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -476,25 +476,48 @@ def test_instances_networking_validator(
 
 
 @pytest.mark.parametrize(
-    "compute_resource_name, capacity_type, allocation_strategy, expected_message",
+    "capacity_type, allocation_strategy, expected_message",
     [
         # OnDemand Capacity type only supports "lowest-price" allocation strategy
-        # Spot Capacity type supports both "lowest-price" and "capacity-optimized" allocation strategy
         (
-            "TestComputeResource",
             CapacityType.ONDEMAND,
             AllocationStrategy.CAPACITY_OPTIMIZED,
             "Compute Resource TestComputeResource is using an OnDemand CapacityType but the Allocation Strategy "
             "specified is capacity-optimized. OnDemand CapacityType can only use 'lowest-price' allocation strategy.",
         ),
-        ("TestComputeResource", CapacityType.ONDEMAND, AllocationStrategy.LOWEST_PRICE, ""),
+        (CapacityType.ONDEMAND, AllocationStrategy.LOWEST_PRICE, ""),
+        (
+            CapacityType.ONDEMAND,
+            None,
+            "Compute Resource TestComputeResource is using an OnDemand CapacityType but the Allocation Strategy "
+            "specified is not set. OnDemand CapacityType can only use 'lowest-price' allocation strategy.",
+        ),
+        # Spot Capacity type supports both "lowest-price" and "capacity-optimized" allocation strategy
+        (CapacityType.SPOT, AllocationStrategy.LOWEST_PRICE, ""),
+        (CapacityType.SPOT, AllocationStrategy.CAPACITY_OPTIMIZED, ""),
+        (CapacityType.SPOT, None, ""),
+        # Capacity Block type supports does not support any allocation strategy
+        (
+            CapacityType.CAPACITY_BLOCK,
+            AllocationStrategy.CAPACITY_OPTIMIZED,
+            (
+                "Compute Resource TestComputeResource is using a CAPACITY_BLOCK CapacityType but the Allocation "
+                "Strategy specified is capacity-optimized. When using CAPACITY_BLOCK CapacityType, "
+                "allocation strategy should not be set."
+            ),
+        ),
+        (
+            CapacityType.CAPACITY_BLOCK,
+            AllocationStrategy.LOWEST_PRICE,
+            "Compute Resource TestComputeResource is using a CAPACITY_BLOCK CapacityType but the Allocation Strategy "
+            "specified is lowest-price. When using CAPACITY_BLOCK CapacityType, allocation strategy should not be set.",
+        ),
+        (CapacityType.CAPACITY_BLOCK, None, ""),
     ],
 )
-def test_instances_allocation_strategy_validator(
-    compute_resource_name: str, capacity_type: Enum, allocation_strategy: Enum, expected_message: str
-):
+def test_instances_allocation_strategy_validator(capacity_type: Enum, allocation_strategy: Enum, expected_message: str):
     actual_failures = InstancesAllocationStrategyValidator().execute(
-        compute_resource_name, capacity_type, allocation_strategy
+        "TestComputeResource", capacity_type, allocation_strategy
     )
     assert_failure_messages(actual_failures, expected_message)
 

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -486,12 +486,7 @@ def test_instances_networking_validator(
             "specified is capacity-optimized. OnDemand CapacityType can only use 'lowest-price' allocation strategy.",
         ),
         (CapacityType.ONDEMAND, AllocationStrategy.LOWEST_PRICE, ""),
-        (
-            CapacityType.ONDEMAND,
-            None,
-            "Compute Resource TestComputeResource is using an OnDemand CapacityType but the Allocation Strategy "
-            "specified is not set. OnDemand CapacityType can only use 'lowest-price' allocation strategy.",
-        ),
+        (CapacityType.ONDEMAND, None, ""),
         # Spot Capacity type supports both "lowest-price" and "capacity-optimized" allocation strategy
         (CapacityType.SPOT, AllocationStrategy.LOWEST_PRICE, ""),
         (CapacityType.SPOT, AllocationStrategy.CAPACITY_OPTIMIZED, ""),

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,5 +1,6 @@
 assertpy
 aws-lambda-powertools
+aws-xray-sdk
 freezegun
 jinja2
 munch


### PR DESCRIPTION
### Description of changes
* Added support for `CapacityType=CAPACITY_BLOCK`.
  * To permit the usage of capacity block it's required to set `market_type="capacity-block"` in the Launch Template.
* Default value for `AllocationStrategy` is now set to `None` when using Capacity Blocks

#### Validators
* Extended `CapacityReservationValidator` to verify capacity-type vs reservation-type
  * CapacityReservation of type `capacity-block` have a new attribute `ReservationType`, we're using it to validate that configured `CapacityType` corresponds to it.
* Extended `CapacityReservationValidator` to have a single instance type when using capacity reservation id
   * Capacity Reservation is always associate to a single instance type.
* Extended `ComputeResourceSizeValidator` to validate min count when using CB
  * At the moment all the instances in Capacity Block reservations are managed as static instances, so min count must be equal to max count and this value should be > 0.
  * To perform this check we had to move ComputeResourceSizeValidator registration at queue level since capacity_type is specified at that level.
*Add new `CapacityReservationSizeValidator` to verify number of instances is not exceeded
  * In the cluster config we created a map to keep track of the number of instances associated through max-count to a given capacity reservation id. Then we're verifying that the number of instances is not exceeding the TotalInstanceCount.
  * This will be executed for every capacity reservation, but has a strong value when using Capacity Block reservation.
* Improve CapacityReservationValidator to always validate subnet
  * Previously the subnet was validated only when instance_type was set.

### Additional changes
* [Add missing requirement for test_lambda_handler unit test](https://github.com/aws/aws-parallelcluster/commit/481cccc966794928b07fd067b0acb8172e434dd5)
* Modify describe_capacity_reservations to return a list of CapacityBlockReservationInfo
  * From this moment we don't need to know the structure of the describe-capacity-reservations output in the entire code.  
  * We can use the `CapacityBlockReservationInfo` wrapper class that decouples boto3 structure from parallelcluster internal logic.
  * The code is now more robust and thanks to this change I found a bug in the code: the _validate_no_pg was returning no errors even if there were no capacity reservations without PG. Aligned the unit test for it.

### Tests
* Added unit tests to cover the new/modified code.

#### Manual test of validators

Instance not supporting capacity block: 
```
"type": "CapacityTypeValidator",
"message": "Usage type 'capacity-block' not supported with instance type 't3.large'"
```
Instance type not aligned with CR instance:
```
"type": "ComputeResourceLaunchTemplateValidator",
"message": "Unable to validate configuration parameters for instance type p5.48xlarge. Please double check your cluster configuration. Capacity Reservation's attribute does not match with requested instance parameter. Attribute: InstanceType, requested value: p5.48xlarge, expected value: t3.large"
...
"type": "CapacityReservationValidator",
"message": "Capacity reservation cr-0541d9b022c98faaa must have the same instance type as p5.48xlarge."
```

More instances in the same compute resource:
```
"type": "CapacityReservationSizeValidator",
"message": "Number of instances configured for Capacity Reservation cr-01d2ca74c0d1f1705: 4 is exceeding the total instances count available for the Capacity Reservation: 2"
```

more instances from multiple queues/compute resources, one with 2 and one with 1 from same CB
```
"type": "CapacityReservationSizeValidator",
"message": "Number of instances configured for Capacity Reservation cr-01d2ca74c0d1f1705: 3 is exceeding the total instances count available for the Capacity Reservation: 2"
```

Wrong size: MinCount: 0, MaxCount: 1
```
"type": "ComputeResourceSizeValidator",
"message": "Max count must be set to the same value of min count when using Capacity Block reservation."
...
"type": "ComputeResourceSizeValidator",
"message": "Min count must be a value > 0 when using Capacity Block reservation."
```


### References
* Cookbook changes: https://github.com/aws/aws-parallelcluster-cookbook/pull/2526
* Related patch for the node: https://github.com/aws/aws-parallelcluster-node/pull/591
* Slurm reservations: https://slurm.schedmd.com/reservations.html
* Capacity Blocks: https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html

