### PR TITLE
Change shellcheck severity level to warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,5 +206,6 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          severity: error
+          severity: warning
+          ignore_paths: tests
           ignore_names: user_data.sh

--- a/api/gradlew
+++ b/api/gradlew
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Copyright 2015 the original author or authors.
@@ -36,9 +36,9 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >/dev/null
+cd "`dirname \"$PRG\"`/" >/dev/null || exit
 APP_HOME="`pwd -P`"
-cd "$SAVED" >/dev/null
+cd "$SAVED" >/dev/null || exit
 
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
@@ -106,10 +106,10 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
-    MAX_FD_LIMIT=`ulimit -H -n`
+if [ "$cygwin" = "false" ] && [ "$darwin" = "false" ] && [ "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=$(ulimit -H -n)
     if [ $? -eq 0 ] ; then
-        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+        if [ "$MAX_FD" = "maximum" ] || [ "$MAX_FD" = "max" ] ; then
             MAX_FD="$MAX_FD_LIMIT"
         fi
         ulimit -n $MAX_FD
@@ -127,14 +127,14 @@ if $darwin; then
 fi
 
 # For Cygwin or MSYS, switch paths to Windows format before running java
-if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
-    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
-    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+if [ "$cygwin" = "true" ] || [ "$msys" = "true" ] ; then
+    APP_HOME=$(cygpath --path --mixed "$APP_HOME")
+    CLASSPATH=$(cygpath --path --mixed "$CLASSPATH")
 
-    JAVACMD=`cygpath --unix "$JAVACMD"`
+    JAVACMD=$(cygpath --unix "$JAVACMD")
 
     # We build the pattern for arguments to be converted via cygpath
-    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    ROOTDIRSRAW=$(find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
     SEP=""
     for dir in $ROOTDIRSRAW ; do
         ROOTDIRS="$ROOTDIRS$SEP$dir"
@@ -148,16 +148,17 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     # Now convert the arguments - kludge to limit ourselves to /bin/sh
     i=0
     for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+        CHECK=$(echo "$arg"|egrep -c "$OURCYGPATTERN" -)
+        CHECK2=$(echo "$arg"|egrep -c "^-")                                 ### Determine if an option
 
         if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
-            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+            eval args$i="$(cygpath --path --ignore --mixed "$arg")"
         else
-            eval `echo args$i`="\"$arg\""
+            eval args$i="\"$arg\""
         fi
-        i=`expr $i + 1`
+        i=$((i+1))
     done
+    # shellcheck disable=SC2154 # Shellcheck doesn't check for dynamic assignments
     case $i in
         0) set -- ;;
         1) set -- "$args0" ;;

--- a/api/gradlew
+++ b/api/gradlew
@@ -21,27 +21,26 @@
 ##  Gradle start up script for UN*X
 ##
 ##############################################################################
-
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"
 # Need this for relative symlinks.
 while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
+    ls=$(ls -ld "$PRG")
+    link=$(expr "$ls" : '.*-> \(.*\)$')
     if expr "$link" : '/.*' > /dev/null; then
         PRG="$link"
     else
-        PRG=`dirname "$PRG"`"/$link"
+        PRG=$(dirname "$PRG")"/$link"
     fi
 done
-SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >/dev/null || exit
-APP_HOME="`pwd -P`"
+SAVED="$(pwd)"
+cd "$(dirname "$PRG")/" >/dev/null || exit
+APP_HOME="$(pwd -P)"
 cd "$SAVED" >/dev/null || exit
 
 APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
+APP_BASE_NAME=$(basename "$0")
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
@@ -65,7 +64,7 @@ cygwin=false
 msys=false
 darwin=false
 nonstop=false
-case "`uname`" in
+case "$(uname)" in
   CYGWIN* )
     cygwin=true
     ;;
@@ -178,7 +177,7 @@ save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }
-APP_ARGS=`save "$@"`
+APP_ARGS=$(save "$@")
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"

--- a/api/infrastructure/deploy-api.sh
+++ b/api/infrastructure/deploy-api.sh
@@ -71,7 +71,6 @@ if [ -z "${S3_BUCKET}" ] || [ -z "${AWS_DEFAULT_REGION}" ] ; then
     exit 1
 fi
 
-ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 S3_UPLOAD_URI="s3://${S3_BUCKET}/api/ParallelCluster.openapi.yaml"
 POLICIES_S3_URI="s3://${S3_BUCKET}/stacks/parallelcluster-policies.yaml"
 POLICIES_TEMPLATE_URI="http://${S3_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/stacks/parallelcluster-policies.yaml"

--- a/api/spec/spec_overrides.sh
+++ b/api/spec/spec_overrides.sh
@@ -2,5 +2,6 @@
 set -ex
 
 YAML_PATH=$1
-export INDEX="$(yq '.paths["/v3/clusters/{clusterName}/logstreams"].get.parameters.[] | select(.name == "filters") | path | .[-1]' "$YAML_PATH")"
+INDEX="$(yq '.paths["/v3/clusters/{clusterName}/logstreams"].get.parameters.[] | select(.name == "filters") | path | .[-1]' "$YAML_PATH")"
+export INDEX
 yq e -i '.paths["/v3/clusters/{clusterName}/logstreams"].get.parameters[env(INDEX)].style = "spaceDelimited"' "$YAML_PATH"

--- a/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
+++ b/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
@@ -34,7 +34,7 @@ build_docker_image() {
 
 if [ -z "${IMAGE}" ]; then
     echo "No image to build specified. Building all images..."
-    for file in $(find `pwd` -type f -name Dockerfile); do
+    find "$(pwd)" -type f -name Dockerfile -print0 | while read -d $'\0' file; do
         IMAGE_TAG=$(dirname "${file}" | xargs basename)
         build_docker_image "${IMAGE_TAG}"
     done

--- a/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -6,7 +6,7 @@ echo "Initializing the environment..."
 
 # Starting ssh agents
 echo "Starting ssh agents..."
-eval $(ssh-agent -s) && ssh-add ${SSHDIR}/id_rsa
+eval "$(ssh-agent -s)" && ssh-add ${SSHDIR}/id_rsa
 /usr/sbin/sshd -f /root/.ssh/sshd_config -h /root/.ssh/ssh_host_rsa_key
 
 # mount nfs
@@ -30,8 +30,6 @@ do
     /parallelcluster/bin/mount_nfs.sh "${PCLUSTER_HEAD_NODE_IP}" "${ebs_shared_dir}"
   fi
 done
-
-ebs_arr=($ebs_shared_dirs)
 
 # mount EFS via nfs
 IFS=',' read -r -a efs_ids <<< "${PCLUSTER_EFS_FS_IDS}"

--- a/cli/src/pcluster/resources/batch/docker/upload-docker-images.sh
+++ b/cli/src/pcluster/resources/batch/docker/upload-docker-images.sh
@@ -17,7 +17,7 @@ push_docker_image() {
 }
 
 if [ -z "${IMAGE}" ]; then
-    for file in $(find `pwd` -type f -name Dockerfile); do
+    find "$(pwd)" -type f -name Dockerfile -print0 | while read -d $'\0' file; do
         IMAGE_TAG=$(dirname "${file}" | xargs basename)
         push_docker_image "${IMAGE_TAG}"
     done

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -14,7 +14,8 @@ _error_exit() {
 }
 
 _help() {
-    local -- _cmd=$(basename "$0")
+    local -- _cmd
+    _cmd=$(basename "$0")
 
     cat <<EOF
 

--- a/util/create-attribution-doc.sh
+++ b/util/create-attribution-doc.sh
@@ -42,7 +42,7 @@ function create_attribution_doc() {
   
   # install pcluster via source
   
-  pip3 install -e $(dirname $ATTR_SCRIPT_DIR )/cli
+  pip3 install -e "$(dirname $ATTR_SCRIPT_DIR )/cli"
   #pip3 install -r requirements.txt
   
   final_license_file=$(dirname $ATTR_SCRIPT_DIR )/THIRD-PARTY-LICENSES.txt
@@ -103,7 +103,8 @@ _error_exit() {
 }
 
 _help() {
-    local -- _cmd=$(basename "$0")
+    local -- _cmd
+    _cmd=$(basename "$0")
 
     cat <<EOF
   This script will create the THIRD_PARTY_LICENSE.txt file assuming you have already installed Pyenv

--- a/util/upload-cli.sh
+++ b/util/upload-cli.sh
@@ -10,7 +10,8 @@ _info() {
 }
 
 _help() {
-    local -- _cmd=$(basename "$0")
+    local -- _cmd
+    _cmd=$(basename "$0")
 
     cat <<EOF
 
@@ -90,10 +91,10 @@ main() {
 
     # Create archive
     _cwd=$(pwd)
-    pushd "${_srcdir}" > /dev/null
+    pushd "${_srcdir}" > /dev/null || exit
     _stashName=$(git stash create)
     git archive --format tar --prefix="aws-parallelcluster-${_pcluster_version}/" "${_stashName:-HEAD}" | gzip > "${_cwd}/aws-parallelcluster-${_pcluster_version}.tgz"
-    popd > /dev/null
+    popd > /dev/null || exit
 
     # upload package
     _key_path="parallelcluster/${_pcluster_version}/cli"


### PR DESCRIPTION
### Description of changes
* Change the shellcheck severity level to warning to discover potential problems earlier
* Ignored the `tests/` folder (many warnings are from the tests)
* Fixed all the other warnings, the warnings are in this check in my [fork](https://github.com/judysng/aws-parallelcluster/actions/runs/7401551031/job/20137537133) 

### Tests
* Some edited files included batch resources, made a batch cluster
* Ran integration test for pcluster API, they fail but with the same failures as develop, but ran gradlew on local and they all worked

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
