### PR TITLE
[Test] Make StarCCM+/OpenFOAM performance test use the capacity reser…

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
@@ -28,6 +28,10 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
+          { % if instance == "c5n.18xlarge" % }
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: arn:aws:resource-groups:eu-west-1:447714826191:group/EC2CRGroup
+          { % endif % }
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -34,6 +34,10 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
+          {% if instance == "c5n.18xlarge" %}
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: arn:aws:resource-groups:eu-west-1:447714826191:group/EC2CRGroup
+          {% endif %}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
Make StarCCM+/OpenFOAM performance test use the capacity reservation.

### Tests
* [ONGOING] Executed StarCCM+ perf test (no need to execute OpenFOAM as the change is the same)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
