### PR TITLE
[Policies] Add optional prefix to the name of IAM managed policies, if parameter IAMRoleAndPolicyPrefix is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ CHANGELOG
 - Make `InstanceType` an optional configuration parameter when configuring `CapacityReservationTarget/CapacityReservationId` in the compute resource.
 - Add `Scheduling/ScalingStrategy` parameter to control job-level scaling strategy for node to be resumed by Slurm.
   Possible values are `all-or-nothing`, `greedy-all-or-nothing`, `best-effort`, with `all-or-nothing` being the default.
+- Add possibility to specify a prefix for IAM roles and policies created by ParallelCluster API.
+- Add possibility to specify a permissions boundary to be applied for IAM roles and policies created by ParallelCluster API.
 
 **CHANGES**
 - Changed cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.
@@ -24,6 +26,7 @@ CHANGELOG
 - Remove `all_or_nothing_batch` resume configuration parameter, in favor of the new `scaling_strategy` parameter 
   that can be set using `Scheduling/ScalingStrategy` cluster configuration.
 - Change default EBS volume types in ADC regions from gp2 to gp3, for both the root and additional volumes.
+- The optional permissions boundary for the ParallelCluster API is now applied to every IAM role created by the API infrastructure.
 
 **BUG FIXES**
 - Fix inconsistent configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -114,10 +114,16 @@ Conditions:
 Resources:
   ### IAM POLICIES
 
+  # Every policy name comes with a suffix derived from the Stack ID to avoid name collisions.
+  # Given a stack id arn:aws:cloudformation:REGION:ACCOUNT:stack/STACK_NAME/8131d980-7fb5-11ee-9589-0a6424944f95,
+  # the resulting StackIdSuffix will be 8131d980.
   DefaultParallelClusterIamAdminPolicy:
     Type: AWS::IAM::ManagedPolicy
     Condition: EnableIamPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}DefaultParallelClusterIamAdminPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Roles:
         - !Ref ParallelClusterLambdaRole
       PolicyDocument:
@@ -221,6 +227,9 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Condition: EnableBatchAccessCondition
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterClusterPolicyBatch-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -330,6 +339,9 @@ Resources:
   ParallelClusterClusterPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterClusterPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -615,6 +627,9 @@ Resources:
   ParallelClusterBuildImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterBuildImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster build-image command without IAM permission
       PolicyDocument:
         Version: '2012-10-17'
@@ -732,6 +747,9 @@ Resources:
   ParallelClusterDeleteImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterDeleteImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster delete-image command without IAM permission
       PolicyDocument:
         Version: '2012-10-17'
@@ -817,6 +835,9 @@ Resources:
   ParallelClusterListImagesManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterListImagesManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster list-images command
       PolicyDocument:
         Version: '2012-10-17'
@@ -836,6 +857,9 @@ Resources:
   ParallelClusterDescribeImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterDescribeImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster describe-image command
       PolicyDocument:
         Version: '2012-10-17'
@@ -857,6 +881,9 @@ Resources:
   ParallelClusterLogRetrievalPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterLogRetrievalPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Policies needed to retrieve cluster and images logs
       PolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
### Description of changes
Add optional prefix to the name of IAM managed policies, if parameter IAMRoleAndPolicyPrefix is specified.
In particular, added to the following policies:
 - DefaultParallelClusterIamAdminPolicy
 - ParallelClusterClusterPolicyBatch
 - ParallelClusterClusterPolicy
 - ParallelClusterBuildImageManagedPolicy
 - ParallelClusterDeleteImageManagedPolicy
 - ParallelClusterListImagesManagedPolicy
 - ParallelClusterDescribeImageManagedPolicy
 - ParallelClusterLogRetrievalPolicy
 
This change is required by the PCUI feature that adds support for custom prefix for IAM roles and policies.
In the context of that feature, the prefix was added to the resources in the PCAPI template, but was missing in the policies template, which is a nested stack for the PCAPI template and should then be aligned.


**Minors**
Added missing entries to the 3.8.0 changelog related to the same feature:
1. support for permissions boundary in PCAPI
2. support for custom IAM prefix in PCAPI

### Tests
1. Manually deployed policies stack with custom prefix and boundary and checked resources are created as expected.
2. Manually deployed PCAPI with custom prefix and verified that every role, inline and managed policy has the expected prefix.
3. API Integration tests succeeded:
    1. test_api_infrastructure.py::test_api_infrastructure_with_default_parameters
    2. test_api.py::test_cluster_slurm
    4. test_api.py::test_cluster_awsbatch
    6. test_api.py::test_login_nodes   
    7. test_api::test_custom_image failed because it failed the last step of the test that aims at deleting the cfn stack; I expect this not to be related to the changes in this PR

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
