### PR TITLE
[develop] Increase wait to give nodes the time to mount NFS share

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
@@ -58,8 +58,8 @@ EOF
     echo "Compiling..."
     /usr/lib64/openmpi/bin/mpicc -o "${_job_dir}/mpi_hello_world" "${_shared_dir}/mpi_hello_world.c"
 
-    echo "Sleeping here 10 sec to see if all nodes have established NFS connection"
-    sleep 10
+    echo "Sleeping here 15 sec to see if all nodes have established NFS connection"
+    sleep 15
 
     echo "Running..."
     /usr/lib64/openmpi/bin/mpirun --mca btl_tcp_if_include eth0 --allow-run-as-root --machinefile "${HOME}/hostfile" "${_job_dir}/mpi_hello_world"


### PR DESCRIPTION
### Description of changes
* Increase wait to give compute nodes the time to mount the NFS share, from 10 to 15 seconds, needed when testing on same region

### Tests
* tested locally

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
