### PR TITLE
Fix others slurm integration tests after updating to 23.11

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1733,11 +1733,11 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
             "command": "sleep 1",
             "partition": partition,
             "constraint": instance_type,
-            "other_options": f"--gres=gpu:{gpus_per_instance} --cpus-per-gpu {cpus_per_gpu}",
+            "other_options": f"--gres=gpu/{gpus_per_instance} --cpus-per-gpu {cpus_per_gpu}",
         }
     )
     job_info = slurm_commands.get_job_info(job_id)
-    assert_that(job_info).contains(f"TresPerNode=gres:gpu:{gpus_per_instance}", f"CpusPerTres=gres:gpu:{cpus_per_gpu}")
+    assert_that(job_info).contains(f"TresPerNode=gres/gpu:{gpus_per_instance}", f"CpusPerTres=gres/gpu:{cpus_per_gpu}")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
### Description of changes
After updating to Slurm 23.11 some tests were failing because minor differences in how messages are logged.
This patch adjust more regex we use to validate the output accordingly.

### Tests
* Some occurrences of the regex were missed in a previous PR and some test still failed.

### References
* [Previous PR](https://github.com/aws/aws-parallelcluster/pull/5909)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
