### PR TITLE
[Test][Isolated Regions] Make test_efa use c5n.9xl rather than c5n.18xl in isolated regions.

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -177,7 +177,7 @@ test-suites:
     test_efa.py::test_efa:
       dimensions:
         - regions: {{ REGIONS }}
-          instances: ["c5n.18xlarge"]
+          instances: ["c5n.9xlarge"]
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
 # This test cannot be executed in US isolated regions


### PR DESCRIPTION
### Description of changes
Make `test_efa` use c5n.9xl rather than c5n.18xl in isolated regions. Using c5n.9xl will reduce a lot the risk of having the test blocked by insufficient capacity.
We know that not using c5n.18xl will make the test skip the OSU benchmark in this test, but this is not an issue because:
1. the most important thing is to unblock the basic test for EFA in iso regions
2. we already validate OSU benchmarks in commercial regions

### Tests
1. `test_efa` succeeded in us-isob-east-1 and us-iso-east-1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
