### PR TITLE
[develop] Create integration tests for Capacity Blocks

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -143,3 +143,9 @@ test-suites:
         - oss: ["rhel8"]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
+  capacity_reservations:
+    test_capacity_blocks.py::test_capacity_blocks:
+      dimensions:
+        - regions: ["eu-west-1"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/tests/capacity_reservations/__init__.py
+++ b/tests/integration-tests/tests/capacity_reservations/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks.py
+++ b/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks.py
@@ -1,0 +1,111 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import random
+import time
+
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+
+
+@pytest.mark.usefixtures("os", "scheduler")
+def test_capacity_blocks(pcluster_config_reader, clusters_factory, test_datadir, scheduler_commands_factory):
+    """
+    Test that clustermgtd and the system works as expected when using Capacity Blocks.
+
+    The Capacity Blocks behaviour is totally simulated, with some mocking and overrides.
+
+    Fleet-config and describe-capacity-reservations output will be mocked in the following way:
+    - static nodes initially will be created because standard on-demand instances,
+    - fleet-config.json will be modified to simulate there is a CB,
+    - the describe_capacity_reservations will be mocked to return a pending/active CB to simulate state transition
+    The test will verify that Slurm reservations are created/deleted accordingly and job in pending will start.
+    """
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    # fake capacity block id
+    capacity_block_id = "cr-123456abc12345abc"
+    reservation_name = f"pcluster-{capacity_block_id}"
+
+    # override describe-capacity-reservations output
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    remote_command_executor.run_remote_script(
+        script_file=str(test_datadir / "override_capacity_blocks.sh"), args=[capacity_block_id]
+    )
+    logging.info("Restart clustermgtd to load the overrides module")
+    remote_command_executor.run_remote_command(command="sudo systemctl restart supervisord")
+    # wait 1 minute for clustermgtd execution
+    time.sleep(60)
+    _check_slurm_reservation_existence(remote_command_executor, capacity_block_id, reservation_name)
+
+    # submit a job that will remain in pending because CB is not active
+    logging.info("Submitted a job in a pending CB")
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    result = scheduler_commands.submit_command("sleep 1")
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.assert_job_state(job_id, "PENDING")
+
+    # Simulate active CB and check slurm reservations are removed
+    _modify_capacity_block_override_status(remote_command_executor, previous_status="pending", new_status="active")
+    # Verify slurm reservation has been removed
+    logging.info("Checking slurm reservation for CB %s has been removed", capacity_block_id)
+    result = remote_command_executor.run_remote_command(
+        command=f"scontrol show ReservationName={reservation_name}", raise_on_error=False
+    )
+    assert_that(result.stdout).contains(f"Reservation {reservation_name} not found")
+
+    # Verify job is completed
+    scheduler_commands.wait_job_completed(job_id)
+    logging.info(f"Job {job_id} that was pending in the inactive CB, is now completed")
+
+    # Move CB back to pending and check slurm reservations are restored
+    _modify_capacity_block_override_status(remote_command_executor, previous_status="active", new_status="pending")
+    _check_slurm_reservation_existence(remote_command_executor, capacity_block_id, reservation_name)
+
+
+def _check_slurm_reservation_existence(remote_command_executor, capacity_block_id, reservation_name):
+    """Verify slurm reservation containing both static and dynamic nodes for the CB exists."""
+    logging.info("Verifying slurm reservation for CB %s exists", capacity_block_id)
+    result = remote_command_executor.run_remote_command(command=f"scontrol show ReservationName={reservation_name}")
+    assert_that(result.stdout).matches(
+        r"Nodes=queue1-dy-cr1-\[1-2\],queue1-st-cr1-\[1-2\] NodeCnt=4 .*Flags=MAINT,SPEC_NODES"
+    )
+
+
+def _modify_capacity_block_override_status(remote_command_executor, previous_status, new_status):
+    """Replace strings in the capacity-reservations-data.json file and re-initialize clustermgtd."""
+    logging.info("Changing status of CB from %s to %s", previous_status, new_status)
+    remote_command_executor.run_remote_command(
+        command=f"sudo sed -i 's/{previous_status}/{new_status}/g' /tmp/capacity-reservations-data.json",
+    )
+    _trigger_capacity_block_manager_execution(remote_command_executor)
+
+
+def _trigger_capacity_block_manager_execution(remote_command_executor):
+    """
+    Modify a random parameter in clustermgtd configuration to trigger a new execution of the CB management loop.
+
+    ClusterManager object (and so CapacityBlockManager) is re-initialized every time the clustermgd config is modified.
+    """
+    logging.info(
+        "Triggering capacity block manager execution after modification of describe-capacity-reservations overrides"
+    )
+    new_timeout_value = random.randint(400, 800)
+    remote_command_executor.run_remote_command(
+        command=(
+            f"sudo sed -i 's/insufficient_capacity_timeout = .*/insufficient_capacity_timeout = {new_timeout_value}/g'"
+            " /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
+        )
+    )
+    # wait 2 minutes to be sure clustermgtd does another round of checks
+    time.sleep(120)

--- a/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks/test_capacity_blocks/override_capacity_blocks.sh
+++ b/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks/test_capacity_blocks/override_capacity_blocks.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+set -ex
+
+capacity_reservation_id=$1
+capacity_reservation_override_file="/tmp/capacity-reservations-data.json"
+
+# Write mocked output in a file to be able to modify it without the need to reload the python module
+cat << EOF | sudo tee -a ${capacity_reservation_override_file}
+{
+    "CapacityReservationId": "${capacity_reservation_id}",
+    "OwnerId": "447714826191",
+    "CapacityReservationArn": "arn:aws:ec2:us-east-2:447714826191:capacity-reservation/${capacity_reservation_id}",
+    "AvailabilityZoneId": "use2-az1",
+    "InstanceType": "t2.micro",
+    "InstancePlatform": "Linux/UNIX",
+    "AvailabilityZone": "us-east-2a",
+    "Tenancy": "default",
+    "TotalInstanceCount": "0",
+    "AvailableInstanceCount": "0",
+    "EbsOptimized": "false",
+    "EphemeralStorage": "false",
+    "State": "pending",
+    "StartDate": "2023-11-20T11:30:00+00:00",
+    "EndDate": "2023-11-21T11:30:00+00:00",
+    "EndDateType": "limited",
+    "InstanceMatchCriteria": "targeted",
+    "CreateDate": "2023-11-06T12:03:21+00:00",
+    "Tags": [
+        {
+            "Key": "aws:ec2capacityreservation:incrementalRequestedQuantity",
+            "Value": "4"
+        },
+        {
+            "Key": "aws:ec2capacityreservation:capacityReservationType",
+            "Value": "capacity-block"
+        }
+    ],
+    "CapacityAllocations": [],
+    "ReservationType": "capacity-block"
+}
+EOF
+
+
+node_virtualenv_path=$(sudo find / -iname "site-packages" | grep "node_virtualenv")
+# the overrides.py file must be in the same folder of the module of the function to be mocked
+cat << EOF | sudo tee -a "${node_virtualenv_path}/aws/overrides.py"
+import json
+from aws.ec2 import CapacityReservationInfo
+
+def describe_capacity_reservations(_, capacity_reservations_ids):
+    capacity_reservation_data = {}
+    # read content from a file, to be able to modify it without the need to reload clustermgtd python module
+    with open("${capacity_reservation_override_file}") as override_file:
+        capacity_reservation_data = json.load(override_file)
+    return [CapacityReservationInfo(capacity_reservation_data)]
+EOF
+
+# create a fake fleet-config.json with a capacity block
+cat << EOF | sudo tee "/etc/parallelcluster/slurm_plugin/fleet-config.json"
+{
+    "queue1": {
+        "cr1": {
+            "CapacityType": "capacity-block",
+            "CapacityReservationId": "${capacity_reservation_id}",
+            "Api": "run-instances",
+            "Instances": [
+                {
+                    "InstanceType": "t2.micro"
+                }
+            ]
+        }
+    }
+}
+EOF

--- a/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks/test_capacity_blocks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/capacity_reservations/test_capacity_blocks/test_capacity_blocks/pcluster.config.yaml
@@ -1,0 +1,25 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: t2.large
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: queue1
+      # CapacityType will be modified to CAPACITY_BLOCK in the fleet-config.json file at runtime.
+      # Do not modify queue, campute resource names and instance type.
+      CapacityType: ONDEMAND
+      ComputeResources:
+        - Name: cr1
+          InstanceType: t2.micro
+          MinCount: 2
+          MaxCount: 4
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}


### PR DESCRIPTION
### Description of changes
The Capacity Blocks behaviour is totally simulated, with mocking and overrides.

Fleet-config and describe-capacity-reservations output will be mocked in the following way:
 - static nodes initially will be created because standard on-demand instances,
 - fleet-config.json will be modified to simulate there is a CB,
 - the describe_capacity_reservations will be mocked to return a pending/active CB to simulate state transition

The test will verify that Slurm reservations are created/deleted accordingly and job in pending will start.

This code relies on a new override mechanism introduced as part of https://github.com/aws/aws-parallelcluster-node/pull/602

### Tests
```
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: /bin/bash override_capacity_blocks.sh cr-123456abc12345abc
- test_capacity_blocks - Restart clustermgtd to load the overrides module
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sudo systemctl restart supervisord

- test_capacity_blocks - Verifying slurm reservation for CB cr-123456abc12345abc exists
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: scontrol show ReservationName=pcluster-cr-123456abc12345abc
- test_capacity_blocks - Submitted a job in a pending CB
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sbatch --wrap='sleep 1'
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: scontrol show jobs -o 1

- test_capacity_blocks - Changing status of CB from pending to active
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sudo sed -i 's/pending/active/g' /tmp/capacity-reservations-data.json
- test_capacity_blocks - Triggering capacity block manager execution after modification of describe-capacity-reservations overrides
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sudo sed -i 's/insufficient_capacity_timeout = .*/insufficient_capacity_timeout = 474/g' /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
- test_capacity_blocks - Checking slurm reservation for CB cr-123456abc12345abc has been removed
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: scontrol show ReservationName=pcluster-cr-123456abc12345abc
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: scontrol show jobs -o 1
- test_capacity_blocks - Job 1 that was pending in the inactive CB, is now completed

- test_capacity_blocks - Changing status of CB from active to pending
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sudo sed -i 's/active/pending/g' /tmp/capacity-reservations-data.json
- test_capacity_blocks - Triggering capacity block manager execution after modification of describe-capacity-reservations overrides
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: sudo sed -i 's/insufficient_capacity_timeout = .*/insufficient_capacity_timeout = 599/g' /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
- test_capacity_blocks - Verifying slurm reservation for CB cr-123456abc12345abc exists
- remote_command_executor - Executing remote command on ec2-user@3.253.85.120: scontrol show ReservationName=pcluster-cr-123456abc12345abc
...

- conftest - Completed test test_capacity_blocks[eu-west-1-alinux2-slurm-None]
[gw0] PASSED tests/capacity_reservations/test_capacity_blocks.py::test_capacity_blocks
```

### References
* Follow-up of #5817 

