### PR TITLE
[develop] Extend CapacityTypeValidator to ensure there is CapacityReservationId when using Capacity Blocks

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2562,10 +2562,12 @@ class SlurmQueue(_CommonQueue):
                     settings_level=CustomSlurmSettingLevel.COMPUTE_RESOURCE,
                 )
             for instance_type in compute_resource.instance_types:
+                cr_target = compute_resource.capacity_reservation_target or self.capacity_reservation_target
                 self._register_validator(
                     CapacityTypeValidator,
                     capacity_type=self.capacity_type,
                     instance_type=instance_type,
+                    capacity_reservation_id=cr_target.capacity_reservation_id if cr_target else None,
                 )
 
 

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -284,6 +284,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     capacity_reservation_validator = mocker.patch(
         ec2_validators + ".CapacityReservationValidator._validate", return_value=[]
     )
+    capacity_type_validator = mocker.patch(ec2_validators + ".CapacityTypeValidator._validate", return_value=[])
 
     mock_aws_api(mocker)
 
@@ -411,6 +412,22 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
                 capacity_type=CapacityType.CAPACITY_BLOCK,
             ),
         ]
+    )
+    capacity_type_validator.assert_has_calls(
+        [
+            call(capacity_type=CapacityType.SPOT, instance_type="t2.large", capacity_reservation_id=None),
+            call(capacity_type=CapacityType.SPOT, instance_type="c4.2xlarge", capacity_reservation_id=None),
+            call(capacity_type=CapacityType.ONDEMAND, instance_type="c5.4xlarge", capacity_reservation_id=None),
+            call(capacity_type=CapacityType.ONDEMAND, instance_type="c5d.xlarge", capacity_reservation_id=None),
+            call(capacity_type=CapacityType.ONDEMAND, instance_type="t2.large", capacity_reservation_id="cr-34567"),
+            call(
+                capacity_type=CapacityType.CAPACITY_BLOCK, instance_type="t2.xlarge", capacity_reservation_id="cr-12345"
+            ),
+            call(
+                capacity_type=CapacityType.CAPACITY_BLOCK, instance_type="t2.xlarge", capacity_reservation_id="cr-23456"
+            ),
+        ],
+        any_order=True,
     )
 
     # No assertion on the argument for minor validators


### PR DESCRIPTION
### Description of changes
Verify there is CapacityReservationId when using Capacity Blocks.

### Tests
Manually tested. A configuration like the following, was correct before the patch:
``` 
  - Name: queue1
    CapacityType: CAPACITY_BLOCK
    ComputeResources:
    - Name: p5
      InstanceType: p5.48xlarge
      MinCount: 1
      MaxCount: 1
    Networking:
      SubnetIds:
        - subnet-0d5734cb1bd32f682
```
Now it's failing with:
``` 
    {
      "level": "ERROR",
      "type": "CapacityTypeValidator",
      "message": "Capacity Reservation id is required when using CAPACITY_BLOCK as capacity type."
    }
```

### References
* Follow-up patch of: https://github.com/aws/aws-parallelcluster/pull/5817
