### PR TITLE
[Test] Upgrade Fabtests to version 1.19.0.

### DIFF
--- a/tests/integration-tests/tests/efa/test_fabric.py
+++ b/tests/integration-tests/tests/efa/test_fabric.py
@@ -49,8 +49,8 @@ def test_fabric(
 
     fabtests_report = _execute_fabtests(remote_command_executor, test_datadir, instance)
 
-    num_tests = int(fabtests_report.get("testsuites", {}).get("testsuite", {}).get("@tests", None))
-    num_failures = int(fabtests_report.get("testsuites", {}).get("testsuite", {}).get("@failures", None))
+    num_tests = int(fabtests_report.get("testsuites", {}).get("@tests", None))
+    num_failures = int(fabtests_report.get("testsuites", {}).get("@failures", None))
 
     assert_that(num_tests, description="Cannot read number of tests from Fabtests report").is_not_none()
     assert_that(num_failures, description="Cannot read number of failures from Fabtests report").is_not_none()
@@ -97,4 +97,5 @@ def _execute_fabtests(remote_command_executor, test_datadir, instance):
 
     logging.info("Retrieving Fabtests report")
     report_content = read_remote_file(remote_command_executor, fabtests_report_file)
+    logging.info("Parsing Fabtests report")
     return xmltodict.parse(report_content)

--- a/tests/integration-tests/tests/efa/test_fabric.py
+++ b/tests/integration-tests/tests/efa/test_fabric.py
@@ -51,14 +51,17 @@ def test_fabric(
 
     num_tests = int(fabtests_report.get("testsuites", {}).get("@tests", None))
     num_failures = int(fabtests_report.get("testsuites", {}).get("@failures", None))
+    num_errors = int(fabtests_report.get("testsuites", {}).get("@errors", None))
 
     assert_that(num_tests, description="Cannot read number of tests from Fabtests report").is_not_none()
     assert_that(num_failures, description="Cannot read number of failures from Fabtests report").is_not_none()
+    assert_that(num_errors, description="Cannot read number of errors from Fabtests report").is_not_none()
 
-    if num_failures > 0:
+    if num_failures + num_errors > 0:
         logging.info(f"Fabtests report:\n{fabtests_report}")
 
     assert_that(num_failures, description=f"{num_failures}/{num_tests} libfabric tests are failing").is_equal_to(0)
+    assert_that(num_errors, description=f"{num_errors}/{num_tests} libfabric tests got errors").is_equal_to(0)
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
@@ -8,9 +8,7 @@ set -ex
 FABTESTS_DIR="$1"
 
 FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"
-# TODO We should target the release 1.16.0 instead of a commit.
-# We must fix this once that version will be released.
-FABTESTS_COMMIT="840a4a93ccf576b950dfd15d979cbf5f06e9c64b"
+FABTESTS_VERSION="1.19.0"
 FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
 CUDA_DIR="/usr/local/cuda"
@@ -19,12 +17,9 @@ echo "[INFO] Installing Fabtests in $FABTESTS_DIR"
 rm -rf $FABTESTS_DIR
 mkdir -p $FABTESTS_SOURCES_DIR
 cd $FABTESTS_SOURCES_DIR
-git clone $FABTESTS_REPO
-cd libfabric
-git reset --hard $FABTESTS_COMMIT
-cd fabtests
+git clone --depth 1 --branch v$FABTESTS_VERSION $FABTESTS_REPO
+cd libfabric/fabtests
 ./autogen.sh
 ./configure --with-libfabric=$LIBFABRIC_DIR --with-cuda=$CUDA_DIR --prefix=$FABTESTS_DIR && make -j 32 && make install
 python3 -m pip install -r $FABTESTS_SOURCES_DIR/libfabric/fabtests/pytest/requirements.txt
-python3 -m pip install pyyaml # TODO This is required but it is missing in the above requirements.txt
 echo "[INFO] Fabtests installed in $FABTESTS_DIR"


### PR DESCRIPTION
### Description of changes
1. Upgrade Fabtests to version 1.19.0.
2. Improved the test by making assertion also on test errors not only test failures.

### Tests
1. Manually installed fabtests 1.9.0 on a g4dn.8xlarge efa-enabled cluster
1. Succeeded `test_fabric`on p4d.24xl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
