### PR TITLE
Build net interfaces using NetworkCards list instead of MaximumNetworkCards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ CHANGELOG
 - Upgrade Slurm to 23.11.1.
 - Add support for Python 3.11, 3.12 in pcluster CLI and aws-parallelcluster-batch-cli.
 - Upgrade Python to version 3.12 and NodeJS to version 18 in ParallelCluster Lambda Layer.
+- Build network interfaces using network card index from `NetworkCardIndex` list of EC2 DescribeInstances response, 
+  instead of looping over `MaximumNetworkCards` range.  
 
 3.8.0
 ------

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -232,9 +232,17 @@ class InstanceTypeInfo:
 
         return cores
 
-    def max_network_interface_count(self) -> int:
+    def max_network_cards(self) -> int:
         """Max number of NICs for the instance."""
-        return int(self.instance_type_data.get("NetworkInfo", {}).get("MaximumNetworkCards", 1))
+        return len(self.instance_type_data.get("NetworkInfo", {}).get("NetworkCards"))
+
+    def network_cards_index_list(self) -> list:
+        """List of NIC indexes for the instance."""
+        return [
+            int(nic.get("NetworkCardIndex"))
+            for nic in self.instance_type_data.get("NetworkInfo", {}).get("NetworkCards")
+            if nic.get("NetworkCardIndex") is not None
+        ]
 
     def default_threads_per_core(self):
         """Return the default threads per core for the given instance type."""

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1172,7 +1172,7 @@ class ClusterCdkStack:
                 network_interface_id=self._head_eni.ref,
             )
         ]
-        for network_interface_index in range(1, head_node.max_network_interface_count):
+        for network_interface_index in head_node.network_cards_index_list[1:]:
             head_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
                     device_index=1,

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -158,11 +158,11 @@ class QueuesStack(NestedStack):
             )
         ]
 
-        for network_interface_index in range(1, compute_resource.max_network_interface_count):
+        for network_card_index in compute_resource.network_cards_index_list[1:]:
             compute_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
                     device_index=0,
-                    network_card_index=network_interface_index,
+                    network_card_index=network_card_index,
                     associate_public_ip_address=False,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -194,7 +194,7 @@ class InstancesNetworkingValidator(Validator, _FlexibleInstanceTypesValidatorMix
         have a varying number of 'maximum network interface cards', the smallest one is used  in the  launch template.
         """
         unique_maximum_nic_counts = {
-            instance_type_info.max_network_interface_count()
+            instance_type_info.max_network_cards()
             for instance_type_name, instance_type_info in instance_types_info.items()
         }
 

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -37,7 +37,8 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         self,
         instance_type,
         gpu_count=0,
-        interfaces_count=1,
+        cards_count=1,
+        cards_index_list=None,
         vcpus=1,
         supported_architectures=None,
         efa_supported=False,
@@ -46,7 +47,8 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
     ):
         super().__init__(instance_type_data={})
         self._gpu_count = gpu_count
-        self._max_network_interface_count = interfaces_count
+        self._max_network_card_count = cards_count
+        self._network_cards_index_list = cards_index_list if cards_index_list else []
         self._vcpus = vcpus
         self._supported_architectures = supported_architectures if supported_architectures else ["x86_64"]
         self._efa_supported = efa_supported
@@ -57,8 +59,11 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
     def gpu_count(self):
         return self._gpu_count
 
-    def max_network_interface_count(self):
-        return self._max_network_interface_count
+    def max_network_cards(self):
+        return self._max_network_card_count
+
+    def network_cards_index_list(self):
+        return self._network_cards_index_list
 
     def default_threads_per_core(self):
         # There are more instance types, but for the simplicity of the mock,

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure.py
@@ -32,7 +32,7 @@ def _mock_instance_type_info(mocker, instance_type="t2.micro"):
             {
                 "InstanceType": instance_type,
                 "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
-                "NetworkInfo": {"EfaSupported": False},
+                "NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]},
             }
         ),
     )
@@ -314,7 +314,7 @@ def _mock_aws_api_required_calls(mocker):
                 {
                     "InstanceType": instance_type,
                     "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
-                    "NetworkInfo": {"EfaSupported": False},
+                    "NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]},
                 }
             )
             for instance_type in supported_instance_types

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -254,7 +254,15 @@ def _mock_instance_type_info(instance_type):
                     "ValidThreadsPerCore": [1, 2],
                 },
                 "EbsInfo": {"EbsOptimizedSupport": "default"},
-                "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 3},
+                "NetworkInfo": {
+                    "EfaSupported": False,
+                    "MaximumNetworkCards": 3,
+                    "NetworkCards": [
+                        {"NetworkCardIndex": 0},
+                        {"NetworkCardIndex": 1},
+                        {"NetworkCardIndex": 2},
+                    ],
+                },
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
         ),
@@ -269,7 +277,14 @@ def _mock_instance_type_info(instance_type):
                     "ValidThreadsPerCore": [1, 2],
                 },
                 "EbsInfo": {"EbsOptimizedSupport": "unsupported"},
-                "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 2},
+                "NetworkInfo": {
+                    "EfaSupported": False,
+                    "MaximumNetworkCards": 2,
+                    "NetworkCards": [
+                        {"NetworkCardIndex": 0},
+                        {"NetworkCardIndex": 1},
+                    ],
+                },
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
         ),

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -185,7 +185,11 @@ def test_init_from_instance_type(mocker, caplog):
                     "ValidCores": [1, 2],
                     "ValidThreadsPerCore": [1, 2],
                 },
-                "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
+                "NetworkInfo": {
+                    "EfaSupported": False,
+                    "MaximumNetworkCards": 1,
+                    "NetworkCards": [{"NetworkCardIndex": 0}],
+                },
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
         ),
@@ -193,7 +197,8 @@ def test_init_from_instance_type(mocker, caplog):
     c4_instance_info = AWSApi.instance().ec2.get_instance_type_info("c4.xlarge")
     assert_that(c4_instance_info.gpu_count()).is_equal_to(0)
     assert_that(caplog.text).is_empty()
-    assert_that(c4_instance_info.max_network_interface_count()).is_equal_to(1)
+    assert_that(c4_instance_info.max_network_cards()).is_equal_to(1)
+    assert_that(c4_instance_info.network_cards_index_list()).is_equal_to([0])
     assert_that(c4_instance_info.cores_count()).is_equal_to(2)
     assert_that(c4_instance_info.default_threads_per_core()).is_equal_to(2)
     assert_that(c4_instance_info.vcpus_count()).is_equal_to(4)
@@ -207,7 +212,16 @@ def test_init_from_instance_type(mocker, caplog):
                 "InstanceType": "g4dn.metal",
                 "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
                 "GpuInfo": {"Gpus": [{"Name": "T4", "Manufacturer": "NVIDIA", "Count": 8}]},
-                "NetworkInfo": {"EfaSupported": True, "MaximumNetworkCards": 4},
+                "NetworkInfo": {
+                    "EfaSupported": True,
+                    "MaximumNetworkCards": 4,
+                    "NetworkCards": [
+                        {"NetworkCardIndex": 0},
+                        {"NetworkCardIndex": 1},
+                        {"NetworkCardIndex": 2},
+                        {"NetworkCardIndex": 3},
+                    ],
+                },
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
         ),
@@ -215,7 +229,8 @@ def test_init_from_instance_type(mocker, caplog):
     g4dn_instance_info = AWSApi.instance().ec2.get_instance_type_info("g4dn.metal")
     assert_that(g4dn_instance_info.gpu_count()).is_equal_to(8)
     assert_that(caplog.text).is_empty()
-    assert_that(g4dn_instance_info.max_network_interface_count()).is_equal_to(4)
+    assert_that(g4dn_instance_info.max_network_cards()).is_equal_to(4)
+    assert_that(g4dn_instance_info.network_cards_index_list()).is_equal_to([0, 1, 2, 3])
     assert_that(g4dn_instance_info.default_threads_per_core()).is_equal_to(2)
     assert_that(g4dn_instance_info.vcpus_count()).is_equal_to(96)
     assert_that(g4dn_instance_info.supported_architecture()).is_equal_to(["x86_64"])
@@ -234,7 +249,11 @@ def test_init_from_instance_type(mocker, caplog):
                     "ValidThreadsPerCore": [1, 2],
                 },
                 "GpuInfo": {"Gpus": [{"Name": "*", "Manufacturer": "AMD", "Count": 4}]},
-                "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
+                "NetworkInfo": {
+                    "EfaSupported": False,
+                    "MaximumNetworkCards": 1,
+                    "NetworkCards": [{"NetworkCardIndex": 0}],
+                },
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
         ),
@@ -242,7 +261,8 @@ def test_init_from_instance_type(mocker, caplog):
     g4ad_instance_info = AWSApi.instance().ec2.get_instance_type_info("g4ad.16xlarge")
     assert_that(g4ad_instance_info.gpu_count()).is_equal_to(0)
     assert_that(g4ad_instance_info.gpu_manufacturer()).is_equal_to("AMD")
-    assert_that(g4ad_instance_info.max_network_interface_count()).is_equal_to(1)
+    assert_that(g4ad_instance_info.max_network_cards()).is_equal_to(1)
+    assert_that(g4ad_instance_info.network_cards_index_list()).is_equal_to([0])
     assert_that(g4ad_instance_info.default_threads_per_core()).is_equal_to(2)
     assert_that(g4ad_instance_info.vcpus_count()).is_equal_to(64)
     assert_that(g4ad_instance_info.supported_architecture()).is_equal_to(["x86_64"])

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -59,7 +59,7 @@ def test_compute_instance_type_validator(mocker, instance_type, max_vcpus, expec
             {
                 "InstanceType": instance_type,
                 "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
-                "NetworkInfo": {"EfaSupported": False},
+                "NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]},
             }
         ),
     )

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -337,9 +337,15 @@ def test_instances_accelerators_validator(compute_resource_name, instance_types_
         (
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "c5n.18xlarge": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": True}}),
+                "t2.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "c5n.18xlarge": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": True, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
             },
             True,
             False,
@@ -349,8 +355,12 @@ def test_instances_accelerators_validator(compute_resource_name, instance_types_
         (
             "TestComputeResource",
             {
-                "c5n.9xlarge": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": True}}),
-                "c5n.18xlarge": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": True}}),
+                "c5n.9xlarge": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": True, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "c5n.18xlarge": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": True, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
             },
             True,
             False,
@@ -360,9 +370,15 @@ def test_instances_accelerators_validator(compute_resource_name, instance_types_
         (
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "c5n.18xlarge": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": True}}),
+                "t2.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "c5n.18xlarge": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": True, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
             },
             False,
             False,
@@ -377,9 +393,15 @@ def test_instances_accelerators_validator(compute_resource_name, instance_types_
         (
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "c5n.18xlarge": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": True}}),
+                "t2.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "c5n.18xlarge": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": True, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
             },
             False,
             True,
@@ -389,8 +411,12 @@ def test_instances_accelerators_validator(compute_resource_name, instance_types_
         (
             "TestComputeResource",
             {
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"EfaSupported": False}}),
+                "t3.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
+                "t2.micro": InstanceTypeInfo(
+                    {"NetworkInfo": {"EfaSupported": False, "NetworkCards": [{"NetworkCardIndex": 0}]}}
+                ),
             },
             True,
             False,
@@ -420,8 +446,30 @@ def test_instances_efa_validator(
             "TestQueue10",
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 2}}),
+                "t2.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 2,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
             },
             False,
             "Compute Resource TestComputeResource has instance types with varying numbers of network cards (Min: 2, "
@@ -431,8 +479,32 @@ def test_instances_efa_validator(
             "TestQueue10",
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
+                "t2.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
             },
             False,
             "",
@@ -443,8 +515,32 @@ def test_instances_efa_validator(
             "TestQueue11",
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
-                "t3.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
+                "t2.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
+                "t3.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
             },
             True,
             "Enabling placement groups for queue: TestQueue11 may result in Insufficient Capacity Errors due to the "
@@ -455,7 +551,19 @@ def test_instances_efa_validator(
             "TestQueue11",
             "TestComputeResource",
             {
-                "t2.micro": InstanceTypeInfo({"NetworkInfo": {"MaximumNetworkCards": 4}}),
+                "t2.micro": InstanceTypeInfo(
+                    {
+                        "NetworkInfo": {
+                            "MaximumNetworkCards": 4,
+                            "NetworkCards": [
+                                {"NetworkCardIndex": 0, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 1, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 2, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                                {"NetworkCardIndex": 3, "NetworkPerformance": "High", "MaximumNetworkInterfaces": 4},
+                            ],
+                        }
+                    }
+                ),
             },
             True,
             "",


### PR DESCRIPTION
### Description of changes
* Build the network interfaces of an instance using the NetworkCards list instead of using MaximumNetworkCards.
  This would allow to customize the network interfaces list by passing a custom instance type data.
  
  The NetworkCards list is validated by the HeadNode and ComputeNode LaunchTemplateValidator respectively.
  The validation message is
```
"message": "Unable to validate configuration parameters for instance type p4de.24xlarge. Please double check your cluster configuration. When specifying network interfaces, you must include a device at index 0 and network card at index 0."
```

### Tests
* added unit tests
* tested manually using compute node with multiple networking interfaces

### References
* n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
