### PR TITLE
[Release 3.8] Pin boto3, botocore, and s3transfer versions to mitigat…

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -15,7 +15,8 @@ aws-cdk.aws-ssm~=1.164
 aws-cdk.core~=1.164
 aws_cdk.aws-cloudwatch~=1.164
 aws_cdk.aws-lambda~=1.164
-boto3>=1.16.14
+boto3>=1.16.14,<1.33.2
+botocore<1.33.2
 connexion~=2.13.0
 flask>=2.2.5,<2.3
 jinja2~=3.0
@@ -23,5 +24,6 @@ jmespath~=0.10
 jsii==1.85.0
 marshmallow~=3.10
 PyYAML>=5.3.1,!=5.4
+s3transfer<0.8.1
 tabulate>=0.8.8,<=0.8.10
 werkzeug~=2.0


### PR DESCRIPTION
…e missing import error in lambda

These three packages are creating a conflict if different versions are used.  See https://github.com/boto/botocore/issues/3082.  This fixes the conflict until it is resolved upstream.

### References
* https://github.com/boto/botocore/issues/3082

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
