### PR TITLE
[Test] Inject partition into policy ARNs for ad, accounting and performance tests.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -76,8 +76,8 @@ Resources:
               Service: ec2.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
       Policies:
         - PolicyDocument:
             Statement:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
@@ -76,8 +76,8 @@ Resources:
               Service: ec2.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
       Policies:
         - PolicyDocument:
             Statement:

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
     S3Access:
       - BucketName: performance-tests-resources-for-parallelcluster
         KeyName: openfoam/*
@@ -36,7 +36,7 @@ Scheduling:
           {% if instance == "c5n.18xlarge" %}Name: c5n_capacity_reservation{% endif %}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
 SharedStorage:
   - MountDir: /shared
     Name: shared-fsx

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
@@ -9,7 +9,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -24,4 +24,4 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status

--- a/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
@@ -8,8 +8,8 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
-      - Policy: arn:aws:iam::aws:policy/CloudWatchFullAccess # Required to add performance testing widgets to the cluster dashboard
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
+      - Policy: arn:{{partition}}:iam::aws:policy/CloudWatchFullAccess # Required to add performance testing widgets to the cluster dashboard
     S3Access:
       - BucketName: {{ bucket_bootstrap_scripts }}
         KeyName: {{ bucket_bootstrap_scripts_prefix }}/*
@@ -35,7 +35,7 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status
         S3Access:
           - BucketName: {{ bucket_bootstrap_scripts }}
             KeyName: {{ bucket_bootstrap_scripts_prefix }}/*

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -9,7 +9,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
     S3Access:
       - BucketName: performance-tests-resources-for-parallelcluster
         KeyName: starccm/*
@@ -42,7 +42,7 @@ Scheduling:
           {% if instance == "c5n.18xlarge" %}Name: c5n_capacity_reservation{% endif %}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
 {% if install_extra_deps %}
         S3Access:
           - BucketName: {{ bucket_name }}

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -8,7 +8,7 @@ HeadNode:
       - {{ database_client_security_group }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -34,7 +34,7 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Monitoring:
   Logs:
     CloudWatch:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -8,7 +8,7 @@ HeadNode:
       - {{ database_client_security_group }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -33,7 +33,7 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Monitoring:
   Logs:
     CloudWatch:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
@@ -8,7 +8,7 @@ HeadNode:
       - {{ database_client_security_group }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -33,7 +33,7 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Monitoring:
   Logs:
     CloudWatch:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
@@ -6,7 +6,7 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -26,7 +26,7 @@ Scheduling:
           - {{ private_subnet_id }}
       Iam:
         AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Monitoring:
   Logs:
     CloudWatch:


### PR DESCRIPTION
### Description of changes
Inject partition into policy ARNs for ad, accounting and performance tests.
For Slurm accounting we also replaced the additional policy `AmazonSSMFullAccess` with `AmazonSSMManagedInstanceCore` because `AmazonSSMFullAccess` is not actually required and it is also missing in US isolated regions.

The `partition` variable is always injected into the cluster config file by this [code](https://github.com/aws/aws-parallelcluster/blob/afa1b0a3b8b5cb717c23fe718fb27235553ef632/tests/integration-tests/conftest.py#L839-L839).

### Tests
* Executed integ test `test_ad_integration`
* Executed integ test `test_slurm_accounting`
* Executed integ test `test_slurm_accounting_disabled_to_enabled_update`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
