### PR TITLE
[Test][Isolated Regions] Restrict us-isob-east-1 test only in 2 AZs + ignore unsupported integ tests + increase monitoring time in us-iso regions.

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -559,11 +559,14 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-    test_update.py::test_multi_az_create_and_update:
-      dimensions:
-        - regions: {{ REGIONS }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
+# This test cannot be executed in US isolated regions
+# because it uses CloudFormation resources that are not available in the regions:
+# CapacityReservation and ResourceGroup.
+#    test_update.py::test_multi_az_create_and_update:
+#      dimensions:
+#        - regions: {{ REGIONS }}
+#          oss: {{ OSS }}
+#          schedulers: {{ SCHEDULERS }}
   log_rotation:
     test_log_rotation.py::test_log_rotation:
       dimensions:

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -56,6 +56,8 @@ AVAILABLE_AVAILABILITY_ZONE = {
     "eu-central-1": ["euc1-az2", "euc1-az3"],
     # FSx not available in cnn1-az4
     "cn-north-1": ["cnn1-az1", "cnn1-az2"],
+    # Should only consider supported AZs
+    "us-isob-east-1": ["us-isob-east-1b", "us-isob-east-1c"],
 }
 
 # used to map a ZoneId to the corresponding region

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -71,11 +71,14 @@ def test_multiple_jobs_submission(
     remote_command_executor.run_remote_script(test_datadir / "cluster-check.sh", args=["submit", scheduler])
 
     logging.info("Monitoring ec2 capacity and compute nodes")
+    monitoring_buffer_minutes = 10 if "us-iso" in region else 5
     ec2_capacity_time_series, compute_nodes_time_series, timestamps = get_compute_nodes_allocation(
         scheduler_commands=scheduler_commands,
         region=region,
         stack_name=cluster.cfn_name,
-        max_monitoring_time=minutes(max_jobs_execution_time) + minutes(scaledown_idletime) + minutes(5),
+        max_monitoring_time=minutes(max_jobs_execution_time)
+        + minutes(scaledown_idletime)
+        + minutes(monitoring_buffer_minutes),
     )
 
     logging.info("Verifying test jobs completed successfully and in the expected time")

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -463,7 +463,7 @@ def assert_subnet_az_relations_from_config(
     # If caller does not expect same az, we expect more availability zones.
     elif region == "us-isob-east-1":
         # us-isob-east-1 provides 2 availability zones.
-        assert_that(len(set(cluster_avail_zones))).is_equal_to(3)
+        assert_that(len(set(cluster_avail_zones))).is_equal_to(2)
     else:
         # For other regions, we impose a strong check to make sure each subnet is in a different availability zone.
         assert_that(len(set(cluster_avail_zones))).is_equal_to(len(cluster_avail_zones))


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/5948

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
