### PR TITLE
[release-3.7] Fix policy addition in cases where a policy already exists #5895

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -80,6 +80,8 @@ class CfnVpcStack(CfnStack):
         self.az_override = None
         self.__public_subnet_ids = None
         self.__private_subnet_ids = None
+        if "CAPABILITY_NAMED_IAM" not in self.capabilities:
+            self.capabilities.append("CAPABILITY_NAMED_IAM")
 
     def set_az_override(self, az_override):
         """Sets the az_id to override the default AZ used to pick the subnets."""

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -621,7 +621,7 @@ def _inject_additional_iam_policies(node_config, additional_iam_policies):
     if dict_has_nested_key(node_config, ("Iam", "AdditionalIamPolicies")):
         for policy in additional_iam_policies:
             if policy not in node_config["Iam"]["AdditionalIamPolicies"]:
-                node_config["Iam"]["AdditionalIamPolicies"] += copy.deepcopy(policy)
+                node_config["Iam"]["AdditionalIamPolicies"] += [copy.deepcopy(policy)]
     else:
         # InstanceProfile, InstanceRole or AdditionalIamPolicies can not be configured together.
         if not (
@@ -635,21 +635,21 @@ def _inject_additional_iam_policies_for_nodes(
     config_content, scheduler: str, node_types: List[NodeType], policies: List[Dict]
 ):
     if NodeType.HEAD_NODE in node_types:
-        _inject_additional_iam_policies(config_content["HeadNode"], copy.deepcopy(policies))
+        _inject_additional_iam_policies(config_content["HeadNode"], policies)
     if (
         scheduler == "slurm"
         and dict_has_nested_key(config_content, ("Scheduling", "SlurmQueues"))
         and NodeType.COMPUTE_NODES in node_types
     ):
         for queue in config_content["Scheduling"]["SlurmQueues"]:
-            _inject_additional_iam_policies(queue, copy.deepcopy(policies))
+            _inject_additional_iam_policies(queue, policies)
     if (
         scheduler == "slurm"
         and dict_has_nested_key(config_content, ("LoginNodes", "Pools"))
         and NodeType.LOGIN_NODES in node_types
     ):
         for pool in config_content["LoginNodes"]["Pools"]:
-            _inject_additional_iam_policies(pool, copy.deepcopy(policies))
+            _inject_additional_iam_policies(pool, policies)
 
 
 def inject_additional_config_settings(cluster_config, request, region, benchmarks=None):  # noqa C901

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -668,7 +668,8 @@ def _create_permission_boundary(permission_boundary_name):
                     ],
                     "Effect": "Allow",
                     "Resource": [
-                        {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${CustomIamNamePrefix}*"}
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${CustomIamNamePrefix}*"},
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"},
                     ],
                 },
             ],


### PR DESCRIPTION
### Description of changes
* Fix policy addition in cases where a policy already exists
* Add the SSM Managed Instance Policy to the networking bastion instance used in tests
* Add the SSM Managed Instance Core Policy to the permission boundary when testing IAM resource prefixes
* Attach a managed SSM Instance policy to the instance used when running the EBS snapshot factory.

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
