### PR TITLE
[develop][Integ-tests] Fix CloudWatch integration tests

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/cw_agent_debug.sh
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/cw_agent_debug.sh
@@ -14,3 +14,4 @@
 sed -i '$s/}/,\n"agent":{"debug": true}}/' /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json
 # restart cw agent
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json
+sleep 10


### PR DESCRIPTION
The tests add debug mode and restart cw agent. With a new version, the cw agent does not give complete output right after the agent restart. Therefore, this commit adds 10 seconds sleep after the agent restart

### Tests
The following tests have been passed
```
test-suites:
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
      - instances:
        - m6g.xlarge
        oss:
        - ubuntu2204
        regions:
        - us-east-1
        schedulers:
        - slurm
      - instances:
        - c5.xlarge
        oss:
        - centos7
        regions:
        - us-east-1
        schedulers:
        - slurm
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - alinux2
        regions:
        - us-east-1
        schedulers:
        - slurm
    test_dcv.py::test_dcv_with_remote_access:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - centos7
        regions:
        - ap-southeast-2
        schedulers:
        - slurm
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
