### PR TITLE
[Test] Adapt tests to be executed in US isolated regions: test_slurm_cli_commands, test_fast_capacity_failover, test_create_wrong_pcluster_version.

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -23,6 +23,8 @@ from assertpy import assert_that
 from dateutil.parser import parse as date_parse
 from framework.credential_providers import run_pcluster_command
 from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+from time_utils import minutes, seconds
 from utils import (
     check_pcluster_list_cluster_log_streams,
     check_status,
@@ -325,10 +327,12 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster):
     boto3.client("s3").put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
     # test with a prefix and an output file
     bucket_prefix = "test_prefix"
-    _test_export_log_files_are_expected(cluster, bucket_name, instance_ids, bucket_prefix)
+    retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
+        cluster, bucket_name, instance_ids, bucket_prefix
+    )
 
     # test export-cluster-logs with filter option
-    _test_export_log_files_are_expected(
+    retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
         cluster, bucket_name, headnode_instance_id, bucket_prefix, filters="Name=node-type,Values=HeadNode"
     )
 

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -55,7 +55,7 @@ def test_create_wrong_pcluster_version(
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
-    wrong_version = "3.5.1"
+    wrong_version = "3.6.1"
     logging.info("Asserting wrong_version is different from current_version")
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -647,7 +647,7 @@ def test_fast_capacity_failover(
         exception_multi_static_nodes,
         exception_multi_dynamic_nodes,
         target_compute_resource="exception-cr-multiple",
-        expected_error_code="InvalidParameterValue",
+        expected_error_code="InvalidParameter" if "us-iso" in region else "InvalidParameterValue",
     )
 
 


### PR DESCRIPTION
### Description of changes
Adapted tests to be executed in US isolated regions: 
* test_slurm_cli_commands: wrap a retrieval&assert on logs within a retry logic so that the test is more robust on cw logs latencies.
* test_fast_capacity_failover: the error code returned by EC2 is _InvalidParameter_ in US isolated regions and _InvalidParameterValue_ in any other region.
* test_create_wrong_pcluster_version: use 3.6.1 rather than 3.5.1 as old AMI to select because 3.6.1 is the oldest AMI in us-iso-east-1.

### Tests
* Executed test_slurm_cli_commands
* Executed test_fast_capacity_failover
* Executed test_create_wrong_pcluster_version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
