### PR TITLE
[release-3.8] Fix InstanceTypeBaseAMICompatibleValidator to properly handle custom AMIs without description

### DIFF
--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -150,6 +150,7 @@ class InstanceTypeBaseAMICompatibleValidator(Validator):
 
         if (
             image_info
+            and image_info.description
             and "AWS ParallelCluster AMI" in image_info.description
             and instance_type.split(".")[0] in NVIDIA_OPENRM_UNSUPPORTED_INSTANCE_TYPES
         ):

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -319,7 +319,7 @@ def test_instance_type_memory_info_validator(mocker, instance_type, instance_typ
             ["m6g.xlarge", "c5.xlarge"],
             [],
         ),
-        (
+        (  # Test Nvidia OpenRM with AWS ParallelCluster AMI
             "p3.2xlarge",
             "ami-0185634c5a8a37250",
             "The instance type 'p3.2xlarge' is not supported by NVIDIA OpenRM drivers. "
@@ -347,7 +347,7 @@ def test_instance_type_memory_info_validator(mocker, instance_type, instance_typ
             ["p3.2xlarge", "c5.xlarge"],
             ["x86_64"],
         ),
-        (
+        (  # Test Nvidia OpenRM with custom AMI with AMI description
             "p3.2xlarge",
             "ami-0185634c5a8a37250",
             None,
@@ -355,6 +355,31 @@ def test_instance_type_memory_info_validator(mocker, instance_type, instance_typ
                 "ImageId": "ami-0185634c5a8a37250",
                 "Architecture": "x86_64",
                 "Description": "Custom AMI",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": True,
+                            "SnapshotId": "snap-0a20b6671bc5e3ead",
+                            "VolumeSize": 25,
+                            "VolumeType": "gp2",
+                            "Encrypted": False,
+                        },
+                    }
+                ],
+            },
+            None,
+            ["p3.2xlarge", "c5.xlarge"],
+            ["x86_64"],
+        ),
+        (  # Test Nvidia OpenRM with custom AMI without AMI description
+            "p3.2xlarge",
+            "ami-0185634c5a8a37250",
+            None,
+            {
+                "ImageId": "ami-0185634c5a8a37250",
+                "Architecture": "x86_64",
+                "Description": None,
                 "BlockDeviceMappings": [
                     {
                         "DeviceName": "/dev/xvda",


### PR DESCRIPTION
Prior to this PR, when using a custom AMI without description, we got the following error:
```
{
      "level": "ERROR",
      "type": "InstanceTypeBaseAMICompatibleValidator",
      "message": "argument of type 'NoneType' is not iterable"
}
```

### References
The bug was introduced by https://github.com/aws/aws-parallelcluster/pull/6013

cherry pick of https://github.com/aws/aws-parallelcluster/pull/6025

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
