### PR TITLE
[develop] Distinguish standard and flexible compute resource when validating ODCRs

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2214,6 +2214,11 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.static_node_priority = Resource.init_param(static_node_priority, default=1)
         self.dynamic_node_priority = Resource.init_param(dynamic_node_priority, default=1000)
 
+    @abstractmethod
+    def is_flexible(self) -> bool:
+        """Return True if the ComputeResource can contain multiple instance types, False otherwise."""
+        pass
+
     @staticmethod
     def fetch_instance_type_info(instance_type) -> InstanceTypeInfo:
         """Return instance type information."""
@@ -2306,6 +2311,10 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
             instance_type=smallest_type,
         )
 
+    def is_flexible(self):
+        """Return True because the ComputeResource can contain multiple instance types."""
+        return True
+
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:
         """Return true if simultaneous multithreading must be disabled with a cookbook script."""
@@ -2336,6 +2345,10 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
         _instance_type = instance_type if instance_type else self._instance_type_from_capacity_reservation()
         self.instance_type = Resource.init_param(_instance_type)
         self.__instance_type_info = None
+
+    def is_flexible(self):
+        """Return False because the ComputeResource can not contain multiple instance types."""
+        return False
 
     @property
     def instance_types(self) -> List[str]:
@@ -2983,6 +2996,7 @@ class SlurmClusterConfig(BaseClusterConfig):
                         CapacityReservationValidator,
                         capacity_reservation_id=cr_target.capacity_reservation_id,
                         instance_types=compute_resource.instance_types,
+                        is_flexible=compute_resource.is_flexible(),
                         subnet=queue.networking.subnet_ids[0],
                         capacity_type=queue.capacity_type,
                     )

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -396,18 +396,21 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
             call(
                 capacity_reservation_id="cr-34567",
                 instance_types=["t2.large"],
+                is_flexible=True,
                 subnet="subnet-23456789",
                 capacity_type=CapacityType.ONDEMAND,
             ),
             call(
                 capacity_reservation_id="cr-12345",
                 instance_types=["t2.xlarge"],
+                is_flexible=True,
                 subnet="subnet-23456789",
                 capacity_type=CapacityType.CAPACITY_BLOCK,
             ),
             call(
                 capacity_reservation_id="cr-23456",
                 instance_types=["t2.xlarge"],
+                is_flexible=False,
                 subnet="subnet-23456789",
                 capacity_type=CapacityType.CAPACITY_BLOCK,
             ),

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
@@ -51,7 +51,8 @@ Scheduling:
           InstanceType: c5d.xlarge
           DisableSimultaneousMultithreading: false
         - Name: compute_resource3
-          InstanceType: t2.large
+          Instances:
+            - InstanceType: t2.large
           DisableSimultaneousMultithreading: true
           CapacityReservationTarget:
             CapacityReservationId: "cr-34567"
@@ -69,7 +70,8 @@ Scheduling:
           - subnet-23456789
       ComputeResources:
         - Name: compute_resource1
-          InstanceType: t2.xlarge
+          Instances:
+            - InstanceType: t2.xlarge
           MinCount: 5
           MaxCount: 5
         - Name: compute_resource2


### PR DESCRIPTION
`CapacityReservationId` is not supported by create-fleet (`FlexibleComputeResource`), independently by the number of instances.

### References

Issue introduced with: 2f25a09183bf7cff51bfbb185ab3909ac19f0761

