### PR TITLE
[Develop] Update shared home test to include mounting to multiple clu…

### DIFF
--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -77,7 +77,19 @@ def test_shared_home(
         )
     else:
         cluster_config = pcluster_config_reader(mount_dir=mount_dir, storage_type=storage_type)
-    cluster = clusters_factory(cluster_config)
+    cluster1 = clusters_factory(cluster_config)
+    _check_shared_home(
+        cluster1, scheduler_commands_factory, storage_type, mount_dir, region, bucket_name, file_cache_path
+    )
+    cluster2 = clusters_factory(cluster_config)
+    _check_shared_home(
+        cluster2, scheduler_commands_factory, storage_type, mount_dir, region, bucket_name, file_cache_path
+    )
+
+
+def _check_shared_home(
+    cluster, scheduler_commands_factory, storage_type, mount_dir, region, bucket_name, file_cache_path
+):
     remote_command_executor = RemoteCommandExecutor(cluster)
     remote_command_executor_login_node = RemoteCommandExecutor(cluster, use_login_node=True)
 


### PR DESCRIPTION
…sters

We need to ensure that the shared file systems can be mounted across clusters.  The FSx ontap and openzfs filesystems for instance are shared filesystems and we can test sharing those filesystems across clusters.

### Tests
* Ran test_shared_home locally with additional clusters.  It will create new filesystems for EFS, Lustre, and EBS, but will reuse the fsx ontap and openzfs filesystems.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
