### PR TITLE
[release-3.8][Isolated Region] Updating the assertion of AZ returned for us-isob-east-1

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -1,5 +1,9 @@
 {%- import 'common.jinja2' as common with context -%}
+{% if REGIONS  %}
+{%- set REGIONS = [ REGIONS ] -%}
+{% else %}
 {%- set REGIONS = ["us-isob-east-1","us-iso-east-1"] -%}
+{% endif %}
 {%- set INSTANCES = ["c5.xlarge"] -%}
 {%- set OSS = ["alinux2"] -%}
 {%- set SCHEDULERS = ["slurm"] -%}

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -463,7 +463,7 @@ def assert_subnet_az_relations_from_config(
     # If caller does not expect same az, we expect more availability zones.
     elif region == "us-isob-east-1":
         # us-isob-east-1 provides 2 availability zones.
-        assert_that(len(set(cluster_avail_zones))).is_equal_to(2)
+        assert_that(len(set(cluster_avail_zones))).is_equal_to(3)
     else:
         # For other regions, we impose a strong check to make sure each subnet is in a different availability zone.
         assert_that(len(set(cluster_avail_zones))).is_equal_to(len(cluster_avail_zones))


### PR DESCRIPTION
### Description of changes
* Updating the assertion of AZ returned for us-isob-east-1
* Overriding the REGIONS set in isolated_regions.yaml using  parameter `--region` if given in Integration tests

### Tests
* Local test with isolated_region.yaml 
* ONGOING test with SSM Automation

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
