### PR TITLE
[release-3.8] Use older versions of jsonschema and urllib3 for Lambda Layer

### DIFF
--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -40,7 +40,19 @@ def install_pc(basepath, pc_version):
     cli_dir = root / "cli"
     try:
         logger.info("installing ParallelCluster packages...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{cli_dir}[awslambda]", "-t", tempdir])
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "jsonschema==4.17.3",
+                "urllib3<2",
+                f"{cli_dir}[awslambda]",
+                "-t",
+                tempdir,
+            ]
+        )
         # The following are provided by the lambda runtime
         shutil.rmtree(tempdir / "botocore")
         shutil.rmtree(tempdir / "boto3")


### PR DESCRIPTION
Use older versions of jsonschema and urllib3 for Lambda Layer

Pcluster API execution fails if using the latest version of the packages.

* jsonschema introduced breaking changes in 4.18.0 in July 2023. Therefore, we use version 4.17.3. https://github.com/aws/aws-cdk/issues/26300
* urllib released 2.0 in May 2023. Pcluster API has been released with urllib 1.x. Therefore, we use version 1.x.

The root cause of both issues are because Lambda Function environment has older boto3/botocore versions than latest released versions on PyPi.
Specifically, when we prepare lambda layers, the dependencies are installed according to new boto3/botocore versions. When running the Lambda function, the older boto3/botocore are not compatible with the dependencies we provide in Lambda layers.

Signed-off-by: Hanwen <hanwenli@amazon.com>
### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
