### PR TITLE
Improvements to the external slurmdbd infrastructure

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -269,19 +269,20 @@ class ExternalSlurmdbdStack(Stack):
             type="String",
             description="The SSH key name to access the instance (for management purposes only)",
         )
-
         private_ip = CfnParameter(
             self,
             "PrivateIp",
             type="String",
             description="Static private IP address + prefix to assign to the slurmdbd instance",
         )
-
         private_prefix = CfnParameter(
             self,
             "PrivatePrefix",
             type="String",
             description="Subnet prefix to assign with the private IP to the slurmdbd instance",
+        )
+        dbms_client_sg_id = CfnParameter(
+            self, "DBMSClientSG", type="String", description="DBMS Client Security Group Id"
         )
 
         launch_template_data = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
@@ -309,6 +310,7 @@ class ExternalSlurmdbdStack(Stack):
                     groups=[
                         self._ssh_server_sg.security_group_id,
                         self._slurmdbd_server_sg.security_group_id,
+                        dbms_client_sg_id.value_as_string,
                     ],
                     subnet_id=self.subnet_id.value_as_string,
                 ),

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -137,17 +137,18 @@ class ExternalSlurmdbdStack(Stack):
                         "mode": "000644",
                         "owner": "root",
                         "group": "root",
-                    },
+                    }
                 },
-                # TODO: fix bug that command not executed
-                "chef": {
-                    "command": (
-                        "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
-                        "--logfile /var/log/chef-client.log --force-formatter --no-color "
-                        "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
-                        "--override-runlist aws-parallelcluster-entrypoints::external_slurmdbd_config"
-                    ),
-                    "cwd": "/etc/chef",
+                "commands": {
+                    "chef": {
+                        "command": (
+                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
+                            "--logfile /var/log/chef-client.log --force-formatter --no-color "
+                            "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
+                            "--override-runlist aws-parallelcluster-entrypoints::external_slurmdbd_config"
+                        ),
+                        "cwd": "/etc/chef",
+                    }
                 },
             },
             # TODO: delete the cfn-hup hook

--- a/cloudformation/external-slurmdbd/resources/user_data.sh
+++ b/cloudformation/external-slurmdbd/resources/user_data.sh
@@ -1,3 +1,18 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-config; charset=us-ascii
+MIME-Version: 1.0
+
+package_update: false
+package_upgrade: false
+repo_upgrade: none
+datasource_list: [ Ec2, None ]
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
 #!/bin/bash -x
 
 function vendor_cookbook


### PR DESCRIPTION
### Description of changes
* Add DBMS client security group from the DBMS stack to the slurmdbd instance;
* Make the user data for the slurmdbd instance modular (and disable some automatic package upgrades enabled by default by cloud-init);
* Fix cfn-init configuration for slurmdbd instance so that the cinc-client command can actually start on the slurmdbd instance.

### Tests
* Successful manual tests of the improvements.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
