### PR TITLE
[release-3.8][Isolated Region]Resolving Region as None when using FeatureRegionValidator for CBR

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2586,7 +2586,7 @@ class SlurmQueue(_CommonQueue):
                     instance_type=instance_type,
                     capacity_reservation_id=cr_target.capacity_reservation_id if cr_target else None,
                 )
-                self._register_validator(FeatureRegionValidator, feature=self.capacity_type)
+                self._register_validator(FeatureRegionValidator, feature=self.capacity_type, region=None)
 
 
 class Dns(Resource):


### PR DESCRIPTION
### Description of changes
Resolving Region as None when using FeatureRegionValidator for CBR



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
