### PR TITLE
Add 0 as an option for RetentionInDays cluster config param to not update CW log retention

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -816,7 +816,7 @@ class CloudWatchLogsSchema(BaseSchema):
 
     enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     retention_in_days = fields.Int(
-        validate=validate.OneOf([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]),
+        validate=validate.OneOf([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
     deletion_policy = fields.Str(

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -229,6 +229,8 @@ def get_cloud_watch_logs_policy_statement(resource: str) -> iam.PolicyStatement:
 
 def get_cloud_watch_logs_retention_days(config: BaseClusterConfig) -> int:
     """Return value to use for CloudWatch logs retention days."""
+    if config.monitoring.logs.cloud_watch.retention_in_days == 0:
+        return None
     return (
         config.monitoring.logs.cloud_watch.retention_in_days
         if config.is_cw_logging_enabled

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -192,6 +192,7 @@ def test_custom_ami_validator(custom_ami, expected_message):
     "retention_in_days, expected_message",
     [
         # right value
+        (0, None),
         (1, None),
         (14, None),
         (180, None),


### PR DESCRIPTION
### Description of changes
* Allow 0 as an option for `RetentionInDays` cluster config parameter
  * Setting that value to be 0 does not change the CW log retention days and instead uses the [CW default, which is indefinite](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention).
    * Right now, the pcluster `RetentionInDays` [default value is 180 days without an option to never expire](https://docs.aws.amazon.com/parallelcluster/latest/ug/Monitoring-v3.html#yaml-Monitoring-Logs-CloudWatch-RetentionInDays). Even if the user doesn't specify `RetentionInDays`, pcluster will automatically make it 180 days. 
    * We want to allow this 0 value because some customers may have restrictions on updating log retentions
* `get_cloud_watch_logs_retention_days` is used when calling `logs.CfnLogGroup()` which passes in the return value for `retention_in_days` (such as in [awsbatch_builder.py](https://github.com/judysng/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/awsbatch_builder.py#L532)). `retention_in_days` is `None` by default in `logs.CfnLogGroup()`, so passing in `None` will use the default retention.

### Tests
* Created a cluster with a cluster config with RetentionInDays as 0
* Created a cluster with a cluster config with RetentionInDays as 1, then ran update-cluster with RetentionInDays as 0. The retention policy updated to never expire, the default.
* Ran cloud watch logs integration test with retention days as 0

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
