### PR TITLE
Add support for static private IP addressing and DNS resolution for external slurmdbd instance

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -392,7 +392,11 @@ class ExternalSlurmdbdStack(Stack):
                         sid="CloudWatchLogsPolicy",
                     ),
                     iam.PolicyStatement(
-                        actions=["ec2:AssignPrivateIpAddresses", "ec2:DescribeInstances"],
+                        actions=[
+                            "ec2:AssignPrivateIpAddresses",
+                            "ec2:DescribeInstances",
+                            "ec2:DescribeNetworkInterfaces",
+                        ],
                         resources=["*"],
                         effect=iam.Effect.ALLOW,
                         sid="IPAssignmentPolicy",

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -7,6 +7,7 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_route53 as route53
 from constructs import Construct
 
 
@@ -100,10 +101,19 @@ class ExternalSlurmdbdStack(Stack):
         self._launch_template = self._add_external_slurmdbd_launch_template()
 
         # define EC2 Auto Scaling Group (ASG)
-        self._external_slurmdbd_asg = self._add_external_slurmdbd_auto_scaling_group()
+        # self._external_slurmdbd_asg = self._add_external_slurmdbd_auto_scaling_group()
 
         # define Primary Slurmdbd Instance (not via ASG)
-        # self._primary_slurmdbd_instance = self._add_slurmdbd_primary_instance()
+        self._primary_slurmdbd_instance = self._add_slurmdbd_primary_instance()
+
+        # define external slurmdbd hosted zone
+        self._hosted_zone = self._add_hosted_zone()
+
+        # Add DNS record to hosted zone
+        self._add_instance_to_dns(
+            ip_addr=self._primary_slurmdbd_instance.attr_private_ip,
+            name="slurmdbd",
+        )
 
     def _add_cfn_init_config(self):
         dna_json_content = {
@@ -387,6 +397,15 @@ class ExternalSlurmdbdStack(Stack):
                         effect=iam.Effect.ALLOW,
                         sid="IPAssignmentPolicy",
                     ),
+                    # iam.PolicyStatement(
+                    #     actions=[
+                    #         "route53:CreateHostedZone",
+                    #         "route53:DeleteHostedZone",
+                    #     ],
+                    #     resources=[slurmdbd_hosted_zone.value_as_string],
+                    #     effect=iam.Effect.ALLOW,
+                    #     sid="IPAssignmentPolicy",
+                    # ),
                 ]
             ),
         )
@@ -400,4 +419,30 @@ class ExternalSlurmdbdStack(Stack):
             "SlurmdbdLogGroup",
             log_group_name=f"/aws/slurmdbd/{self.stack_name}",
             retention=logs.RetentionDays.ONE_WEEK,
+        )
+
+    def _add_hosted_zone(self):
+        return route53.CfnHostedZone(
+            self,
+            id="ExternalSlurmdbdHostedZone",
+            name="externalslurmdbdhostedzone",
+            vpcs=[
+                route53.CfnHostedZone.VPCProperty(
+                    vpc_id=self.vpc_id,
+                    vpc_region=self.region,
+                )
+            ],
+        )
+
+    def _add_instance_to_dns(self, ip_addr, name):
+        route53.CfnRecordSet(
+            self,
+            "ExternalSlurmdbdRecordSet",
+            name=(name + "." + self._hosted_zone.name),
+            type="A",
+            hosted_zone_id=self._hosted_zone.attr_id,
+            region=self.region,
+            resource_records=[ip_addr],
+            set_identifier="externalslurmdbdsetidentifier",
+            ttl="300",
         )

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -102,6 +102,9 @@ class ExternalSlurmdbdStack(Stack):
         # define EC2 Auto Scaling Group (ASG)
         self._external_slurmdbd_asg = self._add_external_slurmdbd_auto_scaling_group()
 
+        # define Primary Slurmdbd Instance (not via ASG)
+        # self._primary_slurmdbd_instance = self._add_slurmdbd_primary_instance()
+
     def _add_cfn_init_config(self):
         dna_json_content = {
             "dbms_uri": self.dbms_uri.value_as_string,
@@ -257,14 +260,24 @@ class ExternalSlurmdbdStack(Stack):
             description="The SSH key name to access the instance (for management purposes only)",
         )
 
+        private_ip = CfnParameter(
+            self,
+            "PrivateIp",
+            type="String",
+            description="Static private IP address + prefix to assign to the slurmdbd instance",
+        )
+
+        private_prefix = CfnParameter(
+            self,
+            "PrivatePrefix",
+            type="String",
+            description="Subnet prefix to assign with the private IP to the slurmdbd instance",
+        )
+
         launch_template_data = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
             key_name=key_name_param.value_as_string,
             image_id=ami_id_param.value_as_string,
             instance_type=instance_type_param.value_as_string,
-            security_group_ids=[
-                self._ssh_server_sg.security_group_id,
-                self._slurmdbd_server_sg.security_group_id,
-            ],
             user_data=Fn.base64(
                 Fn.sub(
                     get_user_data_content("../resources/user_data.sh"),
@@ -273,11 +286,23 @@ class ExternalSlurmdbdStack(Stack):
                             "CustomCookbookUrl": self.custom_cookbook_url_param.value_as_string,
                             "StackName": self.stack_name,
                             "Region": self.region,
+                            "PrivateIp": private_ip.value_as_string,
+                            "SubnetPrefix": private_prefix.value_as_string,
                         },
                     },
                 )
             ),
             iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(name=self._instance_profile),
+            network_interfaces=[
+                ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
+                    device_index=0,
+                    groups=[
+                        self._ssh_server_sg.security_group_id,
+                        self._slurmdbd_server_sg.security_group_id,
+                    ],
+                    subnet_id=self.subnet_id.value_as_string,
+                ),
+            ],
         )
 
         launch_template = ec2.CfnLaunchTemplate(self, "LaunchTemplate", launch_template_data=launch_template_data)
@@ -302,6 +327,15 @@ class ExternalSlurmdbdStack(Stack):
         listener.add_target_groups("External-Slurmdbd-Target", target_group)
 
         return nlb
+
+    def _add_slurmdbd_primary_instance(self):
+        return ec2.CfnInstance(
+            self,
+            id="ExternalSlurmdbdPrimaryInstance",
+            launch_template=ec2.CfnInstance.LaunchTemplateSpecificationProperty(
+                version=self._launch_template.attr_latest_version_number, launch_template_id=self._launch_template.ref
+            ),
+        )
 
     def _add_external_slurmdbd_auto_scaling_group(self):
         return autoscaling.CfnAutoScalingGroup(
@@ -346,6 +380,12 @@ class ExternalSlurmdbdStack(Stack):
                         resources=[self._log_group.log_group_arn],
                         effect=iam.Effect.ALLOW,
                         sid="CloudWatchLogsPolicy",
+                    ),
+                    iam.PolicyStatement(
+                        actions=["ec2:AssignPrivateIpAddresses", "ec2:DescribeInstances"],
+                        resources=["*"],
+                        effect=iam.Effect.ALLOW,
+                        sid="IPAssignmentPolicy",
                     ),
                 ]
             ),

--- a/cloudformation/external-slurmdbd/resources/user_data.sh
+++ b/cloudformation/external-slurmdbd/resources/user_data.sh
@@ -7,12 +7,21 @@ function vendor_cookbook
   tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz
   HOME_BAK="${!HOME}"
   export HOME="/tmp"
-  for d in `ls /tmp/cookbooks`; do
-    cd /tmp/cookbooks/$d
+  for d in /tmp/cookbooks/*; do
+    cd "$d" || continue
     LANG=en_US.UTF-8 /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --delete
   done;
   export HOME="${!HOME_BAK}"
 }
+
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id)
+AVAIL_ZONE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/availability-zone)
+ENI_ID=$(aws ec2 describe-instances --instance-ids ${!INSTANCE_ID} --region ${Region} | jq .Reservations[0].Instances[0].NetworkInterfaces[0].NetworkInterfaceId | tr -d '"')
+
+aws ec2 assign-private-ip-addresses --region ${Region} --network-interface-id ${!ENI_ID} --private-ip-addresses ${PrivateIp} --allow-reassignment
+
+ip addr add ${PrivateIp}/${SubnetPrefix} dev eth0
 
 if [ "${CustomCookbookUrl}" != "NONE" ]; then
   curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${CustomCookbookUrl}

--- a/cloudformation/external-slurmdbd/resources/user_data.sh
+++ b/cloudformation/external-slurmdbd/resources/user_data.sh
@@ -14,12 +14,29 @@ function vendor_cookbook
   export HOME="${!HOME_BAK}"
 }
 
+function wait_for_private_ip_assignment
+{
+  rc=1
+  retries=10
+  retry=1
+  sleeptime=1
+  while [ \( $rc -eq 1 \) -a \( $retry -le $retries \) ]; do
+    aws ec2 describe-network-interfaces --network-interface-ids ${!ENI_ID} --region ${Region} | jq .NetworkInterfaces[0].PrivateIpAddresses | grep -q '"PrivateIpAddress": "${PrivateIp}"'
+    rc=$?
+    retry=$((retry+1))
+    sleep $sleeptime
+  done
+  return $rc
+}
+
 TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
 INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id)
 AVAIL_ZONE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/availability-zone)
 ENI_ID=$(aws ec2 describe-instances --instance-ids ${!INSTANCE_ID} --region ${Region} | jq .Reservations[0].Instances[0].NetworkInterfaces[0].NetworkInterfaceId | tr -d '"')
 
 aws ec2 assign-private-ip-addresses --region ${Region} --network-interface-id ${!ENI_ID} --private-ip-addresses ${PrivateIp} --allow-reassignment
+
+wait_for_private_ip_assignment || echo "Assignment of private IP ${PrivateIp} was not successful."
 
 ip addr add ${PrivateIp}/${SubnetPrefix} dev eth0
 


### PR DESCRIPTION
### Description of changes
* Add mechanism to assign a static secondary private IP to the external slurmdbd instance (via `user_data.sh`).
* Add Route53 hosted zone to the external slurmdbd stack
* Add DNS record for the external slurmdbd instance (only for the case of `CfnInstance`, not via ASG).

### Tests
* Manually provisioned the stack successfully.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
