### PR TITLE
[develop] Move test_awsbatch_defaults into different region

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -403,13 +403,9 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-      - regions: ["ap-northeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
   test_awsbatch.py::test_awsbatch_defaults:
     dimensions:
-      - regions: ["cn-north-1"]
+      - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]


### PR DESCRIPTION
### Description of changes
* Move test_awsbatch_defaults into different region, from cn-north-1 to sa-east-1. This is needed to be able to leverage the "Default Host Management Configuration" (https://docs.aws.amazon.com/systems-manager/latest/userguide/managed-instances-default-host-management.html) for the compute environment instances launched by AWS Batch

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
