### PR TITLE
[external_slurmdbd] Allow traffic from external slurmdbd to slurmctld's

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -204,20 +204,21 @@ class ExternalSlurmdbdStack(Stack):
             description="Allow SSH access to slurmdbd instance (server)",
             vpc=self.vpc,
         )
+
         client_sg = ec2.SecurityGroup(
             self,
             "SSHClientSecurityGroup",
             description="Allow SSH access to slurmdbd instance (client)",
             vpc=self.vpc,
         )
+
         server_sg.add_ingress_rule(
             peer=client_sg, connection=ec2.Port.tcp(22), description="Allow SSH access from client SG"
         )
-        client_sg.add_egress_rule(
-            peer=server_sg, connection=ec2.Port.tcp(22), description="Allow SSH access to server SG"
-        )
+
         return server_sg, client_sg
 
+    # FIXME: make the ingress rules more configurable
     def _add_slurmdbd_accounting_security_groups(self):
         slurmdbd_server_sg = ec2.SecurityGroup(
             self,
@@ -239,10 +240,10 @@ class ExternalSlurmdbdStack(Stack):
             description="Allow Slurm accounting traffic from the cluster head node",
         )
 
-        slurmdbd_client_sg.add_egress_rule(
+        slurmdbd_client_sg.add_ingress_rule(
             peer=slurmdbd_server_sg,
-            connection=ec2.Port.tcp(6819),
-            description="Allow Slurm accounting traffic to the slurmdbd instance",
+            connection=ec2.Port.tcp_range(6820, 6829),
+            description="Allow traffic coming from slurmdbd instance",
         )
 
         return slurmdbd_server_sg, slurmdbd_client_sg


### PR DESCRIPTION
### Description of changes
Add ingress rule in the external dbd client security group to allow connections initiated from the slurmdbd.

Such connections may be established from the slurmdbd's side when the slurmdbd drops and then recovers: in this case it is the slurmdbd attempting to re-establish the connectivity between itself and all the slurmctld's it was previously connected to.

Remove useless egress rules from security groups (all outgoing traffic is enabled by default at the moment).

### Tests
* Manual test with POC external slurmdbd stack confirming that this works.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
