### PR TITLE
[DFSM][Test] Add permissions required by DFSM to compute node role defined in 'cluster-roles.cfn.yaml'.

### DIFF
--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -159,6 +159,9 @@ Resources:
             Statement:
               - Action:
                   - dynamodb:Query
+                  - dynamodb:UpdateItem
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
                 Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/parallelcluster-*
                 Effect: Allow
               - Action: s3:GetObject
@@ -168,6 +171,10 @@ Resources:
               - Action: ec2:DescribeInstanceAttribute
                 Effect: Allow
                 Resource: '*'
+              - Action: cloudformation:DescribeStackResource
+                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*/*
             Version: '2012-10-17'
     Type: AWS::IAM::Role
 


### PR DESCRIPTION
### Description of changes
Add permissions required by DFSM to compute node role defined in 'cluster-roles.cfn.yaml'.

In particular, added:
  - cloudformation:DescribeStackResource
  - dynamodb:UpdateItem
  - dynamodb:PutItem
  - dynamodb:GetItem

These permissions for compute nodes have been introduced in https://github.com/aws/aws-parallelcluster/pull/6003

### Tests
1. Integ test `test_iam_roles` passed (previously failing due to the lack of the permissions added in this PR)

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
