### PR TITLE
[Policies] Add optional prefix to the name of IAM managed policies, if parameter IAMRoleAndPolicyPrefix is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ CHANGELOG
 - Make `InstanceType` an optional configuration parameter when configuring `CapacityReservationTarget/CapacityReservationId` in the compute resource.
 - Add `Scheduling/ScalingStrategy` parameter to control job-level scaling strategy for node to be resumed by Slurm.
   Possible values are `all-or-nothing`, `greedy-all-or-nothing`, `best-effort`, with `all-or-nothing` being the default.
+- Add possibility to specify a prefix for IAM roles and policies created by ParallelCluster API.
+- Add possibility to specify a permissions boundary to be applied for IAM roles and policies created by ParallelCluster API.
 
 **CHANGES**
 - Changed cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.
@@ -34,6 +36,7 @@ CHANGELOG
 - Add support for Python 3.10 in aws-parallelcluster-batch-cli.
 - Remove `all_or_nothing_batch` resume configuration parameter, in favor of the new `scaling_strategy` parameter
   that can be set using `Scheduling/ScalingStrategy` cluster configuration.
+- The optional permissions boundary for the ParallelCluster API is now applied to every IAM role created by the API infrastructure.
 
 **BUG FIXES**
 - Fix inconsistent configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -114,10 +114,16 @@ Conditions:
 Resources:
   ### IAM POLICIES
 
+  # Every policy name comes with a suffix derived from the Stack ID to avoid name collisions.
+  # Given a stack id arn:aws:cloudformation:REGION:ACCOUNT:stack/STACK_NAME/8131d980-7fb5-11ee-9589-0a6424944f95,
+  # the resulting StackIdSuffix will be 8131d980.
   DefaultParallelClusterIamAdminPolicy:
     Type: AWS::IAM::ManagedPolicy
     Condition: EnableIamPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}DefaultParallelClusterIamAdminPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Roles:
         - !Ref ParallelClusterLambdaRole
       PolicyDocument:
@@ -221,6 +227,9 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Condition: EnableBatchAccessCondition
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterClusterPolicyBatch-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -330,6 +339,9 @@ Resources:
   ParallelClusterClusterPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterClusterPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -615,6 +627,9 @@ Resources:
   ParallelClusterBuildImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterBuildImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster build-image command without IAM permission
       PolicyDocument:
         Version: '2012-10-17'
@@ -732,6 +747,9 @@ Resources:
   ParallelClusterDeleteImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterDeleteImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster delete-image command without IAM permission
       PolicyDocument:
         Version: '2012-10-17'
@@ -817,6 +835,9 @@ Resources:
   ParallelClusterListImagesManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterListImagesManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster list-images command
       PolicyDocument:
         Version: '2012-10-17'
@@ -836,6 +857,9 @@ Resources:
   ParallelClusterDescribeImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterDescribeImageManagedPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Managed policy to execute pcluster describe-image command
       PolicyDocument:
         Version: '2012-10-17'
@@ -857,6 +881,9 @@ Resources:
   ParallelClusterLogRetrievalPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterLogRetrievalPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Description: Policies needed to retrieve cluster and images logs
       PolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
Cherry-pick from https://github.com/aws/aws-parallelcluster/pull/5829

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
