### PR TITLE
[3.7.2][integ-test] Add GetInstanceProfile permission for integration test permission boundary

### DIFF
--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -472,15 +472,13 @@ def _create_permission_boundary(permission_boundary_name):
                         "iam:AddRoleToInstanceProfile",
                         "iam:TagInstanceProfile",
                         "iam:UntagInstanceProfile",
+                        "iam:GetInstanceProfile",
                     ],
                     "Effect": "Allow",
                     "Resource": [
                         {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CustomIamPathPrefix}/*"},
                         {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CustomIamNamePrefix}*"},
-                        {
-                            "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/"
-                            "${CustomIamPathPrefix}/*"
-                        },
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*"},
                     ],
                 },
                 {


### PR DESCRIPTION
test_iam_resource_prefix started to fail a few days ago. It seems CloudFormation started to require GetInstanceProfile permission while creating an instance profile. Moreover, the action is ignores the path prefix. Therefore, this commit adds `iam:GetInstanceProfile` and relax the resource specification.

### Tests
test_iam_resource_prefix has been passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
