### PR TITLE
[develop] Extend NCCL test to p5.48xlarge

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -36,7 +36,11 @@ def assert_instance_replaced_or_terminating(instance_id, region):
 def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False, ignore_patterns=None):
     __tracebackhide__ = True
 
-    ice_patterns = ["InsufficientInstanceCapacity", "Failed to launch instances due to limited EC2 capacity"]
+    ice_patterns = [
+        "InsufficientInstanceCapacity",
+        "Insufficient capacity",
+        "Failed to launch instances due to limited EC2 capacity",
+    ]
 
     patterns_to_ignore = []
     if skip_ice:

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+exec &>/shared/init_nccl.out
+set -xe
 
 rm -rf /shared/${1}
 
@@ -8,7 +9,7 @@ NCCL_BENCHMARKS_VERSION='2.13.8'
 NCCL_VERSION='2.19.4-1'
 OFI_NCCL_VERSION='1.7.4-aws'
 MPI_HOME=$(which mpirun | awk -F '/bin' '{print $1}')
-NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80" # Arch for NVIDIA A100
+NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_90,code=compute_90" # Arch for NVIDIA A100 and H100, ref https://docs.nvidia.com/cuda/ada-compatibility-guide/index.html
 
 mkdir -p /shared/${1}
 
@@ -24,7 +25,7 @@ cd /shared/${1}
 wget https://github.com/NVIDIA/nccl-tests/archive/v${NCCL_BENCHMARKS_VERSION}.tar.gz
 tar zxvf "v${NCCL_BENCHMARKS_VERSION}.tar.gz"
 cd "nccl-tests-${NCCL_BENCHMARKS_VERSION}/"
-NVCC_GENCODE="${NVCC_GENCODE}" make MPI=1 MPI_HOME=${MPI_HOME} NCCL_HOME=/shared/${1}/nccl-${NCCL_VERSION}/build/
+NVCC_GENCODE="${NVCC_GENCODE}" make MPI=1 MPI_HOME=${MPI_HOME} NCCL_HOME=/shared/${1}/nccl-${NCCL_VERSION}/build/ CUDA_HOME=/usr/local/cuda
 
 wget https://github.com/aws/aws-ofi-nccl/archive/v${OFI_NCCL_VERSION}.tar.gz
 tar xvfz v${OFI_NCCL_VERSION}.tar.gz


### PR DESCRIPTION
### Description of changes
* Extend NCCL test to p5.48xlarge
* Add "Insufficient capacity" as ice pattern to exclude from log error check

### Tests
* tested with 
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: ["use1-az5"]
          instances: ["p5.48xlarge"]
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
```

### References
* n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
