### PR TITLE
[release-3.8] Move job level scaling from common to develop yaml

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -400,12 +400,6 @@ scaling:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-  test_scaling.py::test_job_level_scaling:
-    dimensions:
-      - regions: ["eu-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: [ "alinux2" ]
-        schedulers: ["slurm"]
 schedulers:
   test_awsbatch.py::test_awsbatch:
     dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -96,6 +96,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.NOT_RELEASED_OSES }}
           schedulers: ["slurm"]
+    test_scaling.py::test_job_level_scaling:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [ "alinux2" ]
+          schedulers: ["slurm"]
   trainium:
     test_trainium.py::test_trainium:
       dimensions:


### PR DESCRIPTION
### Description of changes
Move job level scaling from common to develop yaml, since scaling tests defined in common are overwritten by scaling tests defined in develop. Additionaly, we want to test the scaling only during develop and not for released tests, since once released, the scaling logic doesn't change (we are anyway testing a subset of the scaling tests)

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
