### PR TITLE
Add automated scaling stress test with upload of metrics to CW

### DIFF
--- a/tests/integration-tests/benchmarks/common/metrics_reporter.py
+++ b/tests/integration-tests/benchmarks/common/metrics_reporter.py
@@ -158,18 +158,20 @@ def produce_benchmark_metrics_report(
     logging.info(widget_metric)
     cw_client = boto3.client("cloudwatch", region_name=region)
     response = cw_client.get_metric_widget_image(MetricWidget=widget_metric)
-    _write_results_to_outdir(request, response["MetricWidgetImage"])
+    _write_results_to_outdir(request, response["MetricWidgetImage"], image_name_prefix=f"{scaling_target}-nodes")
 
 
 def _to_datetime(timestamp):
     return datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
 
 
-def _write_results_to_outdir(request, image_bytes):
+def _write_results_to_outdir(request, image_bytes, image_name_prefix):
     out_dir = request.config.getoption("output_dir")
     os.makedirs("{out_dir}/benchmarks".format(out_dir=out_dir), exist_ok=True)
-    graph_dst = "{out_dir}/benchmarks/{test_name}.png".format(
-        out_dir=out_dir, test_name=os.path.basename(request.node.nodeid.replace("::", "-"))
+    graph_dst = "{out_dir}/benchmarks/{test_name}-{image_name_prefix}.png".format(
+        out_dir=out_dir,
+        test_name=os.path.basename(request.node.nodeid.replace("::", "-")),
+        image_name_prefix=image_name_prefix,
     )
     with open(graph_dst, "wb") as image:
         image.write(image_bytes)

--- a/tests/integration-tests/benchmarks/common/scaling_metrics_source.jinja
+++ b/tests/integration-tests/benchmarks/common/scaling_metrics_source.jinja
@@ -1,0 +1,49 @@
+{
+    "metrics": [
+        [ "ParallelCluster/ScalingStressTest", "ComputeNodesCount", "ClusterName", "{{ cluster_name }}" ],
+        [ "ParallelCluster/ScalingStressTest", "EC2NodesCount", "ClusterName", "{{ cluster_name }}" ],
+        [ "ParallelCluster/ScalingStressTest", "PendingJobsCount", "ClusterName", "{{ cluster_name }}", { "yAxis": "right" } ],
+        [ "ParallelCluster/ScalingStressTest", "RunningJobsCount", "ClusterName", "{{ cluster_name }}", { "yAxis": "right" } ]
+    ],
+    "view": "timeSeries",
+    "stacked": false,
+    "stat": "Average",
+    "period": 60,
+    "title": "{{ title }}",
+    "width": 1400,
+    "height": 700,
+    "start": "{{ graph_start_time }}",
+    "end": "{{ graph_end_time }}",
+    "annotations": {
+        "horizontal": [
+            {
+                "label": "Scaling Target",
+                "value": {{ scaling_target }}
+            }
+        ],
+        "vertical": [
+            {
+                "label": "Start Time",
+                "value": "{{ start_time }}"
+            },
+            {
+                "label": "End Time",
+                "value": "{{ end_time }}"
+            },
+            {% if scaling_target_time %}
+            {
+                "label": "Full Capacity ({{ scaling_target }})",
+                "value": "{{ scaling_target_time }}"
+            }
+            {% endif %}
+        ]
+    },
+    "yAxis": {
+        "left": {
+            "label": "NodeCount"
+        },
+        "right": {
+            "label": "JobCount"
+        }
+    }
+}

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -302,10 +302,10 @@ def vpc_stack(vpc_stacks_shared, region, az_id):
 
 def _is_scaling_test(tests_config):
     logging.info(f"Checking any scaling stress tests in {tests_config}")
-    return tests_config.get(
-        "test-suites", {}).get(
-        "performance_tests", {}).get(
-        "test_scaling.py::test_scaling_stress_test"
+    return (
+        tests_config.get("test-suites", {})
+        .get("performance_tests", {})
+        .get("test_scaling.py::test_scaling_stress_test")
     )
 
 
@@ -346,7 +346,9 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
             subnets.append(
                 SubnetConfig(
                     name=subnet_name(visibility="Private", az_id=az_id),
-                    cidr=CIDR_FOR_PRIVATE_SUBNETS_SCALING[index] if is_scaling_test else CIDR_FOR_PRIVATE_SUBNETS[index],
+                    cidr=CIDR_FOR_PRIVATE_SUBNETS_SCALING[index]
+                    if is_scaling_test
+                    else CIDR_FOR_PRIVATE_SUBNETS[index],
                     map_public_ip_on_launch=False,
                     has_nat_gateway=False,
                     availability_zone=az_name,

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -119,6 +119,18 @@ CIDR_FOR_PRIVATE_SUBNETS = [
     "192.168.144.0/21",
     "192.168.152.0/21",
 ]
+CIDR_FOR_PUBLIC_SUBNETS_SCALING = [
+    "192.168.0.0/20",
+    "192.168.16.0/20",
+    "192.168.32.0/20",
+    "192.168.48.0/20",
+]
+CIDR_FOR_PRIVATE_SUBNETS_SCALING = [
+    "192.168.64.0/20",
+    "192.168.80.0/20",
+    "192.168.96.0/20",
+    "192.168.112.0/20",
+]
 CIDR_FOR_CUSTOM_SUBNETS = [
     "192.168.160.0/21",
     "192.168.168.0/21",
@@ -288,6 +300,15 @@ def vpc_stack(vpc_stacks_shared, region, az_id):
     return local_vpc_stack
 
 
+def _is_scaling_test(tests_config):
+    logging.info(f"Checking any scaling stress tests in {tests_config}")
+    return tests_config.get(
+        "test-suites", {}).get(
+        "performance_tests", {}).get(
+        "test_scaling.py::test_scaling_stress_test"
+    )
+
+
 @xdist_session_fixture(autouse=True)
 def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
     """
@@ -297,6 +318,7 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
     """
 
     regions = request.config.getoption("regions") or get_all_regions(request.config.getoption("tests_config"))
+    is_scaling_test = _is_scaling_test(request.config.getoption("tests_config"))
     credential = request.config.getoption("credential")
 
     vpc_stacks_dict = {}
@@ -324,7 +346,7 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
             subnets.append(
                 SubnetConfig(
                     name=subnet_name(visibility="Private", az_id=az_id),
-                    cidr=CIDR_FOR_PRIVATE_SUBNETS[index],
+                    cidr=CIDR_FOR_PRIVATE_SUBNETS_SCALING[index] if is_scaling_test else CIDR_FOR_PRIVATE_SUBNETS[index],
                     map_public_ip_on_launch=False,
                     has_nat_gateway=False,
                     availability_zone=az_name,

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -17,7 +17,7 @@ from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutor
 from retrying import RetryError, retry
 from time_utils import minutes, seconds
-from utils import get_cfn_resources, get_compute_nodes_count, get_compute_nodes_instance_ids
+from utils import get_cfn_resources, get_compute_instances_count, get_compute_nodes_instance_ids
 
 from tests.common.scaling_common import get_compute_nodes_allocation
 
@@ -120,7 +120,7 @@ def submit_job_and_assert_logs(
 
 
 def assert_no_node_in_ec2(region, stack_name, instance_types=None):
-    assert_that(get_compute_nodes_count(stack_name, region, instance_types)).is_equal_to(0)
+    assert_that(get_compute_instances_count(stack_name, region, instance_types)).is_equal_to(0)
 
 
 def assert_scaling_worked(

--- a/tests/integration-tests/tests/common/scaling/collect_metrics_on_headnode.sh
+++ b/tests/integration-tests/tests/common/scaling/collect_metrics_on_headnode.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+set -ex
+
+NODE_COUNT=$(sudo -i sinfo --Node --noheader --responding -o '%t' | grep -v '[*#~%]' | awk '{print $1}' | wc -l)
+PENDING_JOBS_COUNT=$(squeue -h -t configuring,pending | wc -l)
+RUNNING_JOBS_COUNT=$(squeue -h -t running | wc -l)
+
+cat << EOF > "scaling_metrics.json"
+{"NodeCount": "$NODE_COUNT", "PendingJobsCount": "$PENDING_JOBS_COUNT", "RunningJobsCount": "$RUNNING_JOBS_COUNT"}
+EOF

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -26,8 +26,9 @@ SCALING_COMMON_DATADIR = pathlib.Path(__file__).parent / "scaling"
 def scaling_target_condition(
     ec2_capacity_time_series,
     compute_nodes_time_series,
-    target_cluster_size, use_ec2_limit=True,  # Stop monitoring after all EC2 instances have been launched
-    use_compute_nodes_limit=True  # Stop monitoring after all nodes have joined the cluster
+    target_cluster_size,
+    use_ec2_limit=True,  # Stop monitoring after all EC2 instances have been launched
+    use_compute_nodes_limit=True,  # Stop monitoring after all nodes have joined the cluster
 ):
     return (
         (use_ec2_limit and ec2_capacity_time_series[-1] != target_cluster_size)

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -8,6 +8,8 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
+import json
 import logging
 import pathlib
 import time
@@ -16,12 +18,108 @@ import boto3
 from remote_command_executor import RemoteCommandExecutor
 from retrying import RetryError, retry
 from time_utils import seconds
-from utils import get_compute_nodes_count
+from utils import CWMetric, get_compute_instances_count, publish_metrics_to_cloudwatch
 
 SCALING_COMMON_DATADIR = pathlib.Path(__file__).parent / "scaling"
 
 
-def get_compute_nodes_allocation(scheduler_commands, region, stack_name, max_monitoring_time):
+def scaling_target_condition(ec2_capacity_time_series, compute_nodes_time_series, target_cluster_size):
+    return (
+        ec2_capacity_time_series[-1] != target_cluster_size
+        or compute_nodes_time_series[-1] != target_cluster_size
+        or max(ec2_capacity_time_series) == 0
+        or max(compute_nodes_time_series) == 0
+    )
+
+
+def get_scaling_metrics(
+    remote_command_executor: RemoteCommandExecutor,
+    region,
+    cluster_name,
+    max_monitoring_time,
+    target_cluster_size=0,
+    publish_metrics=False,
+):
+    ec2_capacity_time_series = []
+    compute_nodes_time_series = []
+    timestamps = []
+    cw_client = boto3.client("cloudwatch", region_name=region)
+
+    @retry(
+        # Retry until EC2 and Scheduler capacities scale to specified target
+        retry_on_result=lambda _: scaling_target_condition(
+            ec2_capacity_time_series, compute_nodes_time_series, target_cluster_size
+        ),
+        wait_fixed=seconds(20),
+        stop_max_delay=max_monitoring_time,
+    )
+    def _collect_metrics():
+        remote_command_executor.run_remote_script(
+            script_file=str(SCALING_COMMON_DATADIR / "collect_metrics_on_headnode.sh")
+        )
+        headnode_metrics = json.loads(
+            remote_command_executor.run_remote_command(command="cat $HOME/scaling_metrics.json").stdout
+        )
+        logging.info(f"Metrics from HeadNode: {headnode_metrics}")
+        compute_node_count = int(headnode_metrics.get("NodeCount"))
+        pending_jobs_count = int(headnode_metrics.get("PendingJobsCount"))
+        running_jobs_count = int(headnode_metrics.get("RunningJobsCount"))
+        ec2_capacity = get_compute_instances_count(cluster_name, region)
+        if publish_metrics:
+            # Use the cluster name as a dimension for each scaling metric
+            scaling_metrics = [
+                CWMetric(name="ComputeNodesCount", value=compute_node_count, unit="Count"),
+                CWMetric(name="EC2NodesCount", value=ec2_capacity, unit="Count"),
+                CWMetric(name="PendingJobsCount", value=pending_jobs_count, unit="Count"),
+                CWMetric(name="RunningJobsCount", value=running_jobs_count, unit="Count"),
+            ]
+            for metric in scaling_metrics:
+                metric.dimensions_as_dict = {"ClusterName": cluster_name}
+
+            logging.info(f"Publishing metrics: {scaling_metrics}")
+            publish_metrics_to_cloudwatch(
+                namespace="ParallelCluster/ScalingStressTest",
+                cw_client=cw_client,
+                cluster_name=cluster_name,
+                cw_metrics=scaling_metrics,
+            )
+
+        # add values only if there is a transition.
+        if (
+            len(ec2_capacity_time_series) == 0
+            or ec2_capacity_time_series[-1] != ec2_capacity
+            or compute_nodes_time_series[-1] != compute_node_count
+        ):
+            ec2_capacity_time_series.append(ec2_capacity)
+            compute_nodes_time_series.append(compute_node_count)
+            timestamps.append(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
+
+    try:
+        _collect_metrics()
+    except RetryError:
+        # ignoring this error in order to perform assertions on the collected data.
+        pass
+
+    end_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    logging.info(
+        "Monitoring completed: %s, %s, %s",
+        "ec2_capacity_time_series [" + " ".join(map(str, ec2_capacity_time_series)) + "]",
+        "compute_nodes_time_series [" + " ".join(map(str, compute_nodes_time_series)) + "]",
+        "timestamps [" + " ".join(map(str, timestamps)) + "]",
+    )
+
+    logging.info("Sleeping for 3 minutes to wait for the metrics to propagate...")
+    time.sleep(180)
+
+    return ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time
+
+
+def get_compute_nodes_allocation(
+    scheduler_commands,
+    region,
+    stack_name,
+    max_monitoring_time,
+):
     """
     Watch periodically the number of compute nodes in the cluster.
 
@@ -38,16 +136,13 @@ def get_compute_nodes_allocation(scheduler_commands, region, stack_name, max_mon
     @retry(
         # Retry until EC2 and Scheduler capacities scale down to 0
         # Also make sure cluster scaled up before scaling down
-        retry_on_result=lambda _: ec2_capacity_time_series[-1] != 0
-        or compute_nodes_time_series[-1] != 0
-        or max(ec2_capacity_time_series) == 0
-        or max(compute_nodes_time_series) == 0,
+        retry_on_result=lambda _: scaling_target_condition(ec2_capacity_time_series, compute_nodes_time_series, 0),
         wait_fixed=seconds(20),
         stop_max_delay=max_monitoring_time,
     )
     def _watch_compute_nodes_allocation():
         compute_nodes = len(scheduler_commands.get_unique_static_nodes())
-        ec2_capacity = get_compute_nodes_count(stack_name, region)
+        ec2_capacity = get_compute_instances_count(stack_name, region)
         timestamp = time.time()
 
         # add values only if there is a transition.

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -50,7 +50,7 @@ def get_scaling_metrics(
         retry_on_result=lambda _: scaling_target_condition(
             ec2_capacity_time_series, compute_nodes_time_series, target_cluster_size
         ),
-        wait_fixed=seconds(20),
+        wait_fixed=seconds(10),
         stop_max_delay=max_monitoring_time,
     )
     def _collect_metrics():

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -425,11 +425,11 @@ class SlurmCommands(SchedulerCommands):
         command = "sinfo --Node --noheader"
         if filter_by_partition:
             command += " --partition {}".format(filter_by_partition)
-        # Print first and fourth columns to get nodename and state only (default partition contains *)
+        # Get nodename and state only (default partition contains *)
         # Filter out nodes that are not responding or in power saving states
-        command += (
-            " | awk '{print $1, $4}' | grep -v '[*#~%]' | awk '{print $1}'" if not all_nodes else " | awk '{print $1}'"
-        )
+        if not all_nodes:
+            command += " -o '%N %t' | grep -v '[*#~%]'"
+        command += " | awk '{print $1}'"
         result = self._remote_command_executor.run_remote_command(command)
         return result.stdout.splitlines()
 

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -109,7 +109,7 @@ def test_scaling_stress_test(
         # scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage
         # (15, 1000, "c5.24xlarge", "Efs"),
         # (15, 2000, "c5.24xlarge", "Efs"),
-        (20, 3000, "c5.24xlarge", "Efs", "best-effort"),
+        (20 , 3000, "c5.24xlarge", "Efs", "best-effort"),
         # (15, 4000, "c5.24xlarge", "Efs"),
     ]
 

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -75,12 +75,15 @@ def _get_scaling_time(ec2_capacity_time_series: list, timestamps: list, scaling_
     return scaling_target_time, int((scaling_target_time - start_time).total_seconds())
 
 
-# @pytest.mark.parametrize(
-#     "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type",
-#     [
-#         (10, 3000, "Efs", "c5.24xlarge"),  # TODO: Pass these values from an external source
-#     ],
-# )
+@pytest.mark.parametrize(
+    "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type, scaling_strategy",
+    [
+        (20, 1000, "Efs", "c5.24xlarge", "best-effort"),  # TODO: Pass these values from an external source
+        (20, 2000, "Efs", "c5.24xlarge", "best-effort"),
+        (20, 3000, "Efs", "c5.24xlarge", "best-effort"),
+        (20, 4000, "Efs", "c5.24xlarge", "best-effort"),
+    ],
+)
 def test_scaling_stress_test(
     instance,
     os,
@@ -90,6 +93,11 @@ def test_scaling_stress_test(
     pcluster_config_reader,
     scheduler_commands_factory,
     clusters_factory,
+    scaling_max_time_in_mins,
+    scaling_target,
+    shared_headnode_storage,
+    head_node_instance_type,
+    scaling_strategy,
 ):
     """
     This test scales a cluster up and down while periodically monitoring some primary metrics.
@@ -105,100 +113,88 @@ def test_scaling_stress_test(
     - Log with the Metrics Source that can be used from CloudWatch Console
     - A Metrics Image showing the scale up and scale down using a linear graph with annotations
     """
+    # Creating cluster with intended head node instance type and scaling parameters
+    cluster_config = pcluster_config_reader(
+        # Prevent nodes being set down before we start monitoring the scale down metrics
+        scaledown_idletime=scaling_max_time_in_mins,
+        scaling_target=scaling_target,
+        head_node_instance_type=head_node_instance_type,
+        shared_headnode_storage=shared_headnode_storage,
+        scaling_strategy=scaling_strategy,
+    )
+    logging.info(f"Cluster config: {cluster_config}")
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
-    test_params = [
-        # scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage
-        # (15, 1000, "c5.24xlarge", "Efs"),
-        # (15, 2000, "c5.24xlarge", "Efs"),
-        (20 , 3000, "c5.24xlarge", "Efs", "best-effort"),
-        # (15, 4000, "c5.24xlarge", "Efs"),
-    ]
+    # Disable protected mode since bootstrap errors are likely to occur given the large cluster sizes
+    disable_protected_mode(remote_command_executor)
 
-    for (
-        scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage, scaling_strategy
-    ) in test_params:
-        # Creating cluster with intended head node instance type and scaling parameters
-        cluster_config = pcluster_config_reader(
-            # Prevent nodes being set down before we start monitoring the scale down metrics
-            scaledown_idletime=scaling_max_time_in_mins,
-            scaling_target=scaling_target,
-            head_node_instance_type=head_node_instance_type,
-            shared_headnode_storage=shared_headnode_storage,
-            scaling_strategy=scaling_strategy,
-        )
-        cluster = clusters_factory(cluster_config)
-        remote_command_executor = RemoteCommandExecutor(cluster)
-        scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    # Submit a simple job to trigger the launch all compute nodes
+    scaling_job = {
+        # Keep job running until we explicitly cancel it and start monitoring scale down
+        "command": f"srun sleep {minutes(scaling_max_time_in_mins) // 1000}",
+        "nodes": scaling_target,
+    }
+    job_id = scheduler_commands.submit_command_and_assert_job_accepted(scaling_job)
 
-        # Disable protected mode since bootstrap errors are likely to occur given the large cluster sizes
-        disable_protected_mode(remote_command_executor)
+    # Set start time at minute granularity (to simplify calculation and visualising on CloudWatch)
+    start_time = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
 
-        # Submit a simple job to trigger the launch all compute nodes
-        scaling_job = {
-            # Keep job running until we explicitly cancel it and start monitoring scale down
-            "command": f"srun sleep {minutes(scaling_max_time_in_mins) // 1000}",
-            "nodes": scaling_target,
-        }
-        job_id = scheduler_commands.submit_command_and_assert_job_accepted(scaling_job)
+    # Monitor the cluster during scale up
+    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+        remote_command_executor,
+        max_monitoring_time=minutes(scaling_max_time_in_mins),
+        region=region,
+        cluster_name=cluster.name,
+        publish_metrics=True,
+        target_cluster_size=scaling_target,
+    )
+    # Extract scale up duration and timestamp from the monitoring metrics collected above
+    scaling_target_time, scale_up_time = _get_scaling_time(
+        ec2_capacity_time_series, timestamps, scaling_target, start_time
+    )
 
-        # Set start time at minute granularity (to simplify calculation and visualising on CloudWatch)
-        start_time = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+    # Cancel the running job and scale dow the cluster using the update-compute-fleet command
+    scheduler_commands.cancel_job(job_id)
+    cluster.stop()
 
-        # Monitor the cluster during scale up
-        ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
-            remote_command_executor,
-            max_monitoring_time=minutes(scaling_max_time_in_mins),
-            region=region,
-            cluster_name=cluster.name,
-            publish_metrics=True,
-            target_cluster_size=scaling_target,
-        )
-        # Extract scale up duration and timestamp from the monitoring metrics collected above
-        scaling_target_time, scale_up_time = _get_scaling_time(
-            ec2_capacity_time_series, timestamps, scaling_target, start_time
-        )
+    # Monitor the cluster during scale down
+    scale_down_start_timestamp = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+        remote_command_executor,
+        max_monitoring_time=minutes(scaling_max_time_in_mins),
+        region=region,
+        cluster_name=cluster.name,
+        publish_metrics=True,
+        target_cluster_size=0,
+    )
+    # Extract scale down duration and timestamp from the monitoring metrics collected above
+    _, scale_down_time = _get_scaling_time(ec2_capacity_time_series, timestamps, 0, scale_down_start_timestamp)
 
-        # Cancel the running job and scale dow the cluster using the update-compute-fleet command
-        scheduler_commands.cancel_job(job_id)
-        cluster.stop()
+    # Summarize the scaling metrics in a report (logs and metrics image)
+    scaling_results = {
+        "Region": region,
+        "OS": os,
+        "ComputeNode": instance,
+        "HeadNode": head_node_instance_type,
+        "ScaleUpTime": scale_up_time,
+        "ScaleDownTime": scale_down_time,
+    }
 
-        # Monitor the cluster during scale down
-        scale_down_start_timestamp = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
-        ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
-            remote_command_executor,
-            max_monitoring_time=minutes(scaling_max_time_in_mins),
-            region=region,
-            cluster_name=cluster.name,
-            publish_metrics=True,
-            target_cluster_size=0,
-        )
-        # Extract scale down duration and timestamp from the monitoring metrics collected above
-        _, scale_down_time = _get_scaling_time(ec2_capacity_time_series, timestamps, 0, scale_down_start_timestamp)
+    logging.info(f"Scaling Results: {scaling_results}")
 
-        # Summarize the scaling metrics in a report (logs and metrics image)
-        scaling_results = {
-            "Region": region,
-            "OS": os,
-            "ComputeNode": instance,
-            "HeadNode": head_node_instance_type,
-            "ScaleUpTime": scale_up_time,
-            "ScaleDownTime": scale_down_time,
-        }
-
-        logging.info(f"Scaling Results: {scaling_results}")
-
-        produce_benchmark_metrics_report(
-            title=", ".join("{0}[{1}] ".format(key, val) for (key, val) in scaling_results.items()),
-            region=region,
-            cluster_name=cluster.cfn_name,
-            start_time=start_time,
-            end_time=end_time,
-            scaling_target=scaling_target,
-            request=request,
-            scaling_target_time=_datetime_to_minute_granularity(scaling_target_time) + datetime.timedelta(minutes=1),
-        )
-        # Verify that there was no over-scaling
-        # assert_that(max(compute_nodes_time_series)).is_equal_to(scaling_target)
-        assert_that(max(ec2_capacity_time_series)).is_equal_to(scaling_target)
-        # assert_that(compute_nodes_time_series[-1]).is_equal_to(0)
-        cluster.delete()
+    produce_benchmark_metrics_report(
+        title=", ".join("{0}[{1}] ".format(key, val) for (key, val) in scaling_results.items()),
+        region=region,
+        cluster_name=cluster.cfn_name,
+        start_time=start_time,
+        end_time=end_time,
+        scaling_target=scaling_target,
+        request=request,
+        scaling_target_time=_datetime_to_minute_granularity(scaling_target_time) + datetime.timedelta(minutes=1),
+    )
+    # Verify that there was no over-scaling
+    # assert_that(max(compute_nodes_time_series)).is_equal_to(scaling_target)
+    assert_that(max(ec2_capacity_time_series)).is_equal_to(scaling_target)
+    # assert_that(compute_nodes_time_series[-1]).is_equal_to(0)

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -9,6 +9,7 @@ from time_utils import minutes
 
 from tests.common.assertions import assert_no_msg_in_logs
 from tests.common.scaling_common import get_scaling_metrics
+from utils import disable_protected_mode
 
 
 @pytest.mark.parametrize(
@@ -128,6 +129,9 @@ def test_scaling_stress_test(
         cluster = clusters_factory(cluster_config)
         remote_command_executor = RemoteCommandExecutor(cluster)
         scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+        # Disable protected mode since bootstrap errors are likely to occur given the large cluster sizes
+        disable_protected_mode(remote_command_executor)
 
         # Submit a simple job to trigger the launch all compute nodes
         scaling_job = {

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -77,7 +77,7 @@ def _get_scaling_time(ec2_capacity_time_series: list, timestamps: list, scaling_
 @pytest.mark.parametrize(
     "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type",
     [
-        (10, 2000, None, "c5.24xlarge"),  # TODO: Pass these values from an external source
+        (10, 3000, "Efs", "c5.24xlarge"),  # TODO: Pass these values from an external source
     ],
 )
 def test_scaling_stress_test(

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -1,9 +1,14 @@
+import datetime
 import logging
 
 import pytest
+from assertpy import assert_that
+from benchmarks.common.metrics_reporter import produce_benchmark_metrics_report
 from remote_command_executor import RemoteCommandExecutor
+from time_utils import minutes
 
 from tests.common.assertions import assert_no_msg_in_logs
+from tests.common.scaling_common import get_scaling_metrics
 
 
 @pytest.mark.parametrize(
@@ -54,3 +59,133 @@ def test_scaling(
         log_files=["/var/log/parallelcluster/clustermgtd"],
         log_msg=["Found the following bootstrap failure nodes"],
     )
+
+
+def _datetime_to_minute_granularity(dt: datetime):
+    return dt.replace(second=0, microsecond=0)
+
+
+def _get_scaling_time(ec2_capacity_time_series: list, timestamps: list, scaling_target: int, start_time: datetime):
+    scaling_target_index = ec2_capacity_time_series.index(scaling_target)
+    timestamp_at_full_cluster_size = timestamps[scaling_target_index]
+    scaling_target_time = datetime.datetime.fromtimestamp(
+        float(timestamp_at_full_cluster_size), tz=datetime.timezone.utc
+    )
+    return scaling_target_time, int((scaling_target_time - start_time).total_seconds())
+
+
+@pytest.mark.parametrize(
+    "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type",
+    [
+        (10, 2000, None, "c5.24xlarge"),  # TODO: Pass these values from an external source
+    ],
+)
+def test_scaling_stress_test(
+    instance,
+    os,
+    region,
+    scheduler,
+    request,
+    pcluster_config_reader,
+    scheduler_commands_factory,
+    clusters_factory,
+    scaling_max_time_in_mins,
+    scaling_target,
+    head_node_instance_type,
+    shared_headnode_storage,
+):
+    """
+    This test scales a cluster up and down while periodically monitoring some primary metrics.
+    The metrics monitored are:
+    - Number of EC2 instances launched
+    - Number of successfully bootstrapped compute nodes that have joined the cluster
+    - Number of jobs pending or in configuration
+    - Number of jobs currently running
+
+    The above metrics are uploaded to CloudWatch.
+    The output of this test are:
+    - Log messages with the Scale up and Scale down time in seconds
+    - Log with the Metrics Source that can be used from CloudWatch Console
+    - A Metrics Image showing the scale up and scale down using a linear graph with annotations
+    """
+
+    # Creating cluster with intended head node instance type and scaling parameters
+    cluster_config = pcluster_config_reader(
+        # Prevent nodes being set down before wee start monitoring the scale down metrics
+        scaledown_idletime=scaling_max_time_in_mins,
+        scaling_target=scaling_target,
+        head_node_instance_type=head_node_instance_type,
+        shared_headnode_storage=shared_headnode_storage,
+    )
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    # Submit a simple job to trigger the launch all compute nodes
+    scaling_job = {
+        # Keep job running until we explicitly cancel it and start monitoring scale down
+        "command": f"srun sleep {minutes(scaling_max_time_in_mins) // 1000}",
+        "nodes": scaling_target,
+    }
+    job_id = scheduler_commands.submit_command_and_assert_job_accepted(scaling_job)
+
+    # Set start time at minute granularity (to simplify calculation and visualising on CloudWatch)
+    start_time = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+
+    # Monitor the cluster during scale up
+    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+        remote_command_executor,
+        max_monitoring_time=minutes(scaling_max_time_in_mins),
+        region=region,
+        cluster_name=cluster.name,
+        publish_metrics=True,
+        target_cluster_size=scaling_target,
+    )
+    # Extract scale up duration and timestamp from the monitoring metrics collected above
+    scaling_target_time, scale_up_time = _get_scaling_time(
+        ec2_capacity_time_series, timestamps, scaling_target, start_time
+    )
+
+    # Cancel the running job and scale dow the cluster using the update-compute-fleet command
+    scheduler_commands.cancel_job(job_id)
+    cluster.stop()
+
+    # Monitor the cluster during scale down
+    scale_down_start_timestamp = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+        remote_command_executor,
+        max_monitoring_time=minutes(scaling_max_time_in_mins),
+        region=region,
+        cluster_name=cluster.name,
+        publish_metrics=True,
+        target_cluster_size=0,
+    )
+    # Extract scale down duration and timestamp from the monitoring metrics collected above
+    _, scale_down_time = _get_scaling_time(ec2_capacity_time_series, timestamps, 0, scale_down_start_timestamp)
+
+    # Summarize the scaling metrics in a report (logs and metrics image)
+    scaling_results = {
+        "Region": region,
+        "OS": os,
+        "ComputeNode": instance,
+        "HeadNode": head_node_instance_type,
+        "ScaleUpTime": scale_up_time,
+        "ScaleDownTime": scale_down_time,
+    }
+
+    logging.info(f"Scaling Results: {scaling_results}")
+
+    produce_benchmark_metrics_report(
+        title=", ".join("{0}[{1}] ".format(key, val) for (key, val) in scaling_results.items()),
+        region=region,
+        cluster_name=cluster.cfn_name,
+        start_time=start_time,
+        end_time=end_time,
+        scaling_target=scaling_target,
+        request=request,
+        scaling_target_time=_datetime_to_minute_granularity(scaling_target_time) + datetime.timedelta(minutes=1),
+    )
+    # Verify that there was no over-scaling
+    assert_that(max(compute_nodes_time_series)).is_equal_to(scaling_target)
+    assert_that(max(ec2_capacity_time_series)).is_equal_to(scaling_target)
+    assert_that(compute_nodes_time_series[-1]).is_equal_to(0)

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -107,20 +107,23 @@ def test_scaling_stress_test(
 
     test_params = [
         # scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage
-        (15, 1000, "c5.24xlarge", "Efs"),
-        (15, 2000, "c5.24xlarge", "Efs"),
-        (15, 3000, "c5.24xlarge", "Efs"),
-        (15, 4000, "c5.24xlarge", "Efs"),
+        # (15, 1000, "c5.24xlarge", "Efs"),
+        # (15, 2000, "c5.24xlarge", "Efs"),
+        (20, 3000, "c5.24xlarge", "Efs", "best-effort"),
+        # (15, 4000, "c5.24xlarge", "Efs"),
     ]
 
-    for scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage in test_params:
+    for (
+        scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage, scaling_strategy
+    ) in test_params:
         # Creating cluster with intended head node instance type and scaling parameters
         cluster_config = pcluster_config_reader(
-            # Prevent nodes being set down before wee start monitoring the scale down metrics
+            # Prevent nodes being set down before we start monitoring the scale down metrics
             scaledown_idletime=scaling_max_time_in_mins,
             scaling_target=scaling_target,
             head_node_instance_type=head_node_instance_type,
             shared_headnode_storage=shared_headnode_storage,
+            scaling_strategy=scaling_strategy,
         )
         cluster = clusters_factory(cluster_config)
         remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -74,12 +74,12 @@ def _get_scaling_time(ec2_capacity_time_series: list, timestamps: list, scaling_
     return scaling_target_time, int((scaling_target_time - start_time).total_seconds())
 
 
-@pytest.mark.parametrize(
-    "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type",
-    [
-        (10, 3000, "Efs", "c5.24xlarge"),  # TODO: Pass these values from an external source
-    ],
-)
+# @pytest.mark.parametrize(
+#     "scaling_max_time_in_mins, scaling_target, shared_headnode_storage, head_node_instance_type",
+#     [
+#         (10, 3000, "Efs", "c5.24xlarge"),  # TODO: Pass these values from an external source
+#     ],
+# )
 def test_scaling_stress_test(
     instance,
     os,
@@ -89,10 +89,6 @@ def test_scaling_stress_test(
     pcluster_config_reader,
     scheduler_commands_factory,
     clusters_factory,
-    scaling_max_time_in_mins,
-    scaling_target,
-    head_node_instance_type,
-    shared_headnode_storage,
 ):
     """
     This test scales a cluster up and down while periodically monitoring some primary metrics.
@@ -109,83 +105,93 @@ def test_scaling_stress_test(
     - A Metrics Image showing the scale up and scale down using a linear graph with annotations
     """
 
-    # Creating cluster with intended head node instance type and scaling parameters
-    cluster_config = pcluster_config_reader(
-        # Prevent nodes being set down before wee start monitoring the scale down metrics
-        scaledown_idletime=scaling_max_time_in_mins,
-        scaling_target=scaling_target,
-        head_node_instance_type=head_node_instance_type,
-        shared_headnode_storage=shared_headnode_storage,
-    )
-    cluster = clusters_factory(cluster_config)
-    remote_command_executor = RemoteCommandExecutor(cluster)
-    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    test_params = [
+        # scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage
+        (15, 1000, "c5.24xlarge", "Efs"),
+        (15, 2000, "c5.24xlarge", "Efs"),
+        (15, 3000, "c5.24xlarge", "Efs"),
+        (15, 4000, "c5.24xlarge", "Efs"),
+    ]
 
-    # Submit a simple job to trigger the launch all compute nodes
-    scaling_job = {
-        # Keep job running until we explicitly cancel it and start monitoring scale down
-        "command": f"srun sleep {minutes(scaling_max_time_in_mins) // 1000}",
-        "nodes": scaling_target,
-    }
-    job_id = scheduler_commands.submit_command_and_assert_job_accepted(scaling_job)
+    for scaling_max_time_in_mins, scaling_target, head_node_instance_type, shared_headnode_storage in test_params:
+        # Creating cluster with intended head node instance type and scaling parameters
+        cluster_config = pcluster_config_reader(
+            # Prevent nodes being set down before wee start monitoring the scale down metrics
+            scaledown_idletime=scaling_max_time_in_mins,
+            scaling_target=scaling_target,
+            head_node_instance_type=head_node_instance_type,
+            shared_headnode_storage=shared_headnode_storage,
+        )
+        cluster = clusters_factory(cluster_config)
+        remote_command_executor = RemoteCommandExecutor(cluster)
+        scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
-    # Set start time at minute granularity (to simplify calculation and visualising on CloudWatch)
-    start_time = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+        # Submit a simple job to trigger the launch all compute nodes
+        scaling_job = {
+            # Keep job running until we explicitly cancel it and start monitoring scale down
+            "command": f"srun sleep {minutes(scaling_max_time_in_mins) // 1000}",
+            "nodes": scaling_target,
+        }
+        job_id = scheduler_commands.submit_command_and_assert_job_accepted(scaling_job)
 
-    # Monitor the cluster during scale up
-    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
-        remote_command_executor,
-        max_monitoring_time=minutes(scaling_max_time_in_mins),
-        region=region,
-        cluster_name=cluster.name,
-        publish_metrics=True,
-        target_cluster_size=scaling_target,
-    )
-    # Extract scale up duration and timestamp from the monitoring metrics collected above
-    scaling_target_time, scale_up_time = _get_scaling_time(
-        ec2_capacity_time_series, timestamps, scaling_target, start_time
-    )
+        # Set start time at minute granularity (to simplify calculation and visualising on CloudWatch)
+        start_time = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
 
-    # Cancel the running job and scale dow the cluster using the update-compute-fleet command
-    scheduler_commands.cancel_job(job_id)
-    cluster.stop()
+        # Monitor the cluster during scale up
+        ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+            remote_command_executor,
+            max_monitoring_time=minutes(scaling_max_time_in_mins),
+            region=region,
+            cluster_name=cluster.name,
+            publish_metrics=True,
+            target_cluster_size=scaling_target,
+        )
+        # Extract scale up duration and timestamp from the monitoring metrics collected above
+        scaling_target_time, scale_up_time = _get_scaling_time(
+            ec2_capacity_time_series, timestamps, scaling_target, start_time
+        )
 
-    # Monitor the cluster during scale down
-    scale_down_start_timestamp = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
-    ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
-        remote_command_executor,
-        max_monitoring_time=minutes(scaling_max_time_in_mins),
-        region=region,
-        cluster_name=cluster.name,
-        publish_metrics=True,
-        target_cluster_size=0,
-    )
-    # Extract scale down duration and timestamp from the monitoring metrics collected above
-    _, scale_down_time = _get_scaling_time(ec2_capacity_time_series, timestamps, 0, scale_down_start_timestamp)
+        # Cancel the running job and scale dow the cluster using the update-compute-fleet command
+        scheduler_commands.cancel_job(job_id)
+        cluster.stop()
 
-    # Summarize the scaling metrics in a report (logs and metrics image)
-    scaling_results = {
-        "Region": region,
-        "OS": os,
-        "ComputeNode": instance,
-        "HeadNode": head_node_instance_type,
-        "ScaleUpTime": scale_up_time,
-        "ScaleDownTime": scale_down_time,
-    }
+        # Monitor the cluster during scale down
+        scale_down_start_timestamp = _datetime_to_minute_granularity(datetime.datetime.now(tz=datetime.timezone.utc))
+        ec2_capacity_time_series, compute_nodes_time_series, timestamps, end_time = get_scaling_metrics(
+            remote_command_executor,
+            max_monitoring_time=minutes(scaling_max_time_in_mins),
+            region=region,
+            cluster_name=cluster.name,
+            publish_metrics=True,
+            target_cluster_size=0,
+        )
+        # Extract scale down duration and timestamp from the monitoring metrics collected above
+        _, scale_down_time = _get_scaling_time(ec2_capacity_time_series, timestamps, 0, scale_down_start_timestamp)
 
-    logging.info(f"Scaling Results: {scaling_results}")
+        # Summarize the scaling metrics in a report (logs and metrics image)
+        scaling_results = {
+            "Region": region,
+            "OS": os,
+            "ComputeNode": instance,
+            "HeadNode": head_node_instance_type,
+            "ScaleUpTime": scale_up_time,
+            "ScaleDownTime": scale_down_time,
+        }
 
-    produce_benchmark_metrics_report(
-        title=", ".join("{0}[{1}] ".format(key, val) for (key, val) in scaling_results.items()),
-        region=region,
-        cluster_name=cluster.cfn_name,
-        start_time=start_time,
-        end_time=end_time,
-        scaling_target=scaling_target,
-        request=request,
-        scaling_target_time=_datetime_to_minute_granularity(scaling_target_time) + datetime.timedelta(minutes=1),
-    )
-    # Verify that there was no over-scaling
-    assert_that(max(compute_nodes_time_series)).is_equal_to(scaling_target)
-    assert_that(max(ec2_capacity_time_series)).is_equal_to(scaling_target)
-    assert_that(compute_nodes_time_series[-1]).is_equal_to(0)
+        logging.info(f"Scaling Results: {scaling_results}")
+
+        produce_benchmark_metrics_report(
+            title=", ".join("{0}[{1}] ".format(key, val) for (key, val) in scaling_results.items()),
+            region=region,
+            cluster_name=cluster.cfn_name,
+            start_time=start_time,
+            end_time=end_time,
+            scaling_target=scaling_target,
+            request=request,
+            scaling_target_time=_datetime_to_minute_granularity(scaling_target_time) + datetime.timedelta(minutes=1),
+        )
+        # Verify that there was no over-scaling
+        # assert_that(max(compute_nodes_time_series)).is_equal_to(scaling_target)
+        assert_that(max(ec2_capacity_time_series)).is_equal_to(scaling_target)
+        # assert_that(compute_nodes_time_series[-1]).is_equal_to(0)
+        cluster.delete()

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/pcluster.config.yaml
@@ -1,0 +1,25 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  {% if shared_headnode_storage_type %}
+  SharedStorageType: {{ shared_headnode_storage_type }}
+  {% endif %}
+  InstanceType: {{ head_node_instance_type }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmSettings:
+    ScaledownIdletime: {{ scaledown_idletime }}
+  SlurmQueues:
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MaxCount: {{ scaling_target }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/pcluster.config.yaml
@@ -11,6 +11,7 @@ HeadNode:
     KeyName: {{ key_name }}
 Scheduling:
   Scheduler: {{ scheduler }}
+  ScalingStrategy: {{ scaling_strategy }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
   SlurmQueues:

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -27,7 +27,7 @@ from utils import (
     get_compute_nodes_instance_ids,
     get_instance_info,
     test_cluster_health_metric,
-    wait_for_computefleet_changed,
+    wait_for_computefleet_changed, set_protected_failure_count, retrieve_clustermgtd_conf_path,
 )
 
 from tests.common.assertions import (
@@ -126,7 +126,7 @@ def test_slurm(
     head_node_command_executor = RemoteCommandExecutor(cluster)
     assert_no_errors_in_logs(head_node_command_executor, "slurm")
     # Test compute node bootstrap timeout
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(head_node_command_executor)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(head_node_command_executor)
     _test_compute_node_bootstrap_timeout(
         cluster,
         pcluster_config_reader,
@@ -373,8 +373,8 @@ def test_slurm_custom_partitions(
     scheduler_commands.set_partition_state(custom_partitions[0], "UP")
 
     logging.info("Decreasing protected failure count for quicker enter protected mode...")
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
-    _set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(remote_command_executor)
+    set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
     failing_partition = "ondemand1"
     logging.info("Testing protected mode is skipped while job running and activated when no jobs are in the queue...")
     pending_job_id = _test_active_job_running(
@@ -493,7 +493,7 @@ def test_slurm_protected_mode(
     cluster_config = pcluster_config_reader(bucket=bucket_name, scaling_strategy=scaling_strategy)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(remote_command_executor)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
     remote_command_executor.clear_clustermgtd_log()
@@ -506,7 +506,7 @@ def test_slurm_protected_mode(
     # Re-enable protected mode
     _enable_protected_mode(remote_command_executor, clustermgtd_conf_path)
     # Decrease protected failure count for quicker enter protected mode.
-    _set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
+    set_protected_failure_count(remote_command_executor, 2, clustermgtd_conf_path)
 
     partition = "half-broken"
     pending_job_id = _test_active_job_running(
@@ -564,7 +564,7 @@ def test_fast_capacity_failover(
     cluster_config = pcluster_config_reader(scaling_strategy=scaling_strategy)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(remote_command_executor)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
     setup_ec2_launch_override_to_emulate_ice(
@@ -1383,7 +1383,7 @@ def _test_clustermgtd_down_logic(
         scheduler_commands, num_static_nodes, num_dynamic_nodes, partition
     )
     logging.info("Retrieving clustermgtd config path before killing it.")
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(remote_command_executor)
     clustermgtd_heartbeat_file = _retrieve_clustermgtd_heartbeat_file(remote_command_executor, clustermgtd_conf_path)
     logging.info("Killing clustermgtd and rewriting timestamp file to trigger timeout.")
     remote_command_executor.run_remote_script(str(test_datadir / "slurm_kill_clustermgtd.sh"), run_as_root=True)
@@ -1911,13 +1911,6 @@ def _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, sca
     _update_and_start_cluster(cluster, updated_config_file)
 
 
-def _set_protected_failure_count(remote_command_executor, protected_failure_count, clustermgtd_conf_path):
-    """Disable protected mode by setting protected_failure_count to -1."""
-    remote_command_executor.run_remote_command(
-        f"sudo sed -i '/^protected_failure_count /d' {clustermgtd_conf_path}; "
-        + f"echo 'protected_failure_count = {protected_failure_count}' | sudo tee -a {clustermgtd_conf_path}"
-    )
-
 
 @retry(wait_fixed=seconds(30), stop_max_delay=minutes(20))
 def _wait_until_protected_mode_failure_count_set(cluster):
@@ -1930,9 +1923,9 @@ def _wait_until_protected_mode_failure_count_set(cluster):
             "ClusterManager Startup",
         ],
     )
-    clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
+    clustermgtd_conf_path = retrieve_clustermgtd_conf_path(remote_command_executor)
     assert_that(clustermgtd_conf_path).is_not_empty()
-    _set_protected_failure_count(remote_command_executor, 3, clustermgtd_conf_path)
+    set_protected_failure_count(remote_command_executor, 3, clustermgtd_conf_path)
 
     return remote_command_executor
 
@@ -1947,7 +1940,7 @@ def _test_disable_protected_mode(
 ):
     """Test Bootstrap failures have no affect on cluster when protected mode is disabled."""
     # Disable protected_mode by setting protected_failure_count to -1
-    _set_protected_failure_count(remote_command_executor, -1, clustermgtd_conf_path)
+    set_protected_failure_count(remote_command_executor, -1, clustermgtd_conf_path)
     _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, scaling_strategy)
     # wait till the node failed
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(7))(assert_lines_in_logs)(
@@ -2143,16 +2136,6 @@ def _test_compute_node_bootstrap_timeout(
 
 def _retrieve_slurm_root_path(remote_command_executor):
     return remote_command_executor.run_remote_command("dirname $(dirname $(which scontrol))").stdout
-
-
-def _retrieve_clustermgtd_conf_path(remote_command_executor):
-    clustermgtd_conf_path = "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
-    clustermgtd_conf_path_override = remote_command_executor.run_remote_command(
-        "sudo strings /proc/$(pgrep -f bin/clustermgtd$)/environ | grep CONFIG_FILE= | cut -d '=' -f2"
-    ).stdout
-    if clustermgtd_conf_path_override:
-        clustermgtd_conf_path = clustermgtd_conf_path_override
-    return clustermgtd_conf_path
 
 
 def _retrieve_clustermgtd_heartbeat_file(remote_command_executor, clustermgtd_conf_path):

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -26,8 +26,10 @@ from utils import (
     check_status,
     get_compute_nodes_instance_ids,
     get_instance_info,
+    retrieve_clustermgtd_conf_path,
+    set_protected_failure_count,
     test_cluster_health_metric,
-    wait_for_computefleet_changed, set_protected_failure_count, retrieve_clustermgtd_conf_path,
+    wait_for_computefleet_changed,
 )
 
 from tests.common.assertions import (
@@ -1909,7 +1911,6 @@ def _inject_bootstrap_failures(cluster, bucket_name, pcluster_config_reader, sca
         config_file="pcluster.config.broken.yaml", bucket=bucket_name, scaling_strategy=scaling_strategy
     )
     _update_and_start_cluster(cluster, updated_config_file)
-
 
 
 @retry(wait_fixed=seconds(30), stop_max_delay=minutes(20))


### PR DESCRIPTION
### Description of changes
This test scales a cluster up and down while periodically monitoring some primary metrics.
The metrics monitored are:
- Number of EC2 instances launched
- Number of successfully bootstrapped compute nodes that have joined the cluster
- Number of jobs pending or in configuration
- Number of jobs currently running

The above metrics are uploaded to CloudWatch.
The output of this test are:
- Log messages with the Scale up and Scale down time in seconds
- Log with the Metrics Source that can be used from CloudWatch Console
- A Metrics Image showing the scale up and scale down using a linear graph with annotations

(_A variety of cluster sizes will be added in subsequent PRs_)

### Tests
* Ran test and verified the test artifacts

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
