### PR TITLE
[release-3.8] Fix LoginNodes pool name update fail

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -378,13 +378,13 @@ def condition_checker_shared_storage_update_policy(change, patch):
     return result
 
 
-def condition_checker_login_nodes_pools_policy(change, _):
-    """Login fleet stop is required when a login pool is removed."""
-    return not is_login_pool_removed(change)
+def condition_checker_login_nodes_pools_policy(change, patch):
+    """Login pools can be added but removal require LoginNodes stop."""
+    result = not patch.cluster.has_running_login_nodes()
+    if change.is_list and change.key == "Pools":
+        result = result or (change.old_value is None and change.new_value is not None)
 
-
-def is_login_pool_removed(change):
-    return change.is_list and change.key == "Pools" and change.old_value is not None and change.new_value is None
+    return result
 
 
 def condition_checker_login_nodes_stop_policy(_, patch):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1862,7 +1862,7 @@ class DirectoryServiceSchema(BaseSchema):
 class ClusterSchema(BaseSchema):
     """Represent the schema of the Cluster."""
 
-    login_nodes = fields.Nested(LoginNodesSchema, many=False, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    login_nodes = fields.Nested(LoginNodesSchema, many=False, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
     image = fields.Nested(ImageSchema, required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     head_node = fields.Nested(HeadNodeSchema, required=True, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     scheduling = fields.Nested(SchedulingSchema, required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})


### PR DESCRIPTION
Cherry-picked from: https://github.com/aws/aws-parallelcluster/pull/5824

### Description of changes
* Correct the update policy condition_checker to Login pools can be added but removal require LoginNodes stop.
* Change the LoginNodes Update Policy to `LOGIN_NODES_STOP`

### Tests
* Manually tests done, things work well
* Unit tests fixed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
