### PR TITLE
[release-3.8] Execute latest version of NCCL tests

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -4,9 +4,9 @@ set -e
 rm -rf /shared/${1}
 
 module load ${1}
-NCCL_BENCHMARKS_VERSION='2.10.0'
-NCCL_VERSION='2.7.8-1'
-OFI_NCCL_VERSION='1.1.1'
+NCCL_BENCHMARKS_VERSION='2.13.8'
+NCCL_VERSION='2.19.4-1'
+OFI_NCCL_VERSION='1.7.4-aws'
 MPI_HOME=$(which mpirun | awk -F '/bin' '{print $1}')
 NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80" # Arch for NVIDIA A100
 

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -3,9 +3,10 @@
 #SBATCH --exclusive
 #SBATCH --ntasks-per-node=8
 
-
 module load openmpi
-NCCL_VERSION='2.7.8-1'
+NCCL_VERSION='2.19.4-1'
+NCCL_BENCHMARKS_VERSION='2.13.8'
+
 mpirun \
 -x FI_PROVIDER="efa" \
 -x FI_EFA_USE_DEVICE_RDMA=1 \
@@ -15,4 +16,4 @@ mpirun \
 -x NCCL_DEBUG=WARNING \
 -x NCCL_PROTO=simple \
 --mca pml ^cm --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --bind-to none \
-/shared/openmpi/nccl-tests-2.10.0/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out
+/shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out


### PR DESCRIPTION
### Description of changes
Upgrade NCCL version, NCCL Benchmarks versions and OFI NCCL version.
* NCCL_BENCHMARKS_VERSION from 2.10.0 to 2.13.8
* NCCL_VERSION from 2.7.8-1 to 2.19.4-1
* OFI_NCCL_VERSION from 1.1.1 to 1.7.4-aws

### Tests

Print test output.

Improve test assertion to be more robust by searching for specific packet size 1073741824
and specific number of elements 268435456.

### References
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl-base.html#nccl-start-base-tests
* Cherry pick of: https://github.com/aws/aws-parallelcluster/pull/5962
