### PR TITLE
[Develop] Fix miss on renaming for PCAPIUserRole in the infrastructure

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -133,7 +133,7 @@ Globals:
               aws:PrincipalArn: !If
                 - CreateApiUserRoleCondition
                 - !Sub
-                  - arn:${AWS::Partition}:*::${AWS::AccountId}:*/ParallelClusterApiUserRole-${StackIdSuffix}*
+                  - arn:${AWS::Partition}:*::${AWS::AccountId}:*/${IAMRoleAndPolicyPrefix}PCAPIUserRole-${StackIdSuffix}*
                   - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
                 - '*'
     TracingEnabled: True

--- a/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
@@ -59,7 +59,8 @@ def api_with_default_settings(
         factory.create_stack(stack)
         yield stack
     finally:
-        factory.delete_all_stacks()
+        if not request.config.getoption("no_delete"):
+            factory.delete_all_stacks()
 
 
 def test_api_infrastructure_with_default_parameters(region, api_with_default_settings):


### PR DESCRIPTION

### Tests
* Tested the API locally.  The <403> error is gone now so the user role is working.  There is another internal server error that needs to be investigated

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
