### PR TITLE
[Test] Make StarCCM+ and OpenFOAM tests executable on all OSes and set tolerance to 3%

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/starccm.yaml
+++ b/tests/integration-tests/configs/starccm.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -19,7 +19,7 @@ def perf_test_difference(perf_test_result, number_of_nodes):
 
 
 def openfoam_installed(headnode):
-    cmd = '[ -d "/shared/ec2-user/SubspaceBenchmarks" ]'
+    cmd = '[ -d "/shared/SubspaceBenchmarks" ]'
     try:
         headnode.run_remote_command(cmd)
         return True
@@ -53,7 +53,7 @@ def test_openfoam(
         )
     logging.info("OpenFOAM Installed")
     performance_degradation = {}
-    subspace_benchmarks_dir = "/shared/ec2-user/SubspaceBenchmarks"
+    subspace_benchmarks_dir = "/shared/SubspaceBenchmarks"
     for node in number_of_nodes:
         logging.info(f"Submitting OpenFOAM job with {node} nodes")
         remote_command_executor.run_remote_command(

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -9,7 +9,7 @@ OPENFOAM_JOB_TIMEOUT = 5400  # Takes long time because during the first time, it
 # builds and installs many things
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {8: 742, 16: 376, 32: 185}
-PERF_TEST_DIFFERENCE_TOLERANCE = 5
+PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
 
 def perf_test_difference(perf_test_result, number_of_nodes):

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.install.sh
@@ -2,15 +2,11 @@
 #the script installs OpenFOAM in a shared folder that is shared with all the cluster nodes
 set -ex
 
-TARGET_USER=$(whoami)
-
 SHARED_DIR="/shared"
-TARGET_USER_DIR="${SHARED_DIR}/${TARGET_USER}"
 
-SUBSPACE_BENCHMARKS_PACKAGE_ZIP="${TARGET_USER_DIR}/SubspaceBenchmarks.tar"
+SUBSPACE_BENCHMARKS_PACKAGE_ZIP="${SHARED_DIR}/SubspaceBenchmarks.tar"
 
-mkdir -p "${TARGET_USER_DIR}"
-cd "${TARGET_USER_DIR}"
+cd "${SHARED_DIR}"
 
 aws s3 cp s3://performance-tests-resources-for-parallelcluster/openfoam/SubspaceBenchmarks.tar ${SUBSPACE_BENCHMARKS_PACKAGE_ZIP}
 tar -xf SubspaceBenchmarks.tar

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.results.sh
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/openfoam.results.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-OUTPUT=/shared/ec2-user/SubspaceBenchmarks/results/openfoam/openfoam.csv
+OUTPUT="/shared/SubspaceBenchmarks/results/openfoam/openfoam.csv"
 
 cut -d, -f5 $OUTPUT

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -28,7 +28,7 @@ def perf_test_difference(perf_test_result, number_of_nodes):
 
 
 def starccm_installed(headnode):
-    cmd = "/shared/ec2-user/STAR-CCM+/18.02.008/STAR-CCM+18.02.008/star/bin/starccm+ --version"
+    cmd = "/shared/STAR-CCM+/18.02.008/STAR-CCM+18.02.008/star/bin/starccm+ --version"
     try:
         headnode.run_remote_command(cmd)
         return True

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -11,7 +11,7 @@ STARCCM_JOB_TIMEOUT = 600
 STARCCM_LICENCE_SECRET = "starccm-license-secret"
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {8: 60.0233, 16: 31.3820, 32: 17.2294}
-PERF_TEST_DIFFERENCE_TOLERANCE = 5
+PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
 
 def get_starccm_secrets(region_name):

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
@@ -2,19 +2,16 @@
 #the script installs StarCCM+ in a shared folder that is shared with all the cluster nodes
 set -ex
 
-TARGET_USER=$(whoami)
-
 SHARED_DIR="/shared" # /shared or whatever you named the SharedStorage MountDir
-TARGET_USER_DIR="${SHARED_DIR}/${TARGET_USER}"
 
-STARCCM_PACKAGE="${TARGET_USER_DIR}/STAR-CCM+18.02.008_01_linux-x86_64.tar.gz"
-SIM_FILE="${TARGET_USER_DIR}/lemans_poly_17m.amg@00500.sim"
+STARCCM_PACKAGE="${SHARED_DIR}/STAR-CCM+18.02.008_01_linux-x86_64.tar.gz"
+SIM_FILE="${SHARED_DIR}/lemans_poly_17m.amg@00500.sim"
 
 mkdir -p "${TARGET_USER_DIR}"
 
 OLD_PWD=$(pwd)
 
-cd "${TARGET_USER_DIR}"
+cd "${SHARED_DIR}"
 
 aws s3 cp s3://performance-tests-resources-for-parallelcluster/starccm/STAR-CCM+18.02.008_01_linux-x86_64.tar.gz ${STARCCM_PACKAGE}
 tar -xf $(basename ${STARCCM_PACKAGE})
@@ -22,8 +19,8 @@ tar -xf $(basename ${STARCCM_PACKAGE})
 aws s3 cp s3://performance-tests-resources-for-parallelcluster/starccm/lemans_poly_17m.amg@00500.sim ${SIM_FILE}
 
 cd starccm+_18.02.008
-# (executed by the below printf) During the installation, you need to type: <ENTER>, Y, N, /shared/${TARGET_USER}/STAR-CCM+, Y, <ENTER>, <ENTER>
-printf "\nY\nN\n${TARGET_USER_DIR}/STAR-CCM+\nY\n\n\n" | ./STAR-CCM+18.02.008_01_linux-x86_64-2.17_gnu11.2.sh
+# (executed by the below printf) During the installation, you need to type: <ENTER>, Y, N, /shared/${SHARED_DIR}/STAR-CCM+, Y, <ENTER>, <ENTER>
+printf "\nY\nN\n${SHARED_DIR}/STAR-CCM+\nY\n\n\n" | ./STAR-CCM+18.02.008_01_linux-x86_64-2.17_gnu11.2.sh
 
 rm -rf ${STARCCM_PACKAGE}
 

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.slurm.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.slurm.sh
@@ -22,10 +22,9 @@ export FI_EFA_FORK_SAFE=1
 export I_MPI_HYDRA_BOOTSTRAP="slurm"
 
 SHARED_DIR="/shared"
-TARGET_USER=$(whoami)
 
-STARCCM="${SHARED_DIR}/${TARGET_USER}/STAR-CCM+/18.02.008/STAR-CCM+18.02.008/star/bin/starccm+"
-SIM_FILE="${SHARED_DIR}/${TARGET_USER}/lemans_poly_17m.amg@00500.sim"
+STARCCM="${SHARED_DIR}/STAR-CCM+/18.02.008/STAR-CCM+18.02.008/star/bin/starccm+"
+SIM_FILE="${SHARED_DIR}/lemans_poly_17m.amg@00500.sim"
 
 podkey="$1"
 licpath="$2"


### PR DESCRIPTION
Cherry-pick from https://github.com/aws/aws-parallelcluster/pull/5866

Needed to resolve some conflicts because release-3.8 runs StarCCM+ v16 whereas in develop we have StarCCM+ v18.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
