### PR TITLE
[Isolated Regions] Remove integration tests  covering custom resource from isolated regions test config.

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -578,36 +578,38 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-  custom_resource:
-    test_cluster_custom_resource.py::test_cluster_create:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_create_invalid:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_update:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_update_invalid:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_delete_retain:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
-    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
-      dimensions:
-        - oss: {{ OSS }}
-          regions: {{ REGIONS }}
+# These tests cannot be executed in US isolated regions
+# because the feature Custom Resource is not supported in these regions.
+#  custom_resource:
+#    test_cluster_custom_resource.py::test_cluster_create:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_create_invalid:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_update:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_update_invalid:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_delete_retain:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}
+#    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
+#      dimensions:
+#        - oss: {{ OSS }}
+#          regions: {{ REGIONS }}


### PR DESCRIPTION
### Description of changes
[Isolated Regions] Remove integration tests  covering custom resource from isolated regions test config.
The feature is not supported in isolated regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
