### PR TITLE
[Integ-tests-3.8.0] Add SSM VPC Endpoints

### DIFF
--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -249,6 +249,24 @@ class NetworkTemplateBuilder:
                 enable_private_dns=True,
             ),
             VPCEndpointConfig(
+                name="SystemsManagerEndpoint",
+                service_name=f"com.amazonaws.{region}.ssm",
+                type=VPCEndpointConfig.EndpointType.INTERFACE,
+                enable_private_dns=True,
+            ),
+            VPCEndpointConfig(
+                name="SystemsManagerMessagesEndpoint",
+                service_name=f"com.amazonaws.{region}.ssmmessages",
+                type=VPCEndpointConfig.EndpointType.INTERFACE,
+                enable_private_dns=True,
+            ),
+            VPCEndpointConfig(
+                name="EC2MessagesEndpoint",
+                service_name=f"com.amazonaws.{region}.ec2messages",
+                type=VPCEndpointConfig.EndpointType.INTERFACE,
+                enable_private_dns=True,
+            ),
+            VPCEndpointConfig(
                 name="S3Endpoint",
                 service_name=f"com.amazonaws.{region}.s3",
                 type=VPCEndpointConfig.EndpointType.GATEWAY,


### PR DESCRIPTION
### Description of changes
Add SSM VPC Endpoints to be leveraged when testing cluster in isolated networking. These endpoints will allow SSM instance agent to be able to communicate with SSM service. Ref https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html#sysman-setting-up-vpc-create

Signed-off-by: Luca Carrogu <carrogu@amazon.com>
(cherry picked from commit b12c67345498883baa776f939e3e1f868d992c41)

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
