### PR TITLE
[Release 3.8] Prevent updates to clusters that include changes to /home

### DIFF
--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1932,3 +1932,68 @@ def test_compute_and_login_nodes_stop_policy(
     if not expected_update_allowed:
         assert_that(update_policy.fail_reason(change, patch)).is_equal_to(expected_fail_reason)
         assert_that(update_policy.action_needed(change, patch)).is_equal_to(expected_action_needed)
+
+
+@pytest.mark.parametrize(
+    "old_storage_value, new_storage_value, expected_condition, expected_fail_reason, expected_action_needed",
+    [
+        pytest.param(
+            "/home",
+            "dummy",
+            False,
+            "The /home directory cannot be changed during an update",
+            "Please revert any changes to the /home mount",
+        ),
+        pytest.param(
+            "home",
+            "dummy",
+            False,
+            "The /home directory cannot be changed during an update",
+            "Please revert any changes to the /home mount",
+        ),
+        pytest.param(
+            "dummy",
+            "home",
+            False,
+            "The /home directory cannot be changed during an update",
+            "Please revert any changes to the /home mount",
+        ),
+        pytest.param(
+            "dummy",
+            "/home",
+            False,
+            "The /home directory cannot be changed during an update",
+            "Please revert any changes to the /home mount",
+        ),
+        pytest.param(
+            "dummy",
+            "not_home",
+            True,
+            "All login and compute nodes must be stopped",
+            "Stop the compute fleet with the pcluster update-compute-fleet command. "
+            "Stop the login nodes by setting Count parameter to 0 "
+            "and update the cluster with the pcluster update-cluster command",
+        ),
+    ],
+)
+def test_home_change_policy(
+    mocker, old_storage_value, new_storage_value, expected_condition, expected_fail_reason, expected_action_needed
+):
+    cluster = dummy_cluster()
+    mocker.patch.object(cluster, "has_running_capacity", return_value=False)
+    patch_mock = mocker.MagicMock()
+    change_mock = mocker.MagicMock()
+    change_mock.new_value = {"MountDir": new_storage_value}
+    change_mock.old_value = {"MountDir": old_storage_value}
+    change_mock.key = "SharedStorage"
+
+    patch_mock.cluster = cluster
+    assert_that(UpdatePolicy.SHARED_STORAGE_UPDATE_POLICY.condition_checker(change_mock, patch_mock)).is_equal_to(
+        expected_condition
+    )
+    assert_that(UpdatePolicy.SHARED_STORAGE_UPDATE_POLICY.fail_reason(change_mock, patch_mock)).is_equal_to(
+        expected_fail_reason
+    )
+    assert_that(UpdatePolicy.SHARED_STORAGE_UPDATE_POLICY.action_needed(change_mock, patch_mock)).is_equal_to(
+        expected_action_needed
+    )


### PR DESCRIPTION
Currently, PCluster does not support updates to a cluster's home directory.

### Tests
* Tested updates to clusters that have existing /home mounts in `SharedStorage` and those that do not have /home mounts

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
