### PR TITLE
Add wait time after scaling up/down operations to ensure logs are uploaded to CW

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
+import time
 from itertools import chain
 from typing import Union
 
@@ -519,6 +520,8 @@ def _assert_cluster_update_scaling(
     ec2_capacity_time_series, compute_nodes_time_series, timestamps = _monitor_cluster_update(
         cluster, updated_cluster_config, scheduler_commands, region, max_monitoring_time
     )
+
+    time.sleep(300)  # Time to upload logs to CW before deleting cluster in case of assertion failure
 
     _check_scaling_results(
         ec2_capacity_time_series,


### PR DESCRIPTION
### Description of changes
* When scaling up or down, we run assertions on the scaling metrics after a fixed amount of time
* If any of the assertions fail, the test fails and the cluster is deleted as part of the test teardown.
* The CW logs are preserved but they may not have captured some relevant info about the compute nodes that were launched e.g. nodes with bootstrap errors.
* The changes in this PR add a wait time before we run assertions on the collected scaling metrics to ensure we can review logs linked to the assertions in case of a failure

### Tests
* Ran test with a manually injected assertion failure to ensure we receive logs that are at least up to the timestamp of the latest scaling metric used in the assertion

### References
* N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
