### PR TITLE
[develop] Install kernel-devel for Rocky Linux from vault 

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -206,7 +206,7 @@ phases:
                   fi
               
                   if [[ ${!OS} == "rocky8" ]] ; then
-                    yum versionlock rocky-release
+                    yum versionlock rocky-release rocky-repos
                   elif [[ ${!OS} == "rhel8" ]] ; then
                     yum versionlock redhat-release
                   fi

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -234,7 +234,6 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y update
@@ -256,15 +255,29 @@ phases:
                 else
                   package-cleanup -y --oldkernels --count=1
                 fi
-                # Install kernel-devel during OS update, so that headers are aligned with new kernel. 
-                # The same is done for Debian through `apt-get -y install linux-aws`
-                yum -y install kernel-devel
 
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 DEBIAN_FRONTEND=noninteractive apt-get -y update
                 DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade
                 apt-get --purge autoremove -y
+              fi
 
+      - name: InstallUpdatedHeaders
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+
+              if [[ ${!PLATFORM} == RHEL ]]; then
+                # Install kernel-devel during OS update, so that headers are aligned with new kernel. 
+                # The same is done for Debian through `apt-get -y install linux-aws`
+                yum -y install kernel-devel
+              
+              elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 if [[ ${!DISABLE_KERNEL_UPDATE} != true ]]; then
                    # already installed to LTS version
                    apt-get -y install linux-aws linux-headers-aws linux-image-aws

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -262,7 +262,7 @@ phases:
                 apt-get --purge autoremove -y
               fi
 
-      - name: InstallUpdatedHeaders
+      - name: InstallAdditionalKernelPackages
         action: ExecuteBash
         inputs:
           commands:
@@ -275,7 +275,22 @@ phases:
               if [[ ${!PLATFORM} == RHEL ]]; then
                 # Install kernel-devel during OS update, so that headers are aligned with new kernel. 
                 # The same is done for Debian through `apt-get -y install linux-aws`
-                yum -y install kernel-devel
+                if [[ ${!OS} == "rocky8" ]] ; then
+                  PACKAGE="kernel-devel-$(uname -r)"
+                  RELEASE_VERSION=$(source /etc/os-release && echo ${!VERSION_ID})
+              
+                  # try to install kernel source for a specific release version
+                  yum install -y ${!PACKAGE} --releasever ${!RELEASE_VERSION}
+                  if [ $? -ne 0 ]; then
+                    yum install -y wget
+                    # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
+                    # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
+                    wget https://dl.rockylinux.org/vault/rocky/${!RELEASE_VERSION}/BaseOS/$(uname -m)/os/Packages/k/${!PACKAGE}.rpm
+                    yum install -y ./${!PACKAGE}.rpm
+                  fi
+                else
+                  yum -y install kernel-devel
+                fi
               
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 if [[ ${!DISABLE_KERNEL_UPDATE} != true ]]; then


### PR DESCRIPTION
### Description of changes

kernel-devel should be aligned to the installed version.
If there is kernel 8.8 we should have kernel-devel 8.8.

Without this patch we were installing latest kernel-devel package.
We cannot use `--releasever` to install 8.8 version because it is not more available in the repo.
Previous releases are moved into a vault area once a new minor release version is available for at least a week.

On RHEL8 instead all versions of the packages will remain available.

With this patch we're downloading this specific package from vault and installing it
if it's not available in the repository for the specific release version.

### References

Related to https://github.com/aws/aws-parallelcluster-cookbook/pull/2598