### PR TITLE
[release-3.8][Isolated Region] c5a instance Family is not available in Isolated regions

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -27,7 +27,7 @@ Scheduling:
         - Name: ondemand1-i2
           Instances:
             - InstanceType: c5.xlarge
-            - InstanceType: c5a.xlarge
+            - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
           MinCount: 1
         - Name: ondemand1-i3

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -28,7 +28,7 @@ Scheduling:
         - Name: ondemand1-i2
           Instances:
             - InstanceType: c5.xlarge
-            - InstanceType: c5a.xlarge
+            - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
           MinCount: 1
         - Name: ondemand1-i3

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -24,7 +24,7 @@ Scheduling:
         - Name: ondemand1-i2
           Instances:
             - InstanceType: c5.xlarge
-            - InstanceType: c5a.xlarge
+            - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
           MinCount: 1
         - Name: ondemand1-i3


### PR DESCRIPTION
### Description of changes
c5a instance Family is not available in Isolated regions

### Tests
* Locally created the cluster config and ran the test in us-east-1

develop https://github.com/aws/aws-parallelcluster/pull/5945

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
