### PR TITLE
[Performance Test] StarCCM installation: remove creation of wrong folder

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.install.sh
@@ -7,8 +7,6 @@ SHARED_DIR="/shared" # /shared or whatever you named the SharedStorage MountDir
 STARCCM_PACKAGE="${SHARED_DIR}/STAR-CCM+18.02.008_01_linux-x86_64.tar.gz"
 SIM_FILE="${SHARED_DIR}/lemans_poly_17m.amg@00500.sim"
 
-mkdir -p "${TARGET_USER_DIR}"
-
 OLD_PWD=$(pwd)
 
 cd "${SHARED_DIR}"


### PR DESCRIPTION
### Description of changes
Remove creation of wrong folder during StarCCM+ installation.
The command is causing installation script to fail because the variable TARGET_USER_DIR is now undefined after changes in  https://github.com/aws/aws-parallelcluster/pull/5907.

The regression is only impacting develop branch, not the release-3.8 branch.

### Tests
Will be tested on the authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
