### PR TITLE
Remove `CommunicationParameters` from the Slurm Settings deny list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ CHANGELOG
   - Intel Python: 2023.2.0
   - Critical Update for Intel oneAPI DPC++/C++ Compiler: 2023.2.1
   - Critical Update for Intel Fortran Compiler & Intel® Fortran Compiler Classic: 2023.2.1
+  - Remove `CommunicationParameters` from the Custom Slurm Settings deny list.
+
+**CHANGES**
+- Upgrade Slurm to 23.11.1.
 
 3.8.0
 ------

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -19,7 +19,6 @@ from pcluster.validators.common import FailureLevel, Validator
 SLURM_SETTINGS_DENY_LIST = {
     "SlurmConf": {
         "Global": [
-            "communicationparameters",
             "epilog",
             "grestypes",
             "launchparameters",

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -217,11 +217,10 @@ def test_cluster_name_validator_slurm_accounting(cluster_name, scheduling, shoul
         ),
         (
             "Fails when custom settings at SlurmConf level are in the deny_list, invalid parameters are reported",
-            [{"SlurmctldParameters": "SubPar1,Subpar2=1"}, {"CommunicationParameters": "SubPar1"}],
+            [{"SlurmctldParameters": "SubPar1,Subpar2=1"}],
             SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Global"],  # keep the deny-list lowercase
             CustomSlurmSettingLevel.SLURM_CONF,
-            "Using the following custom Slurm settings at SlurmConf level is not allowed: "
-            "CommunicationParameters,SlurmctldParameters",
+            "Using the following custom Slurm settings at SlurmConf level is not allowed: SlurmctldParameters",
         ),
         (
             "When defining custom partitions or nodelists with parameters that exist also at global level and are"


### PR DESCRIPTION
### Description of changes
With Slurm 23.11 `NoAddrCache` parameter was deprecated,
so we don't need to set `CommunicationParameters` in the slurm.conf.

### Tests
* N/A
* 
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
