### PR TITLE
[release-3.8] Add support for passing Slurm patches from S3

### DIFF
--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -199,6 +199,7 @@ class ImagebuilderDevSettings(BaseDevSettings):
         disable_validate_and_test: bool = None,
         cinc_installer_url: str = None,
         disable_kernel_update: bool = None,
+        slurm_patches_s3_archive: str = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -208,6 +209,7 @@ class ImagebuilderDevSettings(BaseDevSettings):
         self.disable_validate_and_test = Resource.init_param(disable_validate_and_test, default=True)
         self.cinc_installer_url = Resource.init_param(cinc_installer_url, default="")
         self.disable_kernel_update = Resource.init_param(disable_kernel_update, default=False)
+        self.slurm_patches_s3_archive = Resource.init_param(slurm_patches_s3_archive, default="")
 
 
 # ---------------------- ImageBuilder ---------------------- #
@@ -279,6 +281,7 @@ class ImageBuilderExtraChefAttributes(ExtraChefAttributes):
         self.custom_awsbatchcli_package = None
         self.base_os = None
         self.disable_kernel_update = None
+        self.slurm_patches_s3_archive = None
         self._set_default(dev_settings)
 
     def _set_default(self, dev_settings: ImagebuilderDevSettings):
@@ -288,6 +291,9 @@ class ImageBuilderExtraChefAttributes(ExtraChefAttributes):
         self.custom_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
         self.custom_awsbatchcli_package = (
             dev_settings.aws_batch_cli_package if dev_settings and dev_settings.aws_batch_cli_package else ""
+        )
+        self.slurm_patches_s3_archive = (
+            dev_settings.slurm_patches_s3_archive if dev_settings and dev_settings.slurm_patches_s3_archive else ""
         )
         self.base_os = "{{ build.OperatingSystemName.outputs.stdout }}"
         self.disable_kernel_update = "true" if dev_settings and dev_settings.disable_kernel_update else "false"

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -176,6 +176,7 @@ def test_imagebuilder_url_validator(
                     "is_official_ami_build": "false",
                     "nvidia": {"enabled": "no"},
                     "region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "slurm_patches_s3_archive": "",
                 }
             },
         ),
@@ -199,6 +200,7 @@ def test_imagebuilder_url_validator(
                     "is_official_ami_build": "false",
                     "nvidia": {"enabled": "yes"},
                     "region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "slurm_patches_s3_archive": "",
                 }
             },
         ),
@@ -223,6 +225,7 @@ def test_imagebuilder_url_validator(
                     "is_official_ami_build": "false",
                     "nvidia": {"enabled": "yes"},
                     "region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "slurm_patches_s3_archive": "",
                 },
                 "nfs": "true",
             },
@@ -246,8 +249,35 @@ def test_imagebuilder_url_validator(
                     "is_official_ami_build": "true",
                     "nvidia": {"enabled": "no"},
                     "region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "slurm_patches_s3_archive": "",
                 },
                 "nfs": "true",
+            },
+        ),
+        # Test case with URL for Slurm patches from S3
+        (
+            {
+                "dev_settings": {
+                    "cookbook": {
+                        "extra_chef_attributes": "{"
+                        '"cluster": {'
+                        '"slurm_patches_s3_archive": "s3://example-s3-bucket/example-archive.tgz"'
+                        "}"
+                        "}"
+                    },
+                },
+            },
+            {
+                "cluster": {
+                    "base_os": "{{ build.OperatingSystemName.outputs.stdout }}",
+                    "custom_awsbatchcli_package": "",
+                    "custom_node_package": "",
+                    "disable_kernel_update": "false",
+                    "is_official_ami_build": "false",
+                    "nvidia": {"enabled": "no"},
+                    "region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "slurm_patches_s3_archive": "s3://example-s3-bucket/example-archive.tgz",
+                }
             },
         ),
     ],


### PR DESCRIPTION
### Description of changes
* Add support for passing an URL for an archive containing Slurm patches to be used when building Slurm via the build-image Extra Chef Attributes.

### Tests
* Manual run of build-image using some patches from an S3 bucket.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2596

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
