### PR TITLE
[release-3.8] Test scaling behaviour of job-level scaling strategies based on available capacity

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -400,6 +400,12 @@ scaling:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
+  test_scaling.py::test_job_level_scaling:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: [ "alinux2" ]
+        schedulers: ["slurm"]
 schedulers:
   test_awsbatch.py::test_awsbatch:
     dimensions:

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import logging
 import time
-from typing import List
+from typing import List, Union
 
 import boto3
 from assertpy import assert_that, soft_assertions
@@ -96,7 +96,7 @@ def submit_job_and_assert_logs(
     remote_command_executor: RemoteCommandExecutor,
     job_kwargs: dict,
     log_files: list,
-    log_assertions: list,
+    log_assertions: Union[list, iter],
     wait_for_job_completion: bool = False,
     clear_logs_before_job_submission: bool = False,
 ):

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
+from itertools import chain
 from typing import Union
 
 import boto3
@@ -265,19 +266,14 @@ def test_job_level_scaling(
         multi_instance_types_ice_cr="ice-cr-multiple",
     )
 
-    partial_capacity_log_assertions = scaling_behaviour_by_capacity["partial_capacity"]["log_assertions"]
-    full_capacity_log_assertions = scaling_behaviour_by_capacity["full_capacity"]["log_assertions"]
-
     # Assert scaling behaviour when partial capacity for a job is available
     submit_job_and_assert_logs(
         scheduler_commands=scheduler_commands,
         remote_command_executor=remote_command_executor,
         job_kwargs=scaling_behaviour_by_capacity["partial_capacity"]["job"],
         log_files=["/var/log/parallelcluster/slurm_resume.log"],
-        log_assertions=list(
-            partial_capacity_log_assertions["launch"]
-            + partial_capacity_log_assertions["node_assignment"]
-            + partial_capacity_log_assertions["post_scaling"]
+        log_assertions=chain.from_iterable(
+            scaling_behaviour_by_capacity["partial_capacity"]["log_assertions"].values()
         ),
         wait_for_job_completion=False,
         clear_logs_before_job_submission=True,
@@ -288,11 +284,7 @@ def test_job_level_scaling(
         remote_command_executor=remote_command_executor,
         job_kwargs=scaling_behaviour_by_capacity["full_capacity"]["job"],
         log_files=["/var/log/parallelcluster/slurm_resume.log"],
-        log_assertions=list(
-            full_capacity_log_assertions["launch"]
-            + full_capacity_log_assertions["node_assignment"]
-            + full_capacity_log_assertions["post_scaling"]
-        ),
+        log_assertions=chain.from_iterable(scaling_behaviour_by_capacity["full_capacity"]["log_assertions"].values()),
         wait_for_job_completion=True,
         clear_logs_before_job_submission=True,
     )

--- a/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
@@ -10,9 +10,9 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: slurm
+  ScalingStrategy: {{ scaling_strategy }}
   SlurmQueues:
     - Name: queue-jls-1-full
-      JobExclusiveAllocation: true
       ComputeResources:
         - Name: compute-resource-0
           Instances:
@@ -24,7 +24,6 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
     - Name: queue-jls-1-partial
-      JobExclusiveAllocation: true
       ComputeResources:
         - Name: compute-resource-0
           Instances:


### PR DESCRIPTION
### Description of changes
* Job-level scaling currently supports these scaling strategies:
    * `all-or-nothing`: Characterised by an all-or-nothing launch, all-or-nothing assignment (if the needed capacity is launched, it's assigned to nodes, otherwise no assignment is performed)) and termination of unassigned capacity at the end of the resume call
    * `best-effort`:  Characterised by a best-effort launch, best-effort assignment (all or partial capacity launched is assigned to nodes) and NO termination of unassigned capacity at the end of the resume call
    * `greedy-all-or-nothing`: Characterised by a best-effort launch, all-or-nothing assignment and termination of unassigned capacity at the end of the resume call
* These tests create a cluster running each of the above strategies and asserts that they apply the expected scaling behaviour

### Tests
* Ran the tests to confirm they pass

### References
* N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
