### PR TITLE
[develop] Fix LoginNodes pool name update fail

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -372,10 +372,6 @@ def condition_checker_login_nodes_pools_policy(change, patch):
     return result
 
 
-def is_login_pool_removed(change):
-    return change.is_list and change.key == "Pools" and change.old_value is not None and change.new_value is None
-
-
 def condition_checker_login_nodes_stop_policy(_, patch):
     return not patch.cluster.has_running_login_nodes()
 

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -363,9 +363,13 @@ def condition_checker_shared_storage_update_policy(change, patch):
     return result
 
 
-def condition_checker_login_nodes_pools_policy(change, _):
-    """Login fleet stop is required when a login pool is removed."""
-    return not is_login_pool_removed(change)
+def condition_checker_login_nodes_pools_policy(change, patch):
+    """Login pools can be added but removal require LoginNodes stop."""
+    result = not patch.cluster.has_running_login_nodes()
+    if change.is_list and change.key == "Pools":
+        result = result or (change.old_value is None and change.new_value is not None)
+
+    return result
 
 
 def is_login_pool_removed(change):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1855,7 +1855,7 @@ class DirectoryServiceSchema(BaseSchema):
 class ClusterSchema(BaseSchema):
     """Represent the schema of the Cluster."""
 
-    login_nodes = fields.Nested(LoginNodesSchema, many=False, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    login_nodes = fields.Nested(LoginNodesSchema, many=False, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
     image = fields.Nested(ImageSchema, required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     head_node = fields.Nested(HeadNodeSchema, required=True, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     scheduling = fields.Nested(SchedulingSchema, required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1752,7 +1752,7 @@ def test_login_nodes_pools_policy(
     expected_actions_needed,
 ):
     cluster = dummy_cluster()
-    mocker.patch.object(cluster, 'has_running_login_nodes', return_value=True)
+    mocker.patch.object(cluster, "has_running_login_nodes", return_value=True)
 
     patch_mock = mocker.MagicMock()
     patch_mock.cluster = cluster
@@ -1762,7 +1762,9 @@ def test_login_nodes_pools_policy(
     change_mock.old_value = old_value
     change_mock.new_value = new_value
 
-    assert_that(UpdatePolicy.LOGIN_NODES_POOLS.condition_checker(change_mock, patch_mock)).is_equal_to(expected_update_allowed)
+    assert_that(UpdatePolicy.LOGIN_NODES_POOLS.condition_checker(change_mock, patch_mock)).is_equal_to(
+        expected_update_allowed
+    )
     assert_that(UpdatePolicy.LOGIN_NODES_POOLS.fail_reason(change_mock, patch_mock)).is_equal_to(expected_fail_reason)
     assert_that(UpdatePolicy.LOGIN_NODES_POOLS.action_needed(change_mock, patch_mock)).is_equal_to(
         expected_actions_needed

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1701,7 +1701,8 @@ def test_condition_checker_managed_fsx(
 
 
 @pytest.mark.parametrize(
-    "key, path, old_value, new_value, expected_has_running_login_nodes_response, expected_update_allowed, expected_fail_reason, expected_actions_needed",
+    "key, path, old_value, new_value, expected_has_running_login_nodes_response, expected_update_allowed, "
+    "expected_fail_reason, expected_actions_needed",
     [
         pytest.param(
             "Pools",
@@ -1804,7 +1805,9 @@ def test_login_nodes_pools_policy(
         expected_update_allowed
     )
     if not expected_update_allowed:
-        assert_that(UpdatePolicy.LOGIN_NODES_POOLS.fail_reason(change_mock, patch_mock)).is_equal_to(expected_fail_reason)
+        assert_that(UpdatePolicy.LOGIN_NODES_POOLS.fail_reason(change_mock, patch_mock)).is_equal_to(
+            expected_fail_reason
+        )
         assert_that(UpdatePolicy.LOGIN_NODES_POOLS.action_needed(change_mock, patch_mock)).is_equal_to(
             expected_actions_needed
         )

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1701,7 +1701,7 @@ def test_condition_checker_managed_fsx(
 
 
 @pytest.mark.parametrize(
-    "key, path, old_value, new_value, expected_update_allowed, expected_fail_reason, expected_actions_needed",
+    "key, path, old_value, new_value, expected_has_running_login_nodes_response, expected_update_allowed, expected_fail_reason, expected_actions_needed",
     [
         pytest.param(
             "Pools",
@@ -1715,11 +1715,30 @@ def test_condition_checker_managed_fsx(
                 "Ssh": {"KeyName": "xuanqi-us-east-2"},
             },
             None,
+            True,
             False,
             "The update is not supported when login nodes are running",
             "Stop the login nodes by setting Count parameter to 0 "
             "and update the cluster with the pcluster update-cluster command",
             id="Login nodes must be stopped to remove a pool",
+        ),
+        pytest.param(
+            "Pools",
+            ["LoginNodes"],
+            {
+                "Name": "pool-old",
+                "InstanceType": "t2.micro",
+                "GracetimePeriod": 3,
+                "Count": 1,
+                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
+                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+            },
+            None,
+            False,
+            True,
+            None,
+            None,
+            id="Login pools can be removed when Login Nodes stopped",
         ),
         pytest.param(
             "Pools",
@@ -1734,9 +1753,27 @@ def test_condition_checker_managed_fsx(
                 "Ssh": {"KeyName": "xuanqi-us-east-2"},
             },
             True,
-            "The update is not supported when login nodes are running",
-            "Stop the login nodes by setting Count parameter to 0 "
-            "and update the cluster with the pcluster update-cluster command",
+            True,
+            None,
+            None,
+            id="Login pools can be added",
+        ),
+        pytest.param(
+            "Pools",
+            ["LoginNodes"],
+            None,
+            {
+                "Name": "pool-new",
+                "InstanceType": "t2.micro",
+                "GracetimePeriod": 3,
+                "Count": 1,
+                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
+                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+            },
+            False,
+            True,
+            None,
+            None,
             id="Login pools can be added",
         ),
     ],
@@ -1747,12 +1784,13 @@ def test_login_nodes_pools_policy(
     path,
     old_value,
     new_value,
+    expected_has_running_login_nodes_response,
     expected_update_allowed,
     expected_fail_reason,
     expected_actions_needed,
 ):
     cluster = dummy_cluster()
-    mocker.patch.object(cluster, "has_running_login_nodes", return_value=True)
+    mocker.patch.object(cluster, "has_running_login_nodes", return_value=expected_has_running_login_nodes_response)
 
     patch_mock = mocker.MagicMock()
     patch_mock.cluster = cluster
@@ -1765,10 +1803,11 @@ def test_login_nodes_pools_policy(
     assert_that(UpdatePolicy.LOGIN_NODES_POOLS.condition_checker(change_mock, patch_mock)).is_equal_to(
         expected_update_allowed
     )
-    assert_that(UpdatePolicy.LOGIN_NODES_POOLS.fail_reason(change_mock, patch_mock)).is_equal_to(expected_fail_reason)
-    assert_that(UpdatePolicy.LOGIN_NODES_POOLS.action_needed(change_mock, patch_mock)).is_equal_to(
-        expected_actions_needed
-    )
+    if not expected_update_allowed:
+        assert_that(UpdatePolicy.LOGIN_NODES_POOLS.fail_reason(change_mock, patch_mock)).is_equal_to(expected_fail_reason)
+        assert_that(UpdatePolicy.LOGIN_NODES_POOLS.action_needed(change_mock, patch_mock)).is_equal_to(
+            expected_actions_needed
+        )
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1701,7 +1701,7 @@ def test_condition_checker_managed_fsx(
 
 
 @pytest.mark.parametrize(
-    "key, path, old_value, new_value, expected_has_running_login_nodes_response, expected_update_allowed, "
+    "key, path, old_value, new_value, expected_running_login_nodes, expected_update_allowed, "
     "expected_fail_reason, expected_actions_needed",
     [
         pytest.param(
@@ -1712,8 +1712,8 @@ def test_condition_checker_managed_fsx(
                 "InstanceType": "t2.micro",
                 "GracetimePeriod": 3,
                 "Count": 1,
-                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
-                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+                "Networking": {"SubnetIds": ["subnet-12345678901234567"]},
+                "Ssh": {"KeyName": "valid-key"},
             },
             None,
             True,
@@ -1731,8 +1731,8 @@ def test_condition_checker_managed_fsx(
                 "InstanceType": "t2.micro",
                 "GracetimePeriod": 3,
                 "Count": 1,
-                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
-                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+                "Networking": {"SubnetIds": ["subnet-12345678901234567"]},
+                "Ssh": {"KeyName": "valid-key"},
             },
             None,
             False,
@@ -1750,8 +1750,8 @@ def test_condition_checker_managed_fsx(
                 "InstanceType": "t2.micro",
                 "GracetimePeriod": 3,
                 "Count": 1,
-                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
-                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+                "Networking": {"SubnetIds": ["subnet-12345678901234567"]},
+                "Ssh": {"KeyName": "valid-key"},
             },
             True,
             True,
@@ -1768,8 +1768,8 @@ def test_condition_checker_managed_fsx(
                 "InstanceType": "t2.micro",
                 "GracetimePeriod": 3,
                 "Count": 1,
-                "Networking": {"SubnetIds": ["subnet-05cfbd48a49df385c"]},
-                "Ssh": {"KeyName": "xuanqi-us-east-2"},
+                "Networking": {"SubnetIds": ["subnet-12345678901234567"]},
+                "Ssh": {"KeyName": "valid-key"},
             },
             False,
             True,
@@ -1785,13 +1785,13 @@ def test_login_nodes_pools_policy(
     path,
     old_value,
     new_value,
-    expected_has_running_login_nodes_response,
+    expected_running_login_nodes,
     expected_update_allowed,
     expected_fail_reason,
     expected_actions_needed,
 ):
     cluster = dummy_cluster()
-    mocker.patch.object(cluster, "has_running_login_nodes", return_value=expected_has_running_login_nodes_response)
+    mocker.patch.object(cluster, "has_running_login_nodes", return_value=expected_running_login_nodes)
 
     patch_mock = mocker.MagicMock()
     patch_mock.cluster = cluster


### PR DESCRIPTION
### Description of changes
* Correct the update policy condition_checker to Login pools can be added but removal require LoginNodes stop.
* Change the LoginNodes Update Policy to `LOGIN_NODES_STOP`

### Tests
* Manually tests done, things work well
* Unit tests fixed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
