### PR TITLE
Add support for ExternalSlurmdbd in SlurmSettings

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -194,6 +194,7 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
+    ExternalSlurmdbdVsDatabaseIncompatibility,
     SlurmNodePrioritiesWarningValidator,
 )
 from pcluster.validators.tags_validators import ComputeResourceTagsValidator
@@ -2709,6 +2710,7 @@ class SlurmSettings(Resource):
         custom_slurm_settings: List[Dict] = None,
         custom_slurm_settings_include_file: str = None,
         munge_key_secret_arn: str = None,
+        external_slurmdbd: str = None,
         **kwargs,
     ):
         super().__init__()
@@ -2722,6 +2724,7 @@ class SlurmSettings(Resource):
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
         self.custom_slurm_settings_include_file = Resource.init_param(custom_slurm_settings_include_file)
         self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
+        self.external_slurmdbd = Resource.init_param(external_slurmdbd)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2759,6 +2762,11 @@ class SlurmSettings(Resource):
                 MungeKeySecretSizeAndBase64Validator,
                 munge_key_secret_arn=self.munge_key_secret_arn,
             )
+        self._register_validator(
+            ExternalSlurmdbdVsDatabaseIncompatibility,
+            database=self.database,
+            external_slurmdbd=self.external_slurmdbd,
+        )
 
 
 class QueueUpdateStrategy(Enum):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1747,6 +1747,7 @@ class SlurmSettingsSchema(BaseSchema):
     custom_slurm_settings = fields.List(fields.Dict, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     custom_slurm_settings_include_file = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP})
+    external_slurmdbd = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -182,3 +182,19 @@ class SlurmNodePrioritiesWarningValidator(Validator):
                 f"({max_static}): {bad_dynamic_priorities}.",
                 FailureLevel.WARNING,
             )
+
+
+class ExternalSlurmdbdVsDatabaseIncompatibility(Validator):
+    """
+    External Slurmdbd vs Database Validator.
+
+    This validator checks that ExternalSlurmdbd and Database are not defined at the same time in the cluster
+    configuration within SlurmSettings.
+    """
+
+    def _validate(self, database, external_slurmdbd):
+        if (database is not None) and (external_slurmdbd is not None):
+            self._add_failure(
+                "Database and ExternalSlurmdbd cannot be defined at the same time within SlurmSettings.",
+                FailureLevel.ERROR,
+            )

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -3796,6 +3796,7 @@ Scheduling:
       HostedZoneId: null
       UseEc2Hostnames: false
     EnableMemoryBasedScheduling: false
+    ExternalSlurmdbd: null
     MungeKeySecretArn: null
     QueueUpdateStrategy: TERMINATE
     ScaledownIdletime: 10

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -90,6 +90,7 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
+    ExternalSlurmdbdVsDatabaseIncompatibility,
     SlurmNodePrioritiesWarningValidator,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
@@ -330,6 +331,48 @@ def test_custom_slurm_settings_include_file_only_validator(
         custom_slurm_settings,
         custom_slurm_settings_include_file,
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "database, external_slurmdbd, expected_message",
+    [
+        pytest.param(
+            None,
+            None,
+            None,
+            id="Case with no Slurm accounting",
+        ),
+        pytest.param(
+            None,
+            "test.slurmdbd.host",
+            None,
+            id="Case with external slurmdbd",
+        ),
+        pytest.param(
+            Database(
+                uri="test.database.server",
+                user_name="databaseadmin",
+                password_secret_arn="fake-password-secret-arn",
+            ),
+            None,
+            None,
+            id="Case with normal Slurm Accounting (via Database)",
+        ),
+        pytest.param(
+            Database(
+                uri="test.database.server",
+                user_name="databaseadmin",
+                password_secret_arn="fake-password-secret-arn",
+            ),
+            "test.slurmdbd.host",
+            "Database and ExternalSlurmdbd cannot be defined at the same time within SlurmSettings.",
+            id="Bad case with Slurm Accounting (via Database) and external slurmdbd",
+        ),
+    ],
+)
+def test_external_slurmdbd_vs_database_incompatibility_validator(database, external_slurmdbd, expected_message):
+    actual_failures = ExternalSlurmdbdVsDatabaseIncompatibility().execute(database, external_slurmdbd)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -316,6 +316,9 @@ class ExternalSlurmdbdStack(Stack):
                     subnet_id=self.subnet_id.value_as_string,
                 ),
             ],
+            metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
+                http_tokens="required",
+            ),
         )
 
         launch_template = ec2.CfnLaunchTemplate(self, "LaunchTemplate", launch_template_data=launch_template_data)


### PR DESCRIPTION
### Description of changes
* Add configuration parameter representing the location of an external slurmdbd daemon.
* Add validator to check that ExternalSlurmdbd and Database (Slurm accounting) are not used together.
* Set IMDSv2 as required for the external Slurmdbd instance in the CDK template.

### Tests
* Add unit test for the validator.
* Successful manual test with cluster connected to a prototype external slurmdbd stack.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2595

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
