### PR TITLE
[develop] Automatically retrieve instance type from capacity reservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Add the option to use EFS storage instead of NFS exports from the head node root volume for intra-cluster shared ParallelCluster, Intel, Slurm, and login node data.
 - Allow for mounting `home` as an EFS or FSx external shared storage via the `SharedStorage` section of the config file.
 - Add support for Rocky Linux 8, only using a `CustomAmi` created through `build-image` process. No official Rocky8 Linux AMIs will be published.
+- Make `InstanceType` an optional configuration parameter when configuring `CapacityReservationTarget/CapacityReservationId` in the compute resource.
 - Add `Scheduling/ScalingStrategy` parameter to control job-level scaling strategy for node to be resumed by Slurm. 
   Possible values are `all-or-nothing`, `greedy-all-or-nothing`, `best-effort`, with `all-or-nothing` being the default.
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2425,7 +2425,7 @@ class _CommonQueue(BaseQueue):
             if isinstance(compute_resource, SlurmComputeResource):
                 self._register_validator(
                     EfaValidator,
-                    instance_type=compute_resource.instance_type,
+                    instance_type=compute_resource.instance_types[0],
                     efa_enabled=compute_resource.efa.enabled,
                     gdr_support=compute_resource.efa.gdr_support,
                     multiaz_enabled=self.multi_az_enabled,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2285,11 +2285,6 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
         """List of instance types under this compute resource."""
         return [self.instance_type]
 
-    @property
-    def instance_type_info(self) -> InstanceTypeInfo:
-        """Return instance type information."""
-        return AWSApi.instance().ec2.get_instance_type_info(self.instance_type)
-
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
         self._register_validator(
@@ -2324,7 +2319,7 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:
         """Return true if simultaneous multithreading must be disabled with a cookbook script."""
-        return self.disable_simultaneous_multithreading and self.instance_type_info.default_threads_per_core() > 1
+        return self.disable_simultaneous_multithreading and self._instance_type_info.default_threads_per_core() > 1
 
 
 class _CommonQueue(BaseQueue):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1509,13 +1509,21 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     @validates_schema
     def no_coexist_instance_type_flexibility(self, data, **kwargs):
         """Validate that 'instance_type' and 'instances' do not co-exist."""
-        if self.fields_coexist(
-            data,
-            ["instance_type", "instances"],
-            one_required=True,
-            **kwargs,
-        ):
+        if self.fields_coexist(data, ["instance_type", "instances"], **kwargs):
             raise ValidationError("A Compute Resource needs to specify either InstanceType or Instances.")
+
+    @validates_schema
+    def instance_type_declaration(self, data, **kwargs):
+        """Validate that 'instance_type' is specified, directly or through capacity reservation id."""
+        if not data.get("instances"):
+            capacity_reservation_target = data.get("capacity_reservation_target")
+            capacity_reservation_id = (
+                capacity_reservation_target.capacity_reservation_id if capacity_reservation_target else None
+            )
+            if not data.get("instance_type") and not capacity_reservation_id:
+                raise ValidationError(
+                    "A Compute Resource needs to specify Instances, InstanceType or CapacityReservationId."
+                )
 
     @validates("instances")
     def no_duplicate_instance_types(self, flexible_instance_types: List[FlexibleInstanceType]):

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -176,7 +176,7 @@ class QueuesStack(NestedStack):
         if compute_resource.is_ebs_optimized:
             conditional_template_properties.update({"ebs_optimized": True})
         if isinstance(compute_resource, SlurmComputeResource):
-            conditional_template_properties.update({"instance_type": compute_resource.instance_type})
+            conditional_template_properties.update({"instance_type": compute_resource.instance_types[0]})
 
         return ec2.CfnLaunchTemplate(
             self,

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -127,6 +127,8 @@ def test_compute_type_validator(capacity_type, expected_message):
     ],
 )
 def test_slurm_compute_resource_validator(section_dict, expected_message):
+    # Add required field
+    section_dict.update({"InstanceType": "t2.micro"})
     _validate_and_assert_error(SlurmComputeResourceSchema(), section_dict, expected_message)
 
 


### PR DESCRIPTION
### Description of changes
Starting from now `InstanceType` is no longer a required configuration parameter.
This can be automatically retrieved from `CapacityReservationTarget/CapacityReservationId`
when it's specified at Compute Resource level.

### Tests
* Extended unit tests accordingly
* Manual test of cluster creation with and without instance type
