### PR TITLE
[develop] Fix assertion on update resize for TERMINATE case

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -967,7 +967,7 @@ def _test_update_resize(
         assert_that(len(static_nodes)).is_equal_to(0)
         assert_that(len(dynamic_nodes)).is_equal_to(4)
         # assert that job running on static nodes removed with the update is re-queued
-        scheduler_commands.assert_job_state(queue1_job_id, "PENDING")
+        scheduler_commands.wait_job_running(queue1_job_id)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of changes
* Fix assertion on update resize for TERMINATE case
  If the launch of a new dynamic node is fast enough, the job gets re-queued and goes into RUNNING


### Tests
* tests already present

### References
* n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
