### PR TITLE
Test protection mode and fast capacity failover with the various scaling strategies

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -57,7 +57,7 @@ from tests.common.scaling_common import setup_ec2_launch_override_to_emulate_ice
 from tests.common.schedulers_common import SlurmCommands, TorqueCommands
 from tests.monitoring import structured_log_event_utils
 
-SCALING_STRATEGIES = ["job-level", "node-list"]
+SCALING_STRATEGIES = ["exclusive", "all"]
 
 
 @pytest.mark.usefixtures("instance", "os")
@@ -475,6 +475,7 @@ def test_error_handling(
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 @pytest.mark.slurm_protected_mode
+@pytest.mark.parametrize("scaling_strategy", ["all-or-nothing", "greedy-all-or-nothing", "best-effort"])
 def test_slurm_protected_mode(
     region,
     pcluster_config_reader,
@@ -482,6 +483,7 @@ def test_slurm_protected_mode(
     test_datadir,
     s3_bucket_factory,
     scheduler_commands_factory,
+    scaling_strategy,
 ):
     """Test that slurm protected mode logic can handle bootstrap failure nodes."""
     # Create S3 bucket for pre-install scripts
@@ -490,35 +492,35 @@ def test_slurm_protected_mode(
     # Upload bootstrap script that triggers a fails if a `c5.large` instance is used
     # Hence emulating a bootstrap error
     bucket.upload_file(str(test_datadir / "preinstall.sh"), "scripts/preinstall.sh")
-    cluster_config = pcluster_config_reader(bucket=bucket_name, scaling_strategies=SCALING_STRATEGIES)
+    cluster_config = pcluster_config_reader(bucket=bucket_name, scaling_strategy=scaling_strategy)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
-    for strategy in SCALING_STRATEGIES:
-        remote_command_executor.clear_clustermgtd_log()
-        remote_command_executor.clear_slurm_resume_log()
+    # for node_allocation_type in NODE_ALLOCATION_TYPES:
+    remote_command_executor.clear_clustermgtd_log()
+    remote_command_executor.clear_slurm_resume_log()
 
-        _test_disable_protected_mode(
-            remote_command_executor, cluster, bucket_name, pcluster_config_reader, clustermgtd_conf_path
-        )
+    _test_disable_protected_mode(
+        remote_command_executor, cluster, bucket_name, pcluster_config_reader, clustermgtd_conf_path, scaling_strategy
+    )
 
-        # Re-enable protected mode
-        _enable_protected_mode(remote_command_executor, clustermgtd_conf_path)
-        # Decrease protected failure count for quicker enter protected mode.
-        _set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
+    # Re-enable protected mode
+    _enable_protected_mode(remote_command_executor, clustermgtd_conf_path)
+    # Decrease protected failure count for quicker enter protected mode.
+    _set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
 
-        partition = f"{strategy}-half-broken"
-        pending_job_id = _test_active_job_running(
-            scheduler_commands, remote_command_executor, running_partition=partition, failing_partition=partition
-        )
-        _test_protected_mode(scheduler_commands, remote_command_executor, cluster, strategy)
-        test_cluster_health_metric(["NoCorrespondingInstanceErrors", "OnNodeStartRunErrors"], cluster.cfn_name, region)
-        _test_job_run_in_working_queue(scheduler_commands, strategy)
-        _test_recover_from_protected_mode(
-            pending_job_id, pcluster_config_reader, bucket_name, cluster, scheduler_commands, strategy
-        )
+    partition = f"half-broken"
+    pending_job_id = _test_active_job_running(
+        scheduler_commands, remote_command_executor, running_partition=partition, failing_partition=partition
+    )
+    _test_protected_mode(scheduler_commands, remote_command_executor, cluster)
+    test_cluster_health_metric(["NoCorrespondingInstanceErrors", "OnNodeStartRunErrors"], cluster.cfn_name, region)
+    _test_job_run_in_working_queue(scheduler_commands)
+    _test_recover_from_protected_mode(
+        pending_job_id, pcluster_config_reader, bucket_name, cluster, scheduler_commands, scaling_strategy
+    )
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
@@ -1903,10 +1905,12 @@ def _update_and_start_cluster(cluster, config_file):
     wait_for_computefleet_changed(cluster, "RUNNING")
 
 
-def _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader):
+def _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, scaling_strategy):
     """Update cluster to include pre-install script, which introduce bootstrap error."""
     updated_config_file = pcluster_config_reader(
-        config_file="pcluster.config.broken.yaml", bucket=bucket_name, scaling_strategies=SCALING_STRATEGIES
+        config_file="pcluster.config.broken.yaml",
+        bucket=bucket_name,
+        scaling_strategy=scaling_strategy
     )
     _update_and_start_cluster(cluster, updated_config_file)
 
@@ -1943,12 +1947,12 @@ def _enable_protected_mode(remote_command_executor, clustermgtd_conf_path):
 
 
 def _test_disable_protected_mode(
-    remote_command_executor, cluster, bucket_name, pcluster_config_reader, clustermgtd_conf_path
+    remote_command_executor, cluster, bucket_name, pcluster_config_reader, clustermgtd_conf_path, scaling_strategy
 ):
     """Test Bootstrap failures have no affect on cluster when protected mode is disabled."""
     # Disable protected_mode by setting protected_failure_count to -1
     _set_protected_failure_count(remote_command_executor, -1, clustermgtd_conf_path)
-    _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader)
+    _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, scaling_strategy)
     # wait till the node failed
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(7))(assert_lines_in_logs)(
         remote_command_executor,
@@ -2009,15 +2013,15 @@ def _test_active_job_running(scheduler_commands, remote_command_executor, runnin
     return job_id_pending
 
 
-def _test_protected_mode(scheduler_commands, remote_command_executor, cluster, strategy):
+def _test_protected_mode(scheduler_commands, remote_command_executor, cluster):
     """Test cluster will be placed into protected mode when protected count reach threshold and no job running."""
     # See if the cluster can be put into protected mode when there's no job running after reaching threshold
     _check_protected_mode_message_in_log(remote_command_executor)
     # Assert bootstrap failure queues are inactive and compute fleet status is PROTECTED
     check_status(cluster, compute_fleet_status="PROTECTED")
-    assert_that(scheduler_commands.get_partition_state(partition=f"{strategy}-normal")).is_equal_to("UP")
-    _wait_for_partition_state_changed(scheduler_commands, f"{strategy}-broken", "INACTIVE")
-    _wait_for_partition_state_changed(scheduler_commands, f"{strategy}-half-broken", "INACTIVE")
+    assert_that(scheduler_commands.get_partition_state(partition="normal")).is_equal_to("UP")
+    _wait_for_partition_state_changed(scheduler_commands, "broken", "INACTIVE")
+    _wait_for_partition_state_changed(scheduler_commands, "half-broken", "INACTIVE")
 
 
 def _check_protected_mode_message_in_log(remote_command_executor):
@@ -2033,17 +2037,17 @@ def _check_protected_mode_message_in_log(remote_command_executor):
     )
 
 
-def _test_job_run_in_working_queue(scheduler_commands, strategy):
+def _test_job_run_in_working_queue(scheduler_commands):
     """After enter protected state, submit a job to the active queue to make sure it can still run jobs."""
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
-        submit_command_args={"command": "sleep 1", "nodes": 2, "partition": f"{strategy}-normal"}
+        submit_command_args={"command": "sleep 1", "nodes": 2, "partition": "normal"}
     )
     scheduler_commands.wait_job_completed(job_id)
     scheduler_commands.assert_job_succeeded(job_id)
 
 
 def _test_recover_from_protected_mode(
-    incomplete_job_id, pcluster_config_reader, bucket_name, cluster, scheduler_commands, strategy
+    incomplete_job_id, pcluster_config_reader, bucket_name, cluster, scheduler_commands, scaling_strategy
 ):
     """
     Test cluster after recovering from protected mode.
@@ -2053,13 +2057,15 @@ def _test_recover_from_protected_mode(
     """
     # Update the cluster again, remove the pre-install script to make the cluster work as expected
     updated_config_file = pcluster_config_reader(
-        config_file="pcluster.config.recover.yaml", bucket=bucket_name, scaling_strategies=SCALING_STRATEGIES
+        config_file="pcluster.config.recover.yaml",
+        bucket=bucket_name,
+        scaling_strategy=scaling_strategy
     )
     _update_and_start_cluster(cluster, updated_config_file)
     # Assert all queues are UP
-    assert_that(scheduler_commands.get_partition_state(partition=f"{strategy}-normal")).is_equal_to("UP")
-    assert_that(scheduler_commands.get_partition_state(partition=f"{strategy}-broken")).is_equal_to("UP")
-    assert_that(scheduler_commands.get_partition_state(partition=f"{strategy}-half-broken")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition=f"normal")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition=f"broken")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition=f"half-broken")).is_equal_to("UP")
     # Pending job that is in the queue when cluster entered protected mode will be run again when cluster is
     # taken out of protected mode.
     scheduler_commands.wait_job_completed(incomplete_job_id)
@@ -2067,7 +2073,7 @@ def _test_recover_from_protected_mode(
     # Job can be run succesfully in all queues
     for partition in ["normal", "broken", "half-broken"]:
         job_id = scheduler_commands.submit_command_and_assert_job_accepted(
-            submit_command_args={"command": "sleep 1", "partition": f"{strategy}-{partition}"}
+            submit_command_args={"command": "sleep 1", "partition": f"{partition}"}
         )
         scheduler_commands.wait_job_completed(job_id)
         scheduler_commands.assert_job_succeeded(job_id)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -57,8 +57,6 @@ from tests.common.scaling_common import setup_ec2_launch_override_to_emulate_ice
 from tests.common.schedulers_common import SlurmCommands, TorqueCommands
 from tests.monitoring import structured_log_event_utils
 
-SCALING_STRATEGIES = ["exclusive", "all"]
-
 
 @pytest.mark.usefixtures("instance", "os")
 @pytest.mark.parametrize("use_login_node", [True, False])
@@ -498,7 +496,6 @@ def test_slurm_protected_mode(
     clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
-    # for node_allocation_type in NODE_ALLOCATION_TYPES:
     remote_command_executor.clear_clustermgtd_log()
     remote_command_executor.clear_slurm_resume_log()
 
@@ -511,7 +508,7 @@ def test_slurm_protected_mode(
     # Decrease protected failure count for quicker enter protected mode.
     _set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
 
-    partition = f"half-broken"
+    partition = "half-broken"
     pending_job_id = _test_active_job_running(
         scheduler_commands, remote_command_executor, running_partition=partition, failing_partition=partition
     )
@@ -555,14 +552,16 @@ def test_slurm_protected_mode_on_cluster_create(
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 @pytest.mark.fast_capacity_failover
+@pytest.mark.parametrize("scaling_strategy", ["all-or-nothing", "greedy-all-or-nothing", "best-effort"])
 def test_fast_capacity_failover(
     pcluster_config_reader,
+    scaling_strategy,
     clusters_factory,
     test_datadir,
     scheduler_commands_factory,
     region,
 ):
-    cluster_config = pcluster_config_reader(scaling_strategies=SCALING_STRATEGIES)
+    cluster_config = pcluster_config_reader(scaling_strategy=scaling_strategy)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
@@ -575,82 +574,81 @@ def test_fast_capacity_failover(
         multi_instance_types_exp_cr="exception-cr-multiple",
     )
 
-    for strategy in SCALING_STRATEGIES:
-        partition = f"queue-{strategy}"
-        # All nodes
-        nodes_in_scheduler = scheduler_commands.get_compute_nodes(partition, all_nodes=True)
-        static_nodes, dynamic_nodes = get_partition_nodes(nodes_in_scheduler)
+    partition = "queue"
+    # All nodes
+    nodes_in_scheduler = scheduler_commands.get_compute_nodes(partition, all_nodes=True)
+    static_nodes, dynamic_nodes = get_partition_nodes(nodes_in_scheduler)
 
-        # Nodes in Single Instance Type CR
-        ice_single_dynamic_nodes = [node for node in dynamic_nodes if "ice-compute-resource" in node]
-        ice_single_static_nodes = [node for node in static_nodes if "ice-compute-resource" in node]
+    # Nodes in Single Instance Type CR
+    ice_single_dynamic_nodes = [node for node in dynamic_nodes if "ice-compute-resource" in node]
+    ice_single_static_nodes = [node for node in static_nodes if "ice-compute-resource" in node]
 
-        # Nodes in Multiple Instance Type (overridden with invalid values)
-        ice_multi_dynamic_nodes = [node for node in dynamic_nodes if "ice-cr-multiple" in node]
-        ice_multi_static_nodes = [node for node in static_nodes if "ice-cr-multiple" in node]
+    # Nodes in Multiple Instance Type (overridden with invalid values)
+    ice_multi_dynamic_nodes = [node for node in dynamic_nodes if "ice-cr-multiple" in node]
+    ice_multi_static_nodes = [node for node in static_nodes if "ice-cr-multiple" in node]
 
-        # Nodes in Multiple Instance Type (overridden with values that will trigger an exception)
-        exception_multi_dynamic_nodes = [node for node in dynamic_nodes if "exception-cr-multiple" in node]
-        exception_multi_static_nodes = [node for node in static_nodes if "exception-cr-multiple" in node]
+    # Nodes in Multiple Instance Type (overridden with values that will trigger an exception)
+    exception_multi_dynamic_nodes = [node for node in dynamic_nodes if "exception-cr-multiple" in node]
+    exception_multi_static_nodes = [node for node in static_nodes if "exception-cr-multiple" in node]
 
-        # Checks Fast Failover in case of Single Instance Type - using RunInstances API
-        # Requires 1 static node in the CR, expects the job to be partially reallocated in a different CR and succeed
-        _test_enable_fast_capacity_failover(
-            partition,
-            scheduler_commands,
-            remote_command_executor,
-            clustermgtd_conf_path,
-            ice_single_static_nodes,
-            ice_single_dynamic_nodes,
-            target_compute_resource="ice-compute-resource",
-            expected_error_code="InsufficientHostCapacity",
-        )
+    # Checks Fast Failover in case of Single Instance Type - using RunInstances API
+    # Requires 1 static node in the CR, expects the job to be partially reallocated in a different CR and succeed
+    _test_enable_fast_capacity_failover(
+        partition,
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        ice_single_static_nodes,
+        ice_single_dynamic_nodes,
+        target_compute_resource="ice-compute-resource",
+        expected_error_code="InsufficientHostCapacity",
+    )
 
-        # Check observability logic
-        structured_log_event_utils.assert_that_event_exists(
-            cluster, r".+\.slurm_resume_events", "node-launch-failure-count"
-        )
-        test_cluster_health_metric(["InsufficientCapacityErrors"], cluster.cfn_name, region)
+    # Check observability logic
+    structured_log_event_utils.assert_that_event_exists(
+        cluster, r".+\.slurm_resume_events", "node-launch-failure-count"
+    )
+    test_cluster_health_metric(["InsufficientCapacityErrors"], cluster.cfn_name, region)
 
-        # Test behavior with RunInstance when Fast Failover is disabled
-        # Requires 1 static node in the CR, force the job to stay in the CR and expects it to fail
-        _test_disable_fast_capacity_failover(
-            partition,
-            scheduler_commands,
-            remote_command_executor,
-            clustermgtd_conf_path,
-            ice_single_static_nodes,
-            ice_single_dynamic_nodes,
-            target_compute_resource="ice-compute-resource",
-            expected_error_code="InsufficientHostCapacity",
-        )
+    # Test behavior with RunInstance when Fast Failover is disabled
+    # Requires 1 static node in the CR, force the job to stay in the CR and expects it to fail
+    _test_disable_fast_capacity_failover(
+        partition,
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        ice_single_static_nodes,
+        ice_single_dynamic_nodes,
+        target_compute_resource="ice-compute-resource",
+        expected_error_code="InsufficientHostCapacity",
+    )
 
-        # Checks Fast Failover in case of Multiple Instance Types - using CreateFleet API
-        # Requires 1 static node in the CR, expects the job to be partially reallocated in a different CR and succeed
-        # CreateFleet will return an empty list of instances, that should trigger FFO behavior
-        _test_enable_fast_capacity_failover(
-            partition,
-            scheduler_commands,
-            remote_command_executor,
-            clustermgtd_conf_path,
-            ice_multi_static_nodes,
-            ice_multi_dynamic_nodes,
-            target_compute_resource="ice-cr-multiple",
-            expected_error_code="InsufficientInstanceCapacity",
-        )
+    # Checks Fast Failover in case of Multiple Instance Types - using CreateFleet API
+    # Requires 1 static node in the CR, expects the job to be partially reallocated in a different CR and succeed
+    # CreateFleet will return an empty list of instances, that should trigger FFO behavior
+    _test_enable_fast_capacity_failover(
+        partition,
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        ice_multi_static_nodes,
+        ice_multi_dynamic_nodes,
+        target_compute_resource="ice-cr-multiple",
+        expected_error_code="InsufficientInstanceCapacity",
+    )
 
-        # Test behavior with CreateFleet when Fast Failover is disabled
-        # Requires 1 static node in the CR, force the job to stay in the CR and expects it to fail
-        _test_disable_fast_capacity_failover(
-            partition,
-            scheduler_commands,
-            remote_command_executor,
-            clustermgtd_conf_path,
-            exception_multi_static_nodes,
-            exception_multi_dynamic_nodes,
-            target_compute_resource="exception-cr-multiple",
-            expected_error_code="InvalidParameterValue",
-        )
+    # Test behavior with CreateFleet when Fast Failover is disabled
+    # Requires 1 static node in the CR, force the job to stay in the CR and expects it to fail
+    _test_disable_fast_capacity_failover(
+        partition,
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        exception_multi_static_nodes,
+        exception_multi_dynamic_nodes,
+        target_compute_resource="exception-cr-multiple",
+        expected_error_code="InvalidParameterValue",
+    )
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
@@ -1908,9 +1906,7 @@ def _update_and_start_cluster(cluster, config_file):
 def _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, scaling_strategy):
     """Update cluster to include pre-install script, which introduce bootstrap error."""
     updated_config_file = pcluster_config_reader(
-        config_file="pcluster.config.broken.yaml",
-        bucket=bucket_name,
-        scaling_strategy=scaling_strategy
+        config_file="pcluster.config.broken.yaml", bucket=bucket_name, scaling_strategy=scaling_strategy
     )
     _update_and_start_cluster(cluster, updated_config_file)
 
@@ -2057,15 +2053,13 @@ def _test_recover_from_protected_mode(
     """
     # Update the cluster again, remove the pre-install script to make the cluster work as expected
     updated_config_file = pcluster_config_reader(
-        config_file="pcluster.config.recover.yaml",
-        bucket=bucket_name,
-        scaling_strategy=scaling_strategy
+        config_file="pcluster.config.recover.yaml", bucket=bucket_name, scaling_strategy=scaling_strategy
     )
     _update_and_start_cluster(cluster, updated_config_file)
     # Assert all queues are UP
-    assert_that(scheduler_commands.get_partition_state(partition=f"normal")).is_equal_to("UP")
-    assert_that(scheduler_commands.get_partition_state(partition=f"broken")).is_equal_to("UP")
-    assert_that(scheduler_commands.get_partition_state(partition=f"half-broken")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition="normal")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition="broken")).is_equal_to("UP")
+    assert_that(scheduler_commands.get_partition_state(partition="half-broken")).is_equal_to("UP")
     # Pending job that is in the queue when cluster entered protected mode will be run again when cluster is
     # taken out of protected mode.
     scheduler_commands.wait_job_completed(incomplete_job_id)

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -8,12 +8,11 @@ HeadNode:
     KeyName: {{ key_name }}
 Scheduling:
   Scheduler: slurm
+  {% if scheduler =="slurm" %}
+  ScalingStrategy: {{ scaling_strategy }}
+  {% endif %}
   SlurmQueues:
-{% for strategy in scaling_strategies %}
-    - Name: queue-{{ strategy }}
-      {% if strategy == "job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: queue
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
@@ -33,7 +32,6 @@ Scheduling:
           MinCount: 1
         - Name: ondemand1-i1
           InstanceType: {{ instance }}
-{% endfor %}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -13,12 +13,11 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: {{ scheduler }}
+  {% if scheduler =="slurm" %}
+  ScalingStrategy: {{ scaling_strategy }}
+  {% endif %}
   {{ scheduler_prefix }}Queues:
-  {% for strategy in scaling_strategies %}
-    - Name: {{ strategy }}-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -39,10 +38,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-half-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: half-broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -67,10 +63,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-normal
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: normal
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -91,7 +84,6 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-  {% endfor %}
 SharedStorage:
   - MountDir: /shared  # Test comment
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -13,12 +13,11 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: {{ scheduler }}
+  {% if scheduler =="slurm" %}
+  ScalingStrategy: {{ scaling_strategy }}
+  {% endif %}
   {{ scheduler_prefix }}Queues:
-  {% for strategy in scaling_strategies %}
-    - Name: {{ strategy }}-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -34,10 +33,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-half-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: half-broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -55,10 +51,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-normal
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: normal
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -73,7 +66,6 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-  {% endfor %}
 SharedStorage:
   - MountDir: /shared  # Test comment
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -13,12 +13,11 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: {{ scheduler }}
+  {% if scheduler =="slurm" %}
+  ScalingStrategy: {{ scaling_strategy }}
+  {% endif %}
   {{ scheduler_prefix }}Queues:
-  {% for strategy in scaling_strategies %}
-    - Name: {{ strategy }}-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -33,10 +32,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-half-broken
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: half-broken
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -54,10 +50,7 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-    - Name: {{ strategy }}-normal
-      {% if strategy=="job-level" %}
-      JobExclusiveAllocation: true
-      {% endif %}
+    - Name: normal
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
@@ -72,7 +65,6 @@ Scheduling:
         S3Access:
           - BucketName: {{ bucket }}
             EnableWriteAccess: true
-  {% endfor %}
 SharedStorage:
   - MountDir: /shared  # Test comment
     Name: name1


### PR DESCRIPTION
### Description of changes
* Job-level scaling uses various strategies, namely: `best-effort`, `all-or-nothing`, `greedy-all-or-nothing`
* These code changes test the following features when each of the scaling strategies is being used:
    * [Protected Mode](https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-protected-mode-v3.html)
    * [Fast Insufficient Capacity Failover](https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-short-capacity-fail-mode-v3.html)
* `JobExclusiveAllocation` is no longer required in order to use job-level scaling since JLS is done for all types of jobs. Supporting it as a dimension also increases the runtime of the test without any additional value (runtime of more than 1 hour).

### Tests
* Ran the tests to confirm they pass

### References
* [Protected Mode](https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-protected-mode-v3.html)
* [Fast Insufficient Capacity Failover](https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-short-capacity-fail-mode-v3.html)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
