### PR TITLE
Add validator to fail when a user is not using a custom ami and is using an instance_type that is not supported by openRM

### DIFF
--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -146,6 +146,13 @@ class InstanceTypeBaseAMICompatibleValidator(Validator):
                     ),
                     FailureLevel.ERROR,
                 )
+        unsupported = ["p3", "p2", "g3", "g2"]
+        if "AWS ParallelCluster AMI" in image_info.description and instance_type.split(".")[0] in unsupported:
+            self._add_failure(
+                f"The instance type '{instance_type}' is not supported by OpenRM drivers. "
+                f"A custom AMI must be used.",
+                FailureLevel.ERROR,
+            )
 
     def _validate_base_ami(self, image: str):
         try:


### PR DESCRIPTION
### Description of changes
*Add validator to fail when a user is not using a custom ami and is using an instance_type that is not supported by openRM

### Tests
* Tried launching a cluster with the following configurations to see if the validator work as intended
   * p3 instance_type in the head node
   * p2 instance_type in one of the compute nodes
   * c5 instance_type in both the head and compute nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
