### PR TITLE
[Release 3.8] Fix create_file_cache import after removal due to linter

### DIFF
--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -24,6 +24,9 @@ from tests.storage.storage_common import (
     test_efs_correctly_mounted,
     verify_directory_correctly_shared,
 )
+from tests.storage.test_fsx_lustre import create_file_cache  # noqa  # pylint: disable=unused-import
+
+# flake8: noqa
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The create_file_cache fixture was imported from the test_fsx_lustre module but pylint sees it as an unused import.  This PR re-enables that import and ignores pylint on this line

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
