### PR TITLE
[develop] Remove limitation of having only static nodes when using CapacityBlocks

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2549,10 +2549,7 @@ class SlurmQueue(_CommonQueue):
                 multi_az_enabled=self.multi_az_enabled,
             )
             self._register_validator(
-                ComputeResourceSizeValidator,
-                min_count=compute_resource.min_count,
-                max_count=compute_resource.max_count,
-                capacity_type=self.capacity_type,
+                ComputeResourceSizeValidator, min_count=compute_resource.min_count, max_count=compute_resource.max_count
             )
             if compute_resource.custom_slurm_settings:
                 self._register_validator(

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -20,7 +20,6 @@ from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.aws.common import AWSClientError
 from pcluster.cli.commands.dcv_util import get_supported_dcv_os
-from pcluster.config.common import CapacityType
 from pcluster.constants import (
     CIDR_ALL_IPS,
     DELETE_POLICY,
@@ -203,19 +202,9 @@ class ComputeResourceSizeValidator(Validator):
     Validate min count and max count combinations.
     """
 
-    def _validate(self, min_count: int, max_count: int, capacity_type: CapacityType):
+    def _validate(self, min_count: int, max_count: int):
         if max_count < min_count:
             self._add_failure("Max count must be greater than or equal to min count.", FailureLevel.ERROR)
-        if capacity_type == CapacityType.CAPACITY_BLOCK:
-            if max_count != min_count:
-                self._add_failure(
-                    "Max count must be set to the same value of min count when using Capacity Block reservation.",
-                    FailureLevel.ERROR,
-                )
-            if min_count == 0:
-                self._add_failure(
-                    "Min count must be a value > 0 when using Capacity Block reservation.", FailureLevel.ERROR
-                )
 
 
 class EfaOsArchitectureValidator(Validator):

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -295,13 +295,13 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     compute_resource_size_validator.assert_has_calls(
         [
             # Defaults of min_count=0, max_count=10
-            call(min_count=0, max_count=10, capacity_type=CapacityType.SPOT),
-            call(min_count=0, max_count=10, capacity_type=CapacityType.SPOT),
-            call(min_count=0, max_count=5, capacity_type=CapacityType.ONDEMAND),
-            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
-            call(min_count=0, max_count=10, capacity_type=CapacityType.ONDEMAND),
-            call(min_count=5, max_count=5, capacity_type=CapacityType.CAPACITY_BLOCK),
-            call(min_count=3, max_count=3, capacity_type=CapacityType.CAPACITY_BLOCK),
+            call(min_count=0, max_count=10),
+            call(min_count=0, max_count=10),
+            call(min_count=0, max_count=5),
+            call(min_count=0, max_count=10),
+            call(min_count=0, max_count=10),
+            call(min_count=5, max_count=5),
+            call(min_count=3, max_count=3),
         ],
         any_order=True,
     )

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -30,7 +30,6 @@ from pcluster.config.cluster_config import (
     SlurmSettings,
     Tag,
 )
-from pcluster.config.common import CapacityType
 from pcluster.constants import PCLUSTER_NAME_MAX_LENGTH, PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING
 from pcluster.validators.cluster_validators import (
     FSX_MESSAGES,
@@ -482,46 +481,17 @@ def test_scheduler_os_validator(os, scheduler, expected_message):
 
 
 @pytest.mark.parametrize(
-    "min_count, max_count, capacity_type, expected_messages",
+    "min_count, max_count, expected_messages",
     [
-        (0, 0, None, None),
-        (1, 2, None, None),
-        (1, 1, None, None),
-        (1, 2, CapacityType.ONDEMAND, None),
-        (1, 1, CapacityType.ONDEMAND, None),
-        (1, 2, CapacityType.SPOT, None),
-        (1, 1, CapacityType.SPOT, None),
-        (
-            1,
-            2,
-            CapacityType.CAPACITY_BLOCK,
-            "Max count must be set to the same value of min count when using Capacity Block reservation",
-        ),
-        (
-            0,
-            2,
-            CapacityType.CAPACITY_BLOCK,
-            [
-                "Max count must be set to the same value of min count when using Capacity Block reservation",
-                "Min count must be a value > 0 when using Capacity Block reservation.",
-            ],
-        ),
-        (0, 0, CapacityType.CAPACITY_BLOCK, "Min count must be a value > 0 when using Capacity Block reservation."),
-        (1, 1, CapacityType.CAPACITY_BLOCK, None),
-        (2, 1, None, "Max count must be greater than or equal to min count"),
-        (
-            2,
-            1,
-            CapacityType.CAPACITY_BLOCK,
-            [
-                "Max count must be greater than or equal to min count",
-                "Max count must be set to the same value of min count when using Capacity Block reservation",
-            ],
-        ),
+        (0, 0, None),
+        (1, 2, None),
+        (1, 1, None),
+        (0, 2, None),
+        (2, 1, "Max count must be greater than or equal to min count"),
     ],
 )
-def test_compute_resource_size_validator(min_count, max_count, capacity_type, expected_messages):
-    actual_failures = ComputeResourceSizeValidator().execute(min_count, max_count, capacity_type)
+def test_compute_resource_size_validator(min_count, max_count, expected_messages):
+    actual_failures = ComputeResourceSizeValidator().execute(min_count, max_count)
     assert_failure_messages(actual_failures, expected_messages)
 
 


### PR DESCRIPTION
### Description of changes

This limitation is not required because when the CB is not active all the nodes associated to CBs are put in a Slurm reservation.

When nodes are in a reservation, Slurm won't try to launch the instances, even if there are pending jobs on them.

### Tests
Verification of slurm resume behaviour:
```
[ec2-user@ip-172-31-11-113 ~]$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue3       up   infinite      3  idle~ queue3-dy-t2on-[1-3]
[root@ip-172-31-11-113 ~]# scontrol create reservation ReservationName=test nodes=queue3-dy-t2on-[1-3] starttime=now duration=infinite users=root flags=maint
Reservation created: test
[root@ip-172-31-11-113 ~]# sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue3       up   infinite      3  maint queue3-dy-t2on-[1-3]

[root@ip-172-31-11-113 ~]# sbatch --wrap "sleep 100" -p queue3
Submitted batch job 4
[root@ip-172-31-11-113 ~]# squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                 4    queue3     wrap     root PD       0:00      1 (ReqNodeNotAvail, Reserved for maintenance)
[root@ip-172-31-11-113 ~]# tail -v /var/log/parallelcluster/slurm_resume.log
==> /var/log/parallelcluster/slurm_resume.log <==
```

### References
* Follow-up of #5817 
