### PR TITLE
[Test] Make StarCCM+ and OpenFOAM tests executable on all OSes and set tolerance to 3%.

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/starccm.yaml
+++ b/tests/integration-tests/configs/starccm.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -19,7 +19,7 @@ def perf_test_difference(perf_test_result, number_of_nodes):
 
 
 def openfoam_installed(headnode):
-    cmd = '[ -d "/shared/ec2-user/SubspaceBenchmarks" ]'
+    cmd = '[ -d "/shared/SubspaceBenchmarks" ]'
     try:
         headnode.run_remote_command(cmd)
         return True
@@ -53,7 +53,7 @@ def test_openfoam(
         )
     logging.info("OpenFOAM Installed")
     performance_degradation = {}
-    subspace_benchmarks_dir = "/shared/ec2-user/SubspaceBenchmarks"
+    subspace_benchmarks_dir = "/shared/SubspaceBenchmarks"
     for node in number_of_nodes:
         logging.info(f"Submitting OpenFOAM job with {node} nodes")
         remote_command_executor.run_remote_command(

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -9,7 +9,7 @@ OPENFOAM_JOB_TIMEOUT = 5400  # Takes long time because during the first time, it
 # builds and installs many things
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {8: 742, 16: 376, 32: 185}
-PERF_TEST_DIFFERENCE_TOLERANCE = 5
+PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
 
 def perf_test_difference(perf_test_result, number_of_nodes):

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.install.sh
@@ -2,15 +2,11 @@
 #the script installs OpenFOAM in a shared folder that is shared with all the cluster nodes
 set -ex
 
-TARGET_USER=$(whoami)
-
 SHARED_DIR="/shared"
-TARGET_USER_DIR="${SHARED_DIR}/${TARGET_USER}"
 
-SUBSPACE_BENCHMARKS_PACKAGE_ZIP="${TARGET_USER_DIR}/SubspaceBenchmarks.tar"
+SUBSPACE_BENCHMARKS_PACKAGE_ZIP="${SHARED_DIR}/SubspaceBenchmarks.tar"
 
-mkdir -p "${TARGET_USER_DIR}"
-cd "${TARGET_USER_DIR}"
+cd "${SHARED_DIR}"
 
 aws s3 cp s3://performance-tests-resources-for-parallelcluster/openfoam/SubspaceBenchmarks.tar ${SUBSPACE_BENCHMARKS_PACKAGE_ZIP}
 tar -xf SubspaceBenchmarks.tar

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.results.sh
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.results.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-OUTPUT=/shared/ec2-user/SubspaceBenchmarks/results/openfoam/openfoam.csv
+OUTPUT="/shared/SubspaceBenchmarks/results/openfoam/openfoam.csv"
 
 cut -d, -f5 $OUTPUT

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -11,7 +11,7 @@ STARCCM_JOB_TIMEOUT = 600
 STARCCM_LICENCE_SECRET = "starccm-license-secret"
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {8: 64.475, 16: 33.1723, 32: 17.8983}
-PERF_TEST_DIFFERENCE_TOLERANCE = 5
+PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
 
 def get_starccm_secrets(region_name):

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -28,7 +28,7 @@ def perf_test_difference(perf_test_result, number_of_nodes):
 
 
 def starccm_installed(headnode):
-    cmd = "/shared/ec2-user/STAR-CCM+/16.02.008/STAR-CCM+16.02.008/star/bin/starccm+ --version"
+    cmd = "/shared/STAR-CCM+/16.02.008/STAR-CCM+16.02.008/star/bin/starccm+ --version"
     try:
         headnode.run_remote_command(cmd)
         return True

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
@@ -2,18 +2,13 @@
 #the script installs StarCCM+ in a shared folder that is shared with all the cluster nodes
 set -ex
 
-TARGET_USER=$(whoami)
-
 SHARED_DIR="/shared" # /shared or whatever you named the SharedStorage MountDir
-TARGET_USER_DIR="${SHARED_DIR}/${TARGET_USER}"
 
-STARCCM_PACKAGE_ZIP="${TARGET_USER_DIR}/pc211debug.tgz"
-
-mkdir -p "${TARGET_USER_DIR}"
+STARCCM_PACKAGE_ZIP="${SHARED_DIR}/pc211debug.tgz"
 
 OLD_PWD=$(pwd)
 
-cd "${TARGET_USER_DIR}"
+cd "${SHARED_DIR}"
 
 aws s3 cp s3://performance-tests-resources-for-parallelcluster/starccm/pc211debug.tgz ${STARCCM_PACKAGE_ZIP}
 tar -xf $(basename ${STARCCM_PACKAGE_ZIP})
@@ -21,8 +16,8 @@ tar -xf $(basename ${STARCCM_PACKAGE_ZIP})
 STARCCM_INSTALLER_ZIP="STAR-CCM+16.02.008_01_linux-x86_64-2.17_gnu9.2.zip"
 unzip ${STARCCM_INSTALLER_ZIP}
 cd STAR-CCM+16.02.008_01_linux-x86_64-2.17_gnu9.2
-# (executed by the below printf) During the installation, you need to type: <ENTER>, Y, N, /shared/${TARGET_USER}/STAR-CCM+, Y, <ENTER>, <ENTER>
-printf "\nY\nN\n${TARGET_USER_DIR}/STAR-CCM+\nY\n\n\n" | ./STAR-CCM+16.02.008_01_linux-x86_64-2.17_gnu9.2.sh
+# (executed by the below printf) During the installation, you need to type: <ENTER>, Y, N, /shared/STAR-CCM+, Y, <ENTER>, <ENTER>
+printf "\nY\nN\n${SHARED_DIR}/STAR-CCM+\nY\n\n\n" | ./STAR-CCM+16.02.008_01_linux-x86_64-2.17_gnu9.2.sh
 
 rm -rf ${STARCCM_PACKAGE_ZIP}
 rm -rf ${STARCCM_INSTALLER_ZIP}

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.slurm.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.slurm.sh
@@ -22,10 +22,9 @@ export FI_EFA_FORK_SAFE=1
 export I_MPI_HYDRA_BOOTSTRAP="slurm"
 
 SHARED_DIR="/shared"
-TARGET_USER=$(whoami)
 
-STARCCM="${SHARED_DIR}/${TARGET_USER}/STAR-CCM+/16.02.008/STAR-CCM+16.02.008/star/bin/starccm+"
-SIM_FILE="${SHARED_DIR}/${TARGET_USER}/lemans_poly_17m.amg@00500.sim"
+STARCCM="${SHARED_DIR}/STAR-CCM+/16.02.008/STAR-CCM+16.02.008/star/bin/starccm+"
+SIM_FILE="${SHARED_DIR}/lemans_poly_17m.amg@00500.sim"
 
 podkey="$1"
 licpath="$2"


### PR DESCRIPTION
### Description of changes
1. Make StarCCM+ and OpenFOAM tests executable on all OSes.
2. Decrease tolerance from 5% to 3%

### Tests
1. Run StarCCM on all OSes. Only RHEL8 failed the cluster creation due to failing mount of FSx (failure not related to this change)
3. [ONGOING, no problem so far] Run OpenFOAM on all OSes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
