### PR TITLE
[DFSM] Load pcluster envars in compute node user data to resolve cfn …

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -125,6 +125,8 @@ write_files:
       }
 
       export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+      # Load ParallelCluster environment variables
+      [ -f /etc/profile.d/pcluster.sh ] && . /etc/profile.d/pcluster.sh
 
       cfn-init -s ${AWS::StackName} -v -c deployFiles -r ${LaunchTemplateResourceId} --region ${AWS::Region} --url ${CloudFormationUrl} --role ${CfnInitRole} || error_exit 'Failed to bootstrap the compute node. Please check /var/log/cfn-init.log in the compute node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs.'
 


### PR DESCRIPTION
### Description of changes
Load pcluster envars in compute node user data to resolve cfn bootstrap scripts, such as cfn-init.
The lack of this change impacts all OS, but AL2, because AL2 comes with its own installation of cfn bootstrap scripts already loaded in the PATH.

This change has been missed in https://github.com/aws/aws-parallelcluster/pull/6003 because we validated that PR with AL2 only.

### Tests
* Without this fix cluster creation on Ubuntu2204 fails because compute node user data fails due to cfn-init not in the PATH.
* With this fix the above creation succeeds.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
