### PR TITLE
[Test] Add permission 'iam:GetInstanceProfile' to the permissions boundary used in integration test 'test_iam_resource_prefix'.

### DIFF
--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -467,6 +467,7 @@ def _create_permission_boundary(permission_boundary_name):
                 {
                     "Action": [
                         "iam:DeleteInstanceProfile",
+                        "iam:GetInstanceProfile",
                         "iam:RemoveRoleFromInstanceProfile",
                         "iam:CreateInstanceProfile",
                         "iam:AddRoleToInstanceProfile",


### PR DESCRIPTION
### Description of changes
Add permission 'iam:GetInstanceProfile' to the permissions boundary used in integration test 'test_iam_resource_prefix'.
The lack of this permission makes the cluster creation fail.

### Tests
* ONGOING: integration test test_iam_resource_prefix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
