### PR TITLE
[release-3.8][Isolated Regions][Integ Tests] Removing one of the unsupported AZ's

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -223,6 +223,9 @@ def get_availability_zones(region, credential):
 def get_az_setup_for_region(region: str, credential: list):
     """Return a default AZ ID and its name, the list of all AZ IDs and names."""
     az_id_to_az_name_map = get_az_id_to_az_name_map(region, credential)
+    if "us-isob-east-1" in region:
+        # Removing One of the Az's from Isolated regions
+        az_id_to_az_name_map.pop("usibe1-az1", "")
     az_ids = list(az_id_to_az_name_map)  # cannot be a dict_keys
     default_az_id = random.choice(AVAILABLE_AVAILABILITY_ZONE.get(region, az_ids))
     default_az_name = az_id_to_az_name_map.get(default_az_id)


### PR DESCRIPTION
Removing one of the unsupported AZ's from an Isolated region
develop https://github.com/aws/aws-parallelcluster/pull/5970
integ-tests-3.8.0 https://github.com/aws/aws-parallelcluster/pull/5972

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
