### PR TITLE
[Performance Tests] Add coverage for all OSes supported by StarCCM+ and OpenFOAM with respective baselines.

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "ubuntu2004", "rhel8", "centos7"] # The OpenFOAM version used by the benchmark suite does not support Ubuntu 22.04.
+          oss: ["alinux2", "ubuntu2004", "centos7"] # Ubuntu22.04, RHEL8 and Rocky8 are not supported
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/starccm.yaml
+++ b/tests/integration-tests/configs/starccm.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "rhel8", "centos7"]
+          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "centos7", "rhel8", "rocky8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -10,7 +10,14 @@ STARCCM_INSTALLATION_TIMEOUT = 1800
 STARCCM_JOB_TIMEOUT = 600
 STARCCM_LICENCE_SECRET = "starccm-license-secret"
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
-BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {8: 64.475, 16: 33.1723, 32: 17.8983}
+BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {
+    "alinux2": {8: 64.475, 16: 33.173, 32: 17.899},  # v3.1.3
+    "ubuntu2204": {8: 75.502, 16: 36.353, 32: 19.688},  # v3.7.0
+    "ubuntu2004": {8: 67.384, 16: 36.434, 32: 19.449},  # v3.1.3
+    "centos7": {8: 67.838, 16: 36.568, 32: 20.935},  # v3.1.3
+    "rhel8": {8: 66.494, 16: 36.154, 32: 20.347},  # v3.6.0
+    "rocky8": {8: 66.859, 16: 33.173, 32: 17.899},  # v3.8.0
+}
 PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
 
@@ -21,9 +28,8 @@ def get_starccm_secrets(region_name):
     return secrets["podkey"], secrets["licpath"]
 
 
-def perf_test_difference(perf_test_result, number_of_nodes):
-    baseline_result = BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS[number_of_nodes]
-    percentage_difference = 100 * (perf_test_result - baseline_result) / baseline_result
+def perf_test_difference(observed_value, baseline_value):
+    percentage_difference = 100 * (observed_value - baseline_value) / baseline_value
     return percentage_difference
 
 
@@ -51,8 +57,16 @@ def test_starccm(
     number_of_nodes,
     test_datadir,
     scheduler_commands_factory,
+    s3_bucket_factory,
 ):
-    cluster_config = pcluster_config_reader(number_of_nodes=max(number_of_nodes))
+    # Create S3 bucket for custom actions scripts
+    bucket_name = s3_bucket_factory()
+    s3 = boto3.client("s3")
+    s3.upload_file(str(test_datadir / "dependencies.install.sh"), bucket_name, "scripts/dependencies.install.sh")
+
+    cluster_config = pcluster_config_reader(
+        bucket_name=bucket_name, install_extra_deps=os in ["rhel8", "rocky8"], number_of_nodes=max(number_of_nodes)
+    )
     cluster = clusters_factory(cluster_config)
     logging.info("Cluster Created")
     remote_command_executor = RemoteCommandExecutor(cluster)
@@ -78,15 +92,18 @@ def test_starccm(
         perf_test_result = remote_command_executor.run_remote_script(
             (str(test_datadir / "starccm.results.sh")), args=[job_id], hide=False
         )
-        logging.info(f"The elapsed time for {node} nodes is {perf_test_result.stdout} seconds")
-        baseline_value = BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS[node]
-        percentage_difference = perf_test_difference(float(perf_test_result.stdout), node)
+        observed_value = float(perf_test_result.stdout)
+        logging.info(f"The elapsed time for {node} nodes is {observed_value} seconds")
+        baseline_value = BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS[os][node]
+        percentage_difference = perf_test_difference(observed_value, baseline_value)
         if percentage_difference < 0:
             outcome = "improvement"
+        elif percentage_difference <= PERF_TEST_DIFFERENCE_TOLERANCE:
+            outcome = "degradation (within tolerance)"
         else:
-            outcome = "degradation"
+            outcome = "degradation (above tolerance)"
         logging.info(
-            f"Nodes: {node}, Baseline: {baseline_value} seconds, Observed: {perf_test_result.stdout} seconds, "
+            f"Nodes: {node}, Baseline: {baseline_value} seconds, Observed: {observed_value} seconds, "
             f"Percentage difference: {percentage_difference}%, Outcome: {outcome}"
         )
         if percentage_difference > PERF_TEST_DIFFERENCE_TOLERANCE:

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/dependencies.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/dependencies.install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script installs the software stack required by StarCCM+
+set -ex
+
+sudo yum install -y libnsl

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -14,6 +14,14 @@ HeadNode:
       - BucketName: performance-tests-resources-for-parallelcluster
         KeyName: starccm/*
         EnableWriteAccess: false
+{% if install_extra_deps %}
+      - BucketName: {{ bucket_name }}
+        KeyName: scripts/dependencies.install.sh
+        EnableWriteAccess: false
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/scripts/dependencies.install.sh
+{% endif %}
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -35,6 +43,15 @@ Scheduling:
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+{% if install_extra_deps %}
+        S3Access:
+          - BucketName: {{ bucket_name }}
+            KeyName: scripts/dependencies.install.sh
+            EnableWriteAccess: false
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://{{ bucket_name }}/scripts/dependencies.install.sh
+{% endif %}
 SharedStorage:
   - MountDir: /shared
     Name: shared-fsx


### PR DESCRIPTION
### Description of changes
1. Add coverage for all OSes supported by StarCCM+ and OpenFOAM
2. Add baselines for every covered OSes.
3. Distinguish between acceptable and unacceptable degradation in test logs.

### Tests
1. Perf tests executed in personal account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
