### PR TITLE
Disable delete_image inorder to stop the integ test reoccuring error

### DIFF
--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -541,7 +541,7 @@ def test_custom_image(region, api_client, build_image, os, request, pcluster_con
     _test_describe_image(region, client, image_id, "BUILD_COMPLETE")
     _test_list_images(region, client, image_id, "AVAILABLE")
 
-    _delete_image(region, client, image_id)
+    # _delete_image(region, client, image_id)
 
 
 def _test_build_image(client, build_image, image_id, config):


### PR DESCRIPTION
### Description of changes
* Disable delete_image inorder to stop the integ test reoccuring error

test_custom_image
Failure:

`botocore.exceptions.WaiterError: Waiter StackDeleteComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "DELETE_FAILED" at least once`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
