### PR TITLE
[Test][Isolated Regions] Make test_efa use c5n.9xl rather than c5n.18xl in isolated regions

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -177,7 +177,7 @@ test-suites:
     test_efa.py::test_efa:
       dimensions:
         - regions: {{ REGIONS }}
-          instances: ["c5n.18xlarge"]
+          instances: ["c5n.9xlarge"]
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
 # This test cannot be executed in US isolated regions


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/5987

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
