### PR TITLE
[develop] [integ-tests] Fix and improve test_on_demand_capacity_reservation 

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1329,14 +1329,14 @@ def odcr_stack(
     open_odcr = ec2.CapacityReservation(
         "integTestsOpenOdcr",
         AvailabilityZone=default_public_az,
-        InstanceCount=4,
+        InstanceCount=6,
         InstancePlatform="Linux/UNIX",
         InstanceType="m5.2xlarge",
     )
     target_odcr = ec2.CapacityReservation(
         "integTestsTargetOdcr",
         AvailabilityZone=default_public_az,
-        InstanceCount=4,
+        InstanceCount=6,
         InstancePlatform="Linux/UNIX",
         InstanceType="r5.xlarge",
         InstanceMatchCriteria="targeted",
@@ -1345,7 +1345,7 @@ def odcr_stack(
     pg_odcr = ec2.CapacityReservation(
         "integTestsPgOdcr",
         AvailabilityZone=default_public_az,
-        InstanceCount=2,
+        InstanceCount=3,
         InstancePlatform="Linux/UNIX",
         InstanceType="m5.xlarge",
         InstanceMatchCriteria="targeted",

--- a/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation.py
+++ b/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation.py
@@ -69,8 +69,8 @@ def test_on_demand_capacity_reservation(
 def _assert_instance_in_capacity_reservation(cluster, region, compute_resource_name, expected_reservation):
     instances = describe_cluster_instances(cluster.name, region, filter_by_compute_resource_name=compute_resource_name)
     if len(instances) == 1:
-        logging.info("One instance found!")
         assert_that(instances[0]["CapacityReservationId"]).is_equal_to(expected_reservation)
+        logging.info(f"One instance launched in the {expected_reservation}")
     else:
         logging.error("Too many instances returned from describe_cluster_instances")
-        pytest.fail("Too many instances found")
+        pytest.fail(f"Too many instances found in the {expected_reservation}")

--- a/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -23,6 +23,13 @@ Scheduling:
           MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
+        - Name: open-odcr-arn-fl-cr
+          Instances:
+          - InstanceType: m5.2xlarge
+          MinCount: 1
+          MaxCount: 1
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
         - Name: open-odcr-id-pg-cr
           InstanceType: m5.2xlarge
           MinCount: 1
@@ -34,6 +41,16 @@ Scheduling:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-pg-cr
           InstanceType: m5.2xlarge
+          MinCount: 1
+          MaxCount: 1
+          Networking:
+            PlacementGroup:
+              Enabled: true
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
+        - Name: open-odcr-arn-pg-fl-cr
+          Instances:
+            - InstanceType: m5.2xlarge
           MinCount: 1
           MaxCount: 1
           Networking:
@@ -58,6 +75,13 @@ Scheduling:
           MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
+        - Name: target-odcr-arn-fl-cr
+          Instances:
+            - InstanceType: r5.xlarge
+          MinCount: 1
+          MaxCount: 1
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
         - Name: target-odcr-id-pg-cr
           InstanceType: r5.xlarge
           MinCount: 1
@@ -69,6 +93,13 @@ Scheduling:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-pg-cr
           InstanceType: r5.xlarge
+          MinCount: 1
+          MaxCount: 1
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
+        - Name: target-odcr-arn-pg-fl-cr
+          Instances:
+            - InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 1
           CapacityReservationTarget:
@@ -89,6 +120,16 @@ Scheduling:
             CapacityReservationId: {{ pg_capacity_reservation_id }}
         - Name: pg-odcr-arn-cr
           InstanceType: m5.xlarge
+          MinCount: 1
+          MaxCount: 1
+          Networking:
+            PlacementGroup:
+              Name: {{ placement_group }}
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ pg_capacity_reservation_arn }}
+        - Name: pg-odcr-arn-fleet-cr
+          Instances:
+            - InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 1
           Networking:

--- a/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/capacity_reservations/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -14,19 +14,19 @@ Scheduling:
         - Name: open-odcr-id-cr
           InstanceType: m5.2xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-cr
           InstanceType: m5.2xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
         - Name: open-odcr-id-pg-cr
           InstanceType: m5.2xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           Networking:
             PlacementGroup:
               Enabled: true
@@ -35,7 +35,7 @@ Scheduling:
         - Name: open-odcr-arn-pg-cr
           InstanceType: m5.2xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           Networking:
             PlacementGroup:
               Enabled: true
@@ -49,19 +49,19 @@ Scheduling:
         - Name: target-odcr-id-cr
           InstanceType: r5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-cr
           InstanceType: r5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
         - Name: target-odcr-id-pg-cr
           InstanceType: r5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           Networking:
             PlacementGroup:
               Enabled: true
@@ -70,7 +70,7 @@ Scheduling:
         - Name: target-odcr-arn-pg-cr
           InstanceType: r5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
       Networking:
@@ -81,7 +81,7 @@ Scheduling:
         - Name: pg-odcr-id-cr
           InstanceType: m5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           Networking:
             PlacementGroup:
               Name: {{ placement_group }}
@@ -90,7 +90,7 @@ Scheduling:
         - Name: pg-odcr-arn-cr
           InstanceType: m5.xlarge
           MinCount: 1
-          MaxCount: 10
+          MaxCount: 1
           Networking:
             PlacementGroup:
               Name: {{ placement_group }}
@@ -99,3 +99,4 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
+


### PR DESCRIPTION
### Description of changes

The config file is in a wrong folder. Issue introduced with: https://github.com/aws/aws-parallelcluster/commit/c71276a88e57eb3a19df6ea015252dfca1b39208

Then, updated `MaxCount` to reflect the actual number of instances in the ODCR

Now we have a `CapacityReservationSizeValidator` that will check if the number of instances is exceeding the total instances count available for that ODCR. See commit: https://github.com/aws/aws-parallelcluster/commit/28968c6c7c67302aa55318e1b4af2569aafb6d68

Test was failing with:
```
"Number of instances configured for Capacity Reservation cr-123: 20 is exceeding the total instances count available for the Capacity Reservation: 4"
"Number of instances configured for Capacity Reservation cr-345: 20 is exceeding the total instances count available for the Capacity Reservation: 4"
"Number of instances configured for Capacity Reservation cr-678: 10 is exceeding the total instances count available for the Capacity Reservation: 2"
```




### Tests

Added some improvements to the logging and extend tests to cover flexible instance types launches too.

Note I didn't add tests when using `CapacityReservationId` and `Instances` because `create-fleet` doesn't support this combination (with both open and target ODCRs). The failure would be:
```
The launch template setting for the Capacity Reservation preference is not compatible with the fleet capacity reservation strategy. In the launch template, specify 'open' for Capacity Reservation (CapacityReservationSpecification:CapacityReservationPreference), and then try to launch the fleet again.
```
This is a known limitation.


Launched the integ test manually:
```
[gw0] PASSED tests/capacity_reservations/test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation[eu-west-1-alinux2-None]
```
