### PR TITLE
[Develop] Add integ tests for a shared /home via FSx Lustre, FSx Onta…

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1754,7 +1754,11 @@ def open_zfs_volume_factory(vpc_stack, cfn_stacks_factory, request, region, key_
                 VolumeType="OPENZFS",
                 OpenZFSConfiguration=VolumeOpenZFSConfiguration(
                     NfsExports=[
-                        NfsExports(ClientConfigurations=[ClientConfigurations(Clients="*", Options=["rw", "crossmnt"])])
+                        NfsExports(
+                            ClientConfigurations=[
+                                ClientConfigurations(Clients="*", Options=["rw", "crossmnt", "no_root_squash"])
+                            ]
+                        )
                     ],
                     ParentVolumeId=root_volume_id,
                 ),

--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -11,36 +11,104 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 
+import boto3
 import pytest
+from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.storage.storage_common import (
+    check_fsx,
+    create_fsx_ontap,
+    create_fsx_open_zfs,
     test_directory_correctly_shared_between_ln_and_hn,
     test_efs_correctly_mounted,
     verify_directory_correctly_shared,
 )
 
 
+@pytest.mark.parametrize(
+    "storage_type",
+    ["Efs", "FsxLustre", "FsxOpenZfs", "FsxOntap", "Ebs"],
+    # TODO full test ["Efs", "FsxLustre", "FsxOpenZfs", "FsxOntap", "FileCache", "Ebs"]
+)
 @pytest.mark.usefixtures("os", "scheduler", "instance")
 def test_shared_home(
-    region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory
+    region,
+    scheduler,
+    pcluster_config_reader,
+    create_file_cache,
+    vpc_stack,
+    scheduler_commands_factory,
+    storage_type,
+    fsx_factory,
+    svm_factory,
+    open_zfs_volume_factory,
+    s3_bucket_factory,
+    test_datadir,
+    clusters_factory,
 ):
-    """Verify the internal shared storage fs is available when set to Efs"""
+    """Verify the shared /home storage fs is available when set"""
     mount_dir = "/home"
-    cluster_config = pcluster_config_reader(mount_dir=mount_dir)
+    bucket_name = None
+    if storage_type == "FileCache":
+        bucket_name = s3_bucket_factory()
+        bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+        bucket.upload_file(str(test_datadir / "s3_test_file"), "s3_test_file")
+    file_cache_path = "/slurm/" if storage_type == "FileCache" else None
+    if storage_type == "FsxOpenZfs":
+        fsx_open_zfs_root_volume_id = create_fsx_open_zfs(fsx_factory, num=1)[0]
+        fsx_open_zfs_volume_id = open_zfs_volume_factory(fsx_open_zfs_root_volume_id, num_volumes=1)[0]
+        cluster_config = pcluster_config_reader(
+            mount_dir=mount_dir, storage_type=storage_type, volume_id=fsx_open_zfs_volume_id
+        )
+    elif storage_type == "FsxOntap":
+        fsx_ontap_fs_id = create_fsx_ontap(fsx_factory, num=1)[0]
+        fsx_on_tap_volume_id = svm_factory(fsx_ontap_fs_id, num_volumes=1)[0]
+        cluster_config = pcluster_config_reader(
+            mount_dir=mount_dir, storage_type=storage_type, volume_id=fsx_on_tap_volume_id
+        )
+    elif storage_type == "FileCache":
+        file_cache_id = create_file_cache(file_cache_path, bucket_name)
+        cluster_config = pcluster_config_reader(
+            mount_dir=mount_dir, storage_type=storage_type, file_cache_id=file_cache_id
+        )
+    else:
+        cluster_config = pcluster_config_reader(mount_dir=mount_dir, storage_type=storage_type)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     remote_command_executor_login_node = RemoteCommandExecutor(cluster, use_login_node=True)
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
-    test_efs_correctly_mounted(remote_command_executor, mount_dir)
-    _test_efs_correctly_shared_compute(remote_command_executor, mount_dir, scheduler_commands)
-    test_efs_correctly_mounted(remote_command_executor_login_node, mount_dir)
-    test_directory_correctly_shared_between_ln_and_hn(
-        remote_command_executor, remote_command_executor_login_node, mount_dir, run_sudo=True
-    )
+    if storage_type == "Efs":
+        test_efs_correctly_mounted(remote_command_executor, mount_dir)
+        logging.info("Testing efs correctly mounted on compute nodes")
+        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, run_sudo=True)
+        test_efs_correctly_mounted(remote_command_executor_login_node, mount_dir)
+        test_directory_correctly_shared_between_ln_and_hn(
+            remote_command_executor, remote_command_executor_login_node, mount_dir, run_sudo=True
+        )
+    elif storage_type in ["FsxLustre", "FsxOpenZfs", "FsxOntap", "FileCache"]:
+        check_fsx(
+            cluster,
+            region,
+            scheduler_commands_factory,
+            [mount_dir],
+            bucket_name,
+            file_cache_path=file_cache_path,
+            run_sudo=True,
+        )
+    elif storage_type == "Ebs":
+        _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size=40)
+        _test_ebs_correctly_mounted(remote_command_executor_login_node, mount_dir, volume_size=40)
+        # Test ebs correctly shared between HeadNode and ComputeNodes
+        logging.info("Testing ebs correctly mounted on compute nodes")
+        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-def _test_efs_correctly_shared_compute(remote_command_executor, mount_dir, scheduler_commands):
-    logging.info("Testing efs correctly mounted on compute nodes")
-    verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, run_sudo=True)
+def _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size):
+    logging.info("Testing ebs {0} is correctly mounted on login".format(mount_dir))
+    result = remote_command_executor.run_remote_command("df -h | grep {0}".format(mount_dir))
+    assert_that(result.stdout).matches(r"{size}G.*{mount_dir}".format(size=volume_size, mount_dir=mount_dir))
+
+    result = remote_command_executor.run_remote_command("cat /etc/fstab")
+    assert_that(result.stdout).matches(r"{mount_dir}.*_netdev".format(mount_dir=mount_dir))

--- a/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
@@ -40,5 +40,23 @@ Scheduling:
         - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: {{ mount_dir }}
-    Name: efs
-    StorageType: Efs
+    Name: home
+    StorageType: {{ storage_type }}
+    {% if storage_type == "FsxLustre" %}
+    FsxLustreSettings:
+      StorageCapacity: 1200
+    {% elif storage_type == "FsxOpenZfs" %}
+    FsxOpenZfsSettings:
+      VolumeId: {{ volume_id }}
+    {% elif storage_type == "FsxOntap" %}
+    FsxOntapSettings:
+      VolumeId: {{ volume_id }}
+    {% elif storage_type == "FileCache" %}
+    FileCacheSettings:
+      FileCacheId: {{ file_cache_id }}
+    {% elif storage_type == "Ebs" %}
+    EbsSettings:
+      Raid:
+        Type: 1
+      Size: 40
+    {% endif %}

--- a/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/s3_test_file
+++ b/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/s3_test_file
@@ -1,0 +1,1 @@
+Downloaded by FSx Lustre


### PR DESCRIPTION
…p, FSx OpenZfs, and EBS

Updated the test_shared_home pytest function to check multiple filesystem types and create existing file systems as necessary This is the initial effort to test across all FSes and FileCache will either be added to this list when the issues with performance are resolved, or it will be excluded from mount options for /home if needed.

This test currently verifies mounting a new filesystem to a new cluster and will be improved in a follow up PR to test mounting the same filesystem across multiple clusters.

### Tests
* test_shared_home run locally to verify

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
