### PR TITLE
[develop] Upgrade Lambda Runtime for Pcluster Lambda Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 **CHANGES**
 - Upgrade Slurm to 23.11.1.
 - Add support for Python 3.11, 3.12 in pcluster CLI and aws-parallelcluster-batch-cli.
+- Upgrade Python to version 3.12 and NodeJS to version 18 in ParallelCluster Lambda Layer.
 
 3.8.0
 ------

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -200,7 +200,7 @@ Resources:
           - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
           - { Version: !FindInMap [ParallelCluster, Constants, Version]}
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
 
   # We need to define three AWS::Serverless::Api due to an issue with the handling of AWS::NoValue
   # See related GitHub issue: https://github.com/aws/serverless-application-model/issues/1435
@@ -294,7 +294,7 @@ Resources:
           Value: api
         - Key: 'parallelcluster:version'
           Value: !FindInMap [ParallelCluster, Constants, Version]
-      Runtime: python3.9
+      Runtime: python3.12
       Handler: pcluster.api.awslambda.entrypoint.lambda_handler
       Layers:
         - !Ref PclusterLayer

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -45,7 +45,7 @@ Resources:
         - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
         - { Version: !FindInMap [ParallelCluster, Constants, Version] }
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
 
   PclusterPolicies:
     Condition: UsePCPolicies
@@ -340,7 +340,7 @@ Resources:
               helper(event, context)
 
       Handler: index.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !If [CustomRoleCondition, !Ref CustomLambdaRole, !GetAtt PclusterLambdaRole.Arn]
       Layers:
         - !Ref PclusterLayer
@@ -394,7 +394,7 @@ Resources:
                   reason = str(e)
               cfnresponse.send(event, context, response_status, {}, event.get('PhysicalResourceId', 'CleanupS3bucketCustomResource'), reason)
       Handler: index.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !If [CustomRoleCondition, !Ref CustomLambdaRole, !GetAtt PclusterLambdaRole.Arn]
 
   CleanupS3bucketCustomResource:

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -30,7 +30,7 @@ from framework.fixture_utils import xdist_session_fixture
 from tests.common.utils import get_installed_parallelcluster_version
 
 logger = logging.getLogger()
-NODE_VERSION = "v16.19.0"  # maintenance version compatible with alinux2's GLIBC
+NODE_VERSION = "v18.18.2"
 
 
 def install_pc(basepath, pc_version):

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -40,7 +40,9 @@ def install_pc(basepath, pc_version):
     cli_dir = root / "cli"
     try:
         logger.info("installing ParallelCluster packages...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{cli_dir}[awslambda]", "-t", tempdir])
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "jsonschema==4.17.3", f"{cli_dir}[awslambda]", "-t", tempdir]
+        )
         # The following are provided by the lambda runtime
         shutil.rmtree(tempdir / "botocore")
         shutil.rmtree(tempdir / "boto3")


### PR DESCRIPTION
### Description of changes
* We would like to upgrade NodeJS for pcluster Lambda Layer to v18 to stop using v16, which is EOL. Amazon Linux 2 does not support NodeJS v18. Therefore, we need to upgrade Lambda runtime to Python 3.12 to use Amazon Linux 2023. For more information about Lambda runtime, see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

### Tests
Manually tested cluster creation.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
