### PR TITLE
[Code Quality] Ignore bandit rules B036 and B038.

### DIFF
--- a/cli/tests/pcluster/models/test_cluster_resources.py
+++ b/cli/tests/pcluster/models/test_cluster_resources.py
@@ -62,7 +62,7 @@ class TestClusterLogsFiltersParser:
         logs_filters = ClusterLogsFiltersParser(mock_head_node, filters)
 
         for attr in expected_attrs:
-            assert_that(getattr(logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
         assert_that(expected_filters_size).is_equal_to(len(logs_filters.filters_list))
 
     @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ class TestExportClusterLogsFiltersParser:
         )
 
         for attr in expected_attrs:
-            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
         "attrs, event_in_window, expected_error",

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -74,7 +74,7 @@ class TestLogGrouptimeFiltersParser:
         )
 
         for attr in expected_attrs:
-            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
         "attrs, event_in_window, log_stream_prefix, expected_error",

--- a/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
+++ b/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
@@ -50,7 +50,7 @@ def generate_plots(datadir, outdir, configurations, nodes):
         # Box Plots
         box_plots = {}
         for configuration in configurations:
-            positions = all_positions[configurations.index(configuration) :: n_configurations]  # noqa: E203
+            positions = all_positions[configurations.index(configuration) :: n_configurations]  # noqa: E203, B038
             box_plots[configuration] = ax.boxplot(
                 data[configuration],
                 patch_artist=True,

--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -157,7 +157,7 @@ class EBSSnapshotsFactory:
                 )
                 ssh_conn.open()
                 tries = 0
-            except BaseException:
+            except BaseException:  # noqa: B036
                 logging.info("SSH connection error - retrying...")
                 tries -= 1
                 time.sleep(20)


### PR DESCRIPTION
### Description of changes
Ignore bandit rules B036 and B038.
B308 are all false positive, B036 can be safely ignored.
These rules started failing today blocking PRs without any changes on our side.

### Tests
* tox -e code-linters

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
