### PR TITLE
[release-3.7] Inject SSMManagedInstanceCore policy as an additional IAM policy

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -623,7 +623,12 @@ def _inject_additional_iam_policies(node_config, additional_iam_policies):
             if policy not in node_config["Iam"]["AdditionalIamPolicies"]:
                 node_config["Iam"]["AdditionalIamPolicies"] += copy.deepcopy(policy)
     else:
-        dict_add_nested_key(node_config, additional_iam_policies, ("Iam", "AdditionalIamPolicies"))
+        # InstanceProfile, InstanceRole or AdditionalIamPolicies can not be configured together.
+        if not (
+            dict_has_nested_key(node_config, ("Iam", "InstanceRole"))
+            or dict_has_nested_key(node_config, ("Iam", "InstanceProfile"))
+        ):
+            dict_add_nested_key(node_config, additional_iam_policies, ("Iam", "AdditionalIamPolicies"))
 
 
 def _inject_additional_iam_policies_for_nodes(

--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -8,7 +8,16 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from enum import Enum
 
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm"]
 
 OSU_BENCHMARK_VERSION = "5.7.1"
+
+
+class NodeType(Enum):
+    """Categories of nodes."""
+
+    HEAD_NODE = "HeadNode"
+    LOGIN_NODES = "LoginNodes"
+    COMPUTE_NODES = "ComputeNodes"


### PR DESCRIPTION
### Description of changes
* Inject SSMManagedInstanceCore policy as an additional IAM policy
* Avoid injecting AdditionalIAMPolicies if using InstanceRole or InstanceProfile

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
