### PR TITLE
[release-3.8] Use older RHEL 8.8 AMI for test_build_image

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -43,8 +43,11 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
         "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*-server-*",
         "owners": ["099720109477"],
     },
-    # We need to specify the minor because the most recently created RHEL8 AMI is currently 8.4
-    "rhel8": {"name": "RHEL-8.8*_HVM*", "owners": ["309956199498", "841258680906", "219670896067"]},
+    # FIXME: unpin once Lustre client is available for RHEL8.9
+    # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
+    # the kernel released in 20231127 RHEL 8.8 AMI
+    "rhel8": {"name": "RHEL-8.8*_HVM-202309*", "owners": ["309956199498", "841258680906", "219670896067"]},
+    # FIXME: unpin once Lustre client is available for Rocky 8.9
     "rocky8": {"name": "Rocky-8-EC2-Base-8.8*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
@@ -54,7 +57,11 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "centos7": {"name": "FPGA Developer AMI*", "owners": ["679593333241"]},
     "ubuntu2004": {"name": "Deep Learning Base GPU AMI (Ubuntu 20.04)*", "owners": ["amazon"]},
     # Simple redhat8 to be able to build in remarkable test
-    "rhel8": {"name": "RHEL-8.8*_HVM*", "owners": ["309956199498", "841258680906", "219670896067"]},
+    # FIXME: unpin once Lustre client is available for RHEL8.9
+    # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
+    # the kernel released in 20231127 RHEL 8.8 AMI
+    "rhel8": {"name": "RHEL-8.8*_HVM-202309*", "owners": ["309956199498", "841258680906", "219670896067"]},
+    # FIXME: unpin once Lustre client is available for Rocky 8.9
     "rocky8": {"name": "Rocky-8-EC2-Base-8.8*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 


### PR DESCRIPTION
### Description of changes
The latest available RHEL 8.8 AMI (20231127) uses a kernel for which there's no `kernel-devel` package available on the RHEL repos.
Pin the base AMI for test_build_image to the previous one.

### Tests
* Successfully ran the `install_packages` kitchen test.

### References
* https://github.com/aws/aws-parallelcluster/pull/5902

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
