### PR TITLE
[release-3.8][Test][Isolated Regions] Fix AZ overrides and test_ebs_multiple when running in US iso regions

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -57,7 +57,7 @@ AVAILABLE_AVAILABILITY_ZONE = {
     # FSx not available in cnn1-az4
     "cn-north-1": ["cnn1-az1", "cnn1-az2"],
     # Should only consider supported AZs
-    "us-isob-east-1": ["us-isob-east-1b", "us-isob-east-1c"],
+    "us-isob-east-1": ["usibe1-az2", "usibe1-az3"],
 }
 
 # used to map a ZoneId to the corresponding region

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -96,6 +96,7 @@ SharedStorage:
       Size: {{ volume_sizes[2] }}
       {% if "-iso" in region %}
       VolumeType: gp3
+      Iops: 3000
       {% else %}
       VolumeType: io2
       Iops: 150


### PR DESCRIPTION
### Description of changes
Fix AZ overrides and test_ebs_multiple when running in US iso regions. In particular, 
* specified the AZ override for us-isob-east-1 with AZ IDs as expected rather than AZ names.
* include Iops when test_ebs_multiple uses gp3 EBS volumes in US iso regions.

### Tests
* Validated in US iso regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
