### PR TITLE
Disable test_custom_image to stop reoccuring integ test failure

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -52,11 +52,11 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-    test_api.py::test_custom_image:
-      dimensions:
-        - regions: ["sa-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+    # test_api.py::test_custom_image:
+    #   dimensions:
+    #     - regions: ["sa-east-1"]
+    #       instances: {{ common.INSTANCES_DEFAULT_X86 }}
+    #       oss: ["alinux2"]
     test_api.py::test_login_nodes:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
### Description of changes
* Disable  test_custom_image inorder to stop the integ test reoccuring error

test_custom_image
Failure:

`botocore.exceptions.WaiterError: Waiter StackDeleteComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "DELETE_FAILED" at least once`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
