### PR TITLE
[Test] Remove Ubuntu 22.04 from OpenFOAM performance tests

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
+          oss: ["alinux2", "ubuntu2004", "rhel8", "centos7"] # The OpenFOAM version used by the benchmark suite does not support Ubuntu 22.04.
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
Remove Ubuntu 22.04 from OpenFOAM performance tests as it's not supported by the adopted version of OpenFOAM.

### Tests
1. Run OpenFOAM tests on all OSes and it failed on Ubuntu 22.04 saying that it's not supproted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
