### PR TITLE
[develop] Change update policy for MinCount and MaxCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@ CHANGELOG
 
 **CHANGES**
 - Upgrade Slurm to 23.11.1.
+- Change of update policy for `MinCount` and `MaxCount`. The stop of the compute fleet is not required when changing these values through a cluster update.
 - Add support for Python 3.11, 3.12 in pcluster CLI and aws-parallelcluster-batch-cli.
 - Upgrade Python to version 3.12 and NodeJS to version 18 in ParallelCluster Lambda Layer.
 - Build network interfaces using network card index from `NetworkCardIndex` list of EC2 DescribeInstances response, 
-  instead of looping over `MaximumNetworkCards` range.  
-
-**CHANGES**
-- Change of update policy for `MinCount` and `MaxCount`. The stop of the compute fleet is not required when changing these values through a cluster update.  
+  instead of looping over `MaximumNetworkCards` range.
 
 3.8.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ CHANGELOG
 - Build network interfaces using network card index from `NetworkCardIndex` list of EC2 DescribeInstances response, 
   instead of looping over `MaximumNetworkCards` range.  
 
+**CHANGES**
+- Change of update policy for `MinCount` and `MaxCount`. The stop of the compute fleet is not required when changing these values through a cluster update.  
+
 3.8.0
 ------
 

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -12,7 +12,7 @@ import re
 from enum import Enum
 
 from pcluster.config.cluster_config import QueueUpdateStrategy
-from pcluster.constants import AWSBATCH, DEFAULT_MAX_COUNT, SLURM
+from pcluster.constants import AWSBATCH, SLURM
 
 
 class UpdatePolicy:
@@ -450,17 +450,6 @@ UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
     condition_checker=lambda change, patch: patch.cluster.get_running_capacity()
     <= patch.target_config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"],
-)
-
-# Checks resize of max_count
-UpdatePolicy.MAX_COUNT = UpdatePolicy(
-    name="MAX_COUNT",
-    level=1,
-    fail_reason=lambda change, patch: "Shrinking a queue requires the compute fleet to be stopped first",
-    action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
-    condition_checker=lambda change, patch: not patch.cluster.has_running_capacity()
-    or (int(change.new_value) if change.new_value is not None else DEFAULT_MAX_COUNT)
-    >= (int(change.old_value) if change.old_value is not None else DEFAULT_MAX_COUNT),
 )
 
 # Update supported only with all compute nodes down or with replacement policy set different from COMPUTE_FLEET_STOP

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1501,8 +1501,8 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
         many=True,
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE, "update_key": "InstanceType"},
     )
-    max_count = fields.Int(validate=validate.Range(min=1), metadata={"update_policy": UpdatePolicy.MAX_COUNT})
-    min_count = fields.Int(validate=validate.Range(min=0), metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    max_count = fields.Int(validate=validate.Range(min=1), metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    min_count = fields.Int(validate=validate.Range(min=0), metadata={"update_policy": UpdatePolicy.SUPPORTED})
     spot_price = fields.Float(
         validate=validate.Range(min=0), metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1649,7 +1649,7 @@ class SlurmQueueSchema(_CommonQueueSchema):
     compute_resources = fields.Nested(
         SlurmComputeResourceSchema,
         many=True,
-        metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE, "update_key": "Name"},
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Name"},
     )
     networking = fields.Nested(
         SlurmQueueNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
@@ -1781,7 +1781,7 @@ class SchedulingSchema(BaseSchema):
     slurm_queues = fields.Nested(
         SlurmQueueSchema,
         many=True,
-        metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE, "update_key": "Name"},
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Name"},
     )
     # Awsbatch schema:
     aws_batch_queues = fields.Nested(

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -163,7 +163,7 @@ def _compare_changes(changes, expected_changes):
             "MaxCount",
             1,
             2,
-            UpdatePolicy.MAX_COUNT,
+            UpdatePolicy.SUPPORTED,
             False,
             id="change compute resources max count",
         ),
@@ -566,7 +566,7 @@ def _test_less_target_sections(base_conf, target_conf):
                 "MinCount",
                 1,
                 None,
-                UpdatePolicy.COMPUTE_FLEET_STOP,
+                UpdatePolicy.SUPPORTED,
                 is_list=False,
             ),
             Change(
@@ -670,7 +670,7 @@ def _test_more_target_sections(base_conf, target_conf):
                 "MinCount",
                 None,
                 1,
-                UpdatePolicy.COMPUTE_FLEET_STOP,
+                UpdatePolicy.SUPPORTED,
                 is_list=False,
             ),
             Change(

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -332,7 +332,7 @@ def _test_compute_resources(base_conf, target_conf):
                 "ComputeResources",
                 {"Name": "compute-removed", "InstanceType": "c5.9xlarge", "MaxCount": 20},
                 None,
-                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                UpdatePolicy.SUPPORTED,
                 is_list=True,
             ),
             Change(
@@ -340,11 +340,11 @@ def _test_compute_resources(base_conf, target_conf):
                 "ComputeResources",
                 None,
                 {"Name": "new-compute", "InstanceType": "c5.large", "MinCount": 1},
-                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                UpdatePolicy.SUPPORTED,
                 is_list=True,
             ),
         ],
-        UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+        UpdatePolicy.SUPPORTED,
     )
 
 
@@ -381,7 +381,7 @@ def _test_queues(base_conf, target_conf):
                     "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
                 },
                 None,
-                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                UpdatePolicy.SUPPORTED,
                 is_list=True,
             ),
             Change(
@@ -393,11 +393,11 @@ def _test_queues(base_conf, target_conf):
                     "Networking": {"SubnetIds": "subnet-987654321"},
                     "ComputeResources": {"Name": "new-compute", "InstanceType": "c5.xlarge"},
                 },
-                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                UpdatePolicy.SUPPORTED,
                 is_list=True,
             ),
         ],
-        UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+        UpdatePolicy.SUPPORTED,
     )
 
 

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -27,36 +27,6 @@ from tests.pcluster.test_utils import dummy_cluster
 
 
 @pytest.mark.parametrize(
-    "is_fleet_stopped, old_max, new_max, expected_result",
-    [
-        pytest.param(True, 10, 9, True, id="stopped fleet and new_max < old_max"),
-        pytest.param(False, "10", "9", False, id="running fleet and new_max < old_max"),
-        pytest.param(True, 10, 11, True, id="stopped fleet new_max > old_max"),
-        pytest.param(False, 10, 9, False, id="running fleet and new_max < old_max"),
-        pytest.param(False, 10, 11, True, id="running fleet and new_max > old_max"),
-        pytest.param(False, None, 0, False, id="running fleet and new_max < DEFAULT_MAX_COUNT"),
-        pytest.param(False, None, 11, True, id="running fleet and new_max > DEFAULT_MAX_COUNT"),
-        pytest.param(False, 11, None, False, id="running fleet and DEFAULT_MAX_COUNT < old_max"),
-        pytest.param(False, 0, None, True, id="running fleet and DEFAULT_MAX_COUNT > old_max"),
-    ],
-)
-def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_result):
-    cluster = dummy_cluster()
-    cluster_has_running_capacity_mock = mocker.patch.object(
-        cluster, "has_running_capacity", return_value=not is_fleet_stopped
-    )
-
-    patch_mock = mocker.MagicMock()
-    patch_mock.cluster = cluster
-    change_mock = mocker.MagicMock()
-    change_mock.new_value = new_max
-    change_mock.old_value = old_max
-
-    assert_that(UpdatePolicy.MAX_COUNT.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
-    cluster_has_running_capacity_mock.assert_called()
-
-
-@pytest.mark.parametrize(
     "is_fleet_stopped, key, path, old_value, new_value, update_strategy, expected_result",
     [
         pytest.param(


### PR DESCRIPTION
### Description of changes
* Change update policy for MinCount and MaxCount, from COMPUTE_FLEET_STOP to SUPPORTED. This is possible by the adoption of Slurm 23.11, ref https://slurm.schedmd.com/news.html
* Remove unused MAX_COUNT update policy, that was used only by MaxCount
* Change update policy when removing a Queue or a ComputeResource, from COMPUTE_FLEET_STOP_ON_REMOVE to SUPPORTED. 

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
