### PR TITLE
[Release 3.8] Add /home to internal EFS when not specified in SharedS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ CHANGELOG
 - Add `Scheduling/SlurmSettings/Database/DatabaseName` parameter to allow users to specify a custom name for the database on the database server to be used for Slurm accounting.
 - Add `Monitoring/Alarms/Enabled` parameter to toggle Amazon CloudWatch Alarms for the cluster.
 - Add head node alarms to monitor EC2 health checks, CPU utilization and the overall status of the head node.
-- Add the option to use EFS storage instead of NFS exports from the head node root volume for intra-cluster shared ParallelCluster, Intel, Slurm, and login node data.
+- Add the option to use EFS storage instead of NFS exports from the head node root volume for intra-cluster shared ParallelCluster, Intel, Slurm, login node, and /home data.
 - Allow for mounting `home` as an EFS or FSx external shared storage via the `SharedStorage` section of the config file.
 - Add support for Rocky Linux 8, only using a `CustomAmi` created through `build-image` process. No official Rocky8 Linux AMIs will be published.
 - Make `InstanceType` an optional configuration parameter when configuring `CapacityReservationTarget/CapacityReservationId` in the compute resource.
-- Add `Scheduling/ScalingStrategy` parameter to control job-level scaling strategy for node to be resumed by Slurm. 
+- Add `Scheduling/ScalingStrategy` parameter to control job-level scaling strategy for node to be resumed by Slurm.
   Possible values are `all-or-nothing`, `greedy-all-or-nothing`, `best-effort`, with `all-or-nothing` being the default.
 
 **CHANGES**

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -100,6 +100,7 @@ from pcluster.validators.cluster_validators import (
     SchedulableMemoryValidator,
     SchedulerOsValidator,
     SchedulerValidator,
+    SharedFileCacheNotHomeValidator,
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
     UnmanagedFsxMultiAzValidator,
@@ -648,6 +649,10 @@ class ExistingFileCache(BaseSharedFsx):
         self.file_cache_id = file_cache_id
         self.file_system_id = file_cache_id
         self.file_system_type = FILECACHE
+
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
+        self._register_validator(SharedFileCacheNotHomeValidator, mount_dir=self.mount_dir)
 
     @property
     def existing_dns_name(self):
@@ -1364,7 +1369,7 @@ class HeadNode(Resource):
         ssh: HeadNodeSsh = None,
         disable_simultaneous_multithreading: bool = None,
         local_storage: LocalStorage = None,
-        internal_shared_storage_type: str = None,
+        shared_storage_type: str = None,
         dcv: Dcv = None,
         custom_actions: CustomActions = None,
         iam: Iam = None,
@@ -1379,8 +1384,8 @@ class HeadNode(Resource):
         self.networking = networking
         self.ssh = ssh or HeadNodeSsh(implied=True)
         self.local_storage = local_storage or LocalStorage(implied=True)
-        self.internal_shared_storage_type = Resource.init_param(
-            internal_shared_storage_type,
+        self.shared_storage_type = Resource.init_param(
+            shared_storage_type,
             default="Ebs",
         )
         self.dcv = dcv

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -72,7 +72,7 @@ write_files:
           "raid_type": "${RAIDType}",
           "base_os": "${BaseOS}",
           "region": "${AWS::Region}",
-          "internal_shared_storage_type": "${InternalSharedStorageType}",
+          "shared_storage_type": "${SharedStorageType}",
           "efs_fs_ids": "${EFSIds}",
           "efs_shared_dirs": "${EFSSharedDirs}",
           "efs_encryption_in_transits": "${EFSEncryptionInTransits}",

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -64,7 +64,7 @@ write_files:
             "domain_read_only_user": "${DirectoryServiceReadOnlyUser}",
             "generate_ssh_keys_for_users": "${DirectoryServiceGenerateSshKeys}"
           },
-          "internal_shared_storage_type": "${InternalSharedStorageType}",
+          "shared_storage_type": "${SharedStorageType}",
           "ebs_shared_dirs": "${EbsSharedDirs}",
           "efs_fs_ids": "${EFSIds}",
           "efs_shared_dirs": "${EFSSharedDirs}",

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1312,7 +1312,7 @@ class HeadNodeSchema(BaseSchema):
     )
     ssh = fields.Nested(HeadNodeSshSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     local_storage = fields.Nested(HeadNodeStorageSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    internal_shared_storage_type = fields.Str(
+    shared_storage_type = fields.Str(
         required=False,
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
         validate=validate.OneOf(["Ebs", "Efs"]),

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -263,7 +263,7 @@ class ClusterCdkStack:
         # This FS will be mounted, the shared dirs will be added,
         # then it will be unmounted and the shared dirs will be
         # mounted.  We need to create the additional mount points first.
-        if self.config.head_node.internal_shared_storage_type.lower() == SharedStorageType.EFS.value:
+        if self.config.head_node.shared_storage_type.lower() == SharedStorageType.EFS.value:
             internal_efs_storage_shared = SharedEfs(
                 mount_dir="/opt/parallelcluster/init_shared", name="internal_pcluster_shared", throughput_mode="elastic"
             )
@@ -1241,7 +1241,7 @@ class ClusterCdkStack:
                     ),
                     "base_os": self.config.image.os,
                     "region": self.stack.region,
-                    "internal_shared_storage_type": self.config.head_node.internal_shared_storage_type.lower(),
+                    "shared_storage_type": self.config.head_node.shared_storage_type.lower(),
                     "efs_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EFS),
                     "efs_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.EFS]),
                     "efs_encryption_in_transits": to_comma_separated_string(

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -143,7 +143,7 @@ class Pool(Construct):
                                 "DirectoryServiceEnabled": str(ds_config is not None).lower(),
                                 "DirectoryServiceReadOnlyUser": ds_config.domain_read_only_user if ds_config else "",
                                 "DirectoryServiceGenerateSshKeys": ds_generate_keys,
-                                "InternalSharedStorageType": self._config.head_node.internal_shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
+                                "SharedStorageType": self._config.head_node.shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
                                 "EbsSharedDirs": to_comma_separated_string(
                                     self._shared_storage_mount_dirs[SharedStorageType.EBS]
                                 ),

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -221,7 +221,7 @@ class QueuesStack(NestedStack):
                                 if compute_resource.disable_simultaneous_multithreading_manually
                                 else "false",
                                 "BaseOS": self._config.image.os,
-                                "InternalSharedStorageType": self._config.head_node.internal_shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
+                                "SharedStorageType": self._config.head_node.shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
                                 "EFSIds": get_shared_storage_ids_by_type(
                                     self._shared_storage_infos, SharedStorageType.EFS
                                 ),

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -952,6 +952,24 @@ class SharedStorageMountDirValidator(Validator):
             )
 
 
+class SharedFileCacheNotHomeValidator(Validator):
+    """
+    Shared FileCache Not Home Validator.
+
+    Validate if the provided name for the shared storage is not /home for FileCache
+    """
+
+    def _validate(self, mount_dir: str):
+        if mount_dir in ("/home", "home"):
+            self._add_failure(
+                (
+                    f"Error: FileCache cannot be used to mount the shared storage directory '{mount_dir}'.  Please "
+                    f"select a supported filesystem."
+                ),
+                FailureLevel.ERROR,
+            )
+
+
 class DeletionPolicyValidator(Validator):
     """Print warning message when deletion policy is set to Delete or Retain."""
 

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -36,7 +36,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /scratch
-  InternalSharedStorageType: Ebs  # Efs
+  SharedStorageType: Ebs  # Efs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -42,7 +42,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /test
-  InternalSharedStorageType: Efs  # Ebs
+  SharedStorageType: Efs  # Ebs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -47,7 +47,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /test
-  InternalSharedStorageType: Efs  # Ebs
+  SharedStorageType: Efs  # Ebs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -43,7 +43,6 @@ HeadNode:
   Imds:
     Secured: true
   InstanceType: t2.micro
-  InternalSharedStorageType: Efs
   LocalStorage:
     EphemeralVolume:
       MountDir: /test
@@ -71,6 +70,7 @@ HeadNode:
       HttpProxyAddress: https://proxy-address:port
     SecurityGroups: null
     SubnetId: subnet-12345678
+  SharedStorageType: Efs
   Ssh:
     AllowedIps: 1.2.3.4/32
     KeyName: ec2-key-name

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
@@ -29,7 +29,6 @@
     "head_node_imds_secured": "true",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "instance_types_data_version": "",
-    "internal_shared_storage_type": "ebs",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "log_rotation_enabled": "true",
     "node_type": "HeadNode",
@@ -38,6 +37,7 @@
     "raid_type": "",
     "raid_vol_ids": "",
     "region": "{'Ref': 'AWS::Region'}",
+    "shared_storage_type": "ebs",
     "stack_arn": "{'Ref': 'AWS::StackId'}",
     "stack_name": "clustername",
     "volume": ""

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -198,6 +198,11 @@ SharedStorage:
     StorageType: FsxOpenZfs
     FsxOpenZfsSettings:
       VolumeId: "fsvol-00e6e91b8898ec4ef"
+  - MountDir: /my/mount/point6
+    Name: name6
+    StorageType: FileCache
+    FileCacheSettings:
+      FileCacheId: "fc-00e6e91b8898ec4ef"
 Iam:
   PermissionsBoundary: arn:aws:iam::aws:policy/boundary
   ResourcePrefix: /path-prefix/name-prefix

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -68,6 +68,7 @@ from pcluster.validators.cluster_validators import (
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
     SchedulerOsValidator,
+    SharedFileCacheNotHomeValidator,
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
     UnmanagedFsxMultiAzValidator,
@@ -1523,6 +1524,27 @@ def test_shared_storage_name_validator(name, expected_message):
 )
 def test_shared_storage_mount_dir_validator(mount_dir, expected_message):
     actual_failures = SharedStorageMountDirValidator().execute(mount_dir)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "mount_dir, expected_message",
+    [
+        ("my_dir", None),
+        (
+            "home",
+            "Error: FileCache cannot be used to mount the shared storage directory 'home'.  "
+            "Please select a supported filesystem.",
+        ),
+        (
+            "/home",
+            "Error: FileCache cannot be used to mount the shared storage directory '/home'.  "
+            "Please select a supported filesystem.",
+        ),
+    ],
+)
+def test_shared_filecache_not_home_validator(mount_dir, expected_message):
+    actual_failures = SharedFileCacheNotHomeValidator().execute(mount_dir)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/tests/integration-tests/tests/storage/test_internal_efs.py
+++ b/tests/integration-tests/tests/storage/test_internal_efs.py
@@ -26,8 +26,8 @@ def test_internal_efs(
     region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory
 ):
     """Verify the internal shared storage fs is available when set to Efs"""
-    compute_shared_dirs = ["/opt/parallelcluster/shared", "/opt/slurm", "/opt/intel"]
-    login_shared_dirs = ["/opt/parallelcluster/shared_login_nodes", "/opt/slurm", "/opt/intel"]
+    compute_shared_dirs = ["/opt/parallelcluster/shared", "/opt/slurm", "/opt/intel", "/home"]
+    login_shared_dirs = ["/opt/parallelcluster/shared_login_nodes", "/opt/slurm", "/opt/intel", "/home"]
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
@@ -12,7 +12,7 @@ LoginNodes:
       GracetimePeriod: 60
 {% endif %}
 HeadNode:
-  InternalSharedStorageType: Efs
+  SharedStorageType: Efs
   InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}

--- a/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
@@ -12,6 +12,7 @@ LoginNodes:
       GracetimePeriod: 60
   {% endif %}
 HeadNode:
+  SharedStorageType: {{ shared_storage_type }}
   InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}


### PR DESCRIPTION
…torage

We are going to include /home with the new `SharedStorageType` parameter to support a larger set of use cases. With this change, when a user specifies `Efs` for `SharedStorageType` pcluster will replace all EBS exports with shared EFS storage.

FileCache is incompatible with the use case for shared /home.  The initial load times for files into the cache are too long (over an hour in some cases) and cause timeouts and race conditions in the bootstrapping process.  For this reason, FileCache is not allowed for mounting a shared /home.

### Tests
* Tested creating clusters locally that use a shared /home in the SharedStorage config and Efs for SharedStorageType will use SharedStorage over SharedStorageType for /home

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2550

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
