### PR TITLE
[DFSM] Add custom resource to check that all compute nodes have the expected cluster config version.

### DIFF
--- a/cli/pytest.ini
+++ b/cli/pytest.ini
@@ -1,0 +1,15 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[pytest]
+pythonpath =
+    src
+    src/pcluster/resources/custom_resources/custom_resources_code

--- a/cli/src/pcluster/resources/custom_resources/__init__.py
+++ b/cli/src/pcluster/resources/custom_resources/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
@@ -108,6 +108,7 @@ def _terminate_cluster_nodes(event):
         completed_successfully = False
         while not completed_successfully:
             completed_successfully = True
+            # TODO use utils.ec2_utils.list_cluster_instance_ids_iterator to reduce code duplication.
             for instance_ids in _describe_instance_ids_iterator(stack_name):
                 logger.info("Terminating instances %s", instance_ids)
                 if instance_ids:

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/constants.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/constants.py
@@ -1,0 +1,6 @@
+# TAGS
+CLUSTER_NAME_TAG = "parallelcluster:cluster-name"
+NODE_TYPE_TAG = "parallelcluster:node-type"
+
+# DDB
+CLUSTER_CONFIG_DDB_ID = "CLUSTER_CONFIG.{instance_id}"

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/__init__.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/ec2_utils.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/ec2_utils.py
@@ -1,0 +1,67 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import boto3
+from constants import CLUSTER_NAME_TAG, NODE_TYPE_TAG
+from utils.retry_utils import retry
+
+
+@retry(max_retries=5, wait_time_seconds=3)
+def list_cluster_instance_ids_iterator(
+    cluster_name: str,
+    instance_state: [str] = ("pending", "running", "stopping", "stopped"),
+    node_type: [str] = None,
+    batch_size: int = 100,
+    ec2_client=None,
+):
+    """
+    Generate an iterator over batch of cluster instances.
+
+    :param cluster_name: name of the cluster.
+    :param instance_state: list of instance states to include in the filter; default is None.
+    :param node_type: list of node types to include in the filter; default is None.
+    :param batch_size: the maximum size of the batch returned by the iterator; default is 100.
+    :param ec2_client: the EC2 client to use in the requests; default is a plain EC2 client with default settings.
+    :return: the iterator to iterate over batch of cluster instances.
+    """
+    ec2 = ec2_client if ec2_client is not None else boto3.client("ec2")
+
+    filters = _get_filters_to_list_instances(cluster_name, instance_state, node_type)
+
+    pagination_config = {"PageSize": batch_size}
+    paginator = ec2.get_paginator("describe_instances")
+
+    for page in paginator.paginate(Filters=filters, PaginationConfig=pagination_config):
+        instances = []
+        for reservation in page.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                instances.append(instance.get("InstanceId"))
+        yield instances
+
+
+def _get_filters_to_list_instances(cluster_name: str, instance_state: [str] = None, node_type: [str] = None):
+    """
+    Generate a list of filters to be used in EC2 requests to filter cluster instances.
+
+    :param cluster_name: name of the cluster.
+    :param instance_state: list of instance states to include in the filter; default is None.
+    :param node_type: list of node types to include in the filter; default is None.
+    :return: the list of filters.
+    """
+    filters = [{"Name": f"tag:{CLUSTER_NAME_TAG}", "Values": [cluster_name]}]
+
+    if node_type:
+        filters.append({"Name": f"tag:{NODE_TYPE_TAG}", "Values": list(node_type)})
+
+    if instance_state:
+        filters.append({"Name": "instance-state-name", "Values": list(instance_state)})
+
+    return filters

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/retry_utils.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/utils/retry_utils.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def retry(max_retries: int, wait_time_seconds: int):
+    """
+    Retry the decorated function.
+
+    :param max_retries: maximum number of retries.
+                        When reached the inner exception causing the failure is raised.
+    :param wait_time_seconds: wait time between retries, in seconds.
+    :return: None
+    """
+
+    def decorator_retry(func):
+        @functools.wraps(func)
+        def wrapper_retry(*args, **kwargs):
+            retries = 0
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    logger.error(f"Function {func.__name__} failed: {e}")
+                    retries += 1
+                    if retries < max_retries:
+                        logger.info(f"Function {func.__name__} will be retried after {wait_time_seconds} seconds")
+                        time.sleep(wait_time_seconds)
+                    else:
+                        break
+
+            raise Exception(f"Max retries of function {func} exceeded")
+
+        return wrapper_retry
+
+    return decorator_retry

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/wait_cluster_ready.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/wait_cluster_ready.py
@@ -1,0 +1,193 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import string
+
+import boto3
+from botocore.config import Config
+from constants import CLUSTER_CONFIG_DDB_ID
+from crhelper import CfnResource
+from utils.ec2_utils import list_cluster_instance_ids_iterator
+from utils.retry_utils import retry
+
+helper = CfnResource(json_logging=False, log_level="INFO", boto_level="ERROR", sleep_on_delete=0)
+logger = logging.getLogger(__name__)
+BOTO3_CONFIG = Config(retries={"max_attempts": 60})
+BATCH_SIZE = 500
+
+
+@retry(max_retries=5, wait_time_seconds=3)
+def _get_cluster_config_records(table_name: str, instance_ids: [string]):
+    ddb = boto3.client("dynamodb", config=BOTO3_CONFIG)
+
+    if not instance_ids:
+        logger.warning("No instances to retrieve cluster config records for")
+        return []
+
+    item_ids = [CLUSTER_CONFIG_DDB_ID.format(instance_id=instance_id) for instance_id in instance_ids]
+    requested_keys = [{"Id": {"S": item_id}} for item_id in item_ids]
+
+    try:
+        response = ddb.batch_get_item(RequestItems={table_name: {"Keys": requested_keys}})
+        items = response.get("Responses", {}).get(table_name, [])
+    except Exception as e:
+        raise RuntimeError(f"Cannot read config versions due to DDB error: {e}")
+
+    return items
+
+
+def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_config_version: str):
+    missing = []
+    incomplete = []
+    wrong = []
+
+    if not instance_ids:
+        logger.warning("No instances to check cluster config version for")
+        return missing, incomplete, wrong
+
+    # Transform DDB items to make it easier to search.
+    # Example: the original items:
+    # [
+    #   { "Id": { "S": "CLUSTER_CONFIG.i-123456789" },
+    #     "Data": {
+    #       "M": {
+    #         "cluster_config_version": { "HoqyEZYBkMig3gSxaMARUv0NGcG0rrso" },
+    #         "lastUpdateTime": { "2024-01-16 18:59:18 UTC" }
+    #       }
+    #     }
+    #   }
+    # ]
+    #
+    # is transformed into items_by_id:
+    #
+    # {
+    #   "CLUSTER_CONFIG.i-123456789": {
+    #     "cluster_config_version": { "HoqyEZYBkMig3gSxaMARUv0NGcG0rrso" },
+    #     "lastUpdateTime": { "2024-01-16 18:59:18 UTC" }
+    #   }
+    # }
+    items_by_id = {item["Id"]["S"]: item["Data"]["M"] for item in items}
+
+    for instance_id in instance_ids:
+        key = CLUSTER_CONFIG_DDB_ID.format(instance_id=instance_id)
+        data = items_by_id.get(key)
+        if data is None:
+            logger.warning(f"Missing cluster config record for instance {instance_id}")
+            missing.append(instance_id)
+            continue
+        cluster_config_version = data.get("cluster_config_version", {}).get("S")
+        if cluster_config_version is None:
+            logger.warning(f"Missing cluster config version in data for instance {instance_id}")
+            incomplete.append(instance_id)
+            continue
+        if cluster_config_version != expected_config_version:
+            logger.warning(
+                f"Wrong cluster config version for instance {instance_id}; "
+                f"expected {expected_config_version}, but got {cluster_config_version}"
+            )
+            wrong.append(instance_id)
+
+    return missing, incomplete, wrong
+
+
+@retry(max_retries=5, wait_time_seconds=180)
+def check_compute_nodes_config_version(cluster_name: str, table_name: str, expected_config_version: str):
+    """
+    Verify that every compute node in the cluster has deployed the expected config version.
+
+    The verification is made by checking the config version reported by compute nodes on the cluster DDB table.
+    A RuntimeError exception is raised if the check fails.
+    The function is retried and the wait time is expected to be in the interval (cfn_hup_time, 2*cfn_hup_time),
+    where cfn_hup_time is the wait time for the cfn-hup daemon (as of today it is 120 seconds).
+
+    :param cluster_name: name of the cluster.
+    :param table_name: DDB table to read the deployed config version from.
+    :param expected_config_version: expected config version
+    :return: None
+    """
+    ec2 = boto3.client("ec2", config=BOTO3_CONFIG)
+
+    logger.info(
+        f"Checking that cluster configuration deployed on compute nodes for cluster {cluster_name} "
+        f"is {expected_config_version}"
+    )
+
+    for instance_ids in list_cluster_instance_ids_iterator(
+        cluster_name=cluster_name, node_type=["Compute"], batch_size=BATCH_SIZE, ec2_client=ec2
+    ):
+        n_instance_ids = len(instance_ids)
+
+        if not n_instance_ids:
+            logger.warning("Found empty batch of compute nodes: nothing to check")
+            continue
+
+        logger.info(f"Found batch of {n_instance_ids} compute node(s): {instance_ids}")
+
+        items = _get_cluster_config_records(table_name, instance_ids)
+        logger.info(f"Retrieved {len(items)} item(s): {items}")
+
+        missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
+
+        if missing or incomplete or wrong:
+            raise RuntimeError(
+                f"Check failed due to the following erroneous records:\n"
+                f"  * missing records ({len(missing)}): {missing}\n"
+                f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
+                f"  * wrong records ({len(wrong)}): {wrong}"
+            )
+        else:
+            logger.info(f"Verified cluster configuration for instance(s) {instance_ids}")
+
+
+@helper.create
+@helper.update
+def create_update(event, _):
+    request, properties = event["RequestType"], event["ResourceProperties"]
+    logger.info(f"Received request {request} with properties: {properties}")
+
+    check_compute_nodes_config_version(
+        cluster_name=properties["ClusterName"],
+        table_name=properties["TableName"],
+        expected_config_version=properties["ConfigVersion"],
+    )
+
+    logger.info("All checks succeeded")
+
+
+@helper.delete
+def delete(event, _):
+    request, properties = event["RequestType"], event["ResourceProperties"]
+    logger.info(f"Received request {request} with properties: {properties}")
+    logger.info("Nothing to do")
+
+
+def handler(event, context):
+    helper(event, context)
+
+
+if __name__ == "__main__":
+    import sys
+
+    request_type, cluster_name, table_name, config_version = sys.argv[1:5]
+
+    event = {
+        "RequestType": request_type,
+        "ResourceProperties": {
+            "ClusterName": cluster_name,
+            "TableName": table_name,
+            "ConfigVersion": config_version,
+        },
+    }
+
+    context = {}
+
+    create_update(event, context)

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -297,6 +297,10 @@ class ClusterCdkStack:
         # Initialize Login Nodes
         self._add_login_nodes_resources()
 
+        # SLURM only - Add Custom Resource to wait for the compute fleet stack to be ready,
+        # e.g. verifying that every compute node has deployed the expected cluster config version
+        self._add_wait_cluster_ready_lambda()
+
         # AWS Batch related resources
         if self._condition_is_batch():
             self.scheduler_resources = AwsBatchConstruct(
@@ -476,6 +480,77 @@ class ClusterCdkStack:
             )
             # Add dependency on the Head Node construct
             self.login_nodes_stack.node.add_dependency(self.head_node_instance)
+
+    def _add_wait_cluster_ready_lambda(self):
+        """Create a Custom Resource that performs some checks to consider the cluster ready (SLURM only).
+
+        In particular, it performs the following checks:
+          1. Verify that all compute nodes have deployed the expected cluster config version.
+        """
+        if not self._condition_is_slurm():
+            return
+
+        function_id = "WaitClusterReady"
+        lambda_role = None
+        if self._condition_create_lambda_iam_role():
+            lambda_role = add_lambda_cfn_role(
+                scope=self.stack,
+                config=self.config,
+                function_id=function_id,
+                statements=[
+                    iam.PolicyStatement(
+                        actions=["ec2:DescribeInstances"],
+                        effect=iam.Effect.ALLOW,
+                        resources=["*"],
+                        sid="EC2Policy",
+                    ),
+                    iam.PolicyStatement(
+                        actions=["dynamodb:BatchGetItem"],
+                        effect=iam.Effect.ALLOW,
+                        resources=[
+                            self.stack.format_arn(
+                                service="dynamodb",
+                                account=self.stack.account,
+                                region=self.stack.region,
+                                resource=f"table/parallelcluster-{self.stack.stack_name}",
+                            )
+                        ],
+                        sid="DynamoDbPolicy",
+                    ),
+                    get_cloud_watch_logs_policy_statement(
+                        resource=self.stack.format_arn(
+                            service="logs",
+                            account=self.stack.account,
+                            region=self.stack.region,
+                            resource=get_lambda_log_group_prefix(f"{function_id}-*"),
+                        )
+                    ),
+                ],
+                has_vpc_config=self.config.lambda_functions_vpc_config,
+            )
+
+        lambda_fn = PclusterLambdaConstruct(
+            scope=self.stack,
+            id=f"{function_id}FunctionConstruct",
+            function_id=function_id,
+            bucket=self.bucket,
+            config=self.config,
+            execution_role=lambda_role.attr_arn if lambda_role else self.config.iam.roles.lambda_functions_role,
+            handler_func="wait_cluster_ready",
+        ).lambda_func
+
+        custom_resource = CustomResource(
+            self.stack,
+            f"{function_id}CustomResource",
+            service_token=lambda_fn.attr_arn,
+            properties={
+                "ClusterName": self.config.cluster_name,
+                "TableName": self.dynamodb_table_status.ref,
+                "ConfigVersion": self.config.config_version,
+            },
+        )
+
+        custom_resource.node.add_dependency(self.wait_condition)
 
     def _add_cleanup_resources_lambda(self):
         """Create Lambda cleanup resources function and its role."""

--- a/cli/tests/pcluster/resources/__init__.py
+++ b/cli/tests/pcluster/resources/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/tests/pcluster/resources/custom_resources/__init__.py
+++ b/cli/tests/pcluster/resources/custom_resources/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/tests/pcluster/resources/custom_resources/custom_resources_code/__init__.py
+++ b/cli/tests/pcluster/resources/custom_resources/custom_resources_code/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/tests/pcluster/resources/custom_resources/custom_resources_code/test_wait_cluster_ready.py
+++ b/cli/tests/pcluster/resources/custom_resources/custom_resources_code/test_wait_cluster_ready.py
@@ -1,0 +1,162 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from tests.pcluster.resources.custom_resources.custom_resources_code.utils import (
+    _build_lambda_event,
+    do_nothing_decorator,
+)
+
+# This patching must be executed before the import of the module wait_cluster_ready
+# otherwise the module would be loaded with the original retry decorator.
+# As a consequence, we need to suppress the linter rule E402 on every import below.
+patch("utils.retry_utils.retry", do_nothing_decorator).start()
+
+from pcluster.resources.custom_resources.custom_resources_code.wait_cluster_ready import (  # noqa: E402
+    create_update,
+    delete,
+)
+from tests.utils import MockedBoto3Request  # noqa: E402
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.resources.custom_resources.custom_resources_code.wait_cluster_ready.boto3"
+
+
+def _mocked_request_describe_instances(cluster_name: str, node_types: [str], compute_nodes: [str]):
+    return MockedBoto3Request(
+        method="describe_instances",
+        response={"Reservations": [{"Instances": [{"InstanceId": instance_id} for instance_id in compute_nodes]}]},
+        expected_params={
+            "Filters": [
+                {"Name": "tag:parallelcluster:cluster-name", "Values": [cluster_name]},
+                {"Name": "tag:parallelcluster:node-type", "Values": node_types},
+                {"Name": "instance-state-name", "Values": ["pending", "running", "stopping", "stopped"]},
+            ],
+            "MaxResults": 500,
+        },
+        generate_error=False,
+        error_code=None,
+    )
+
+
+def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_records: {}):
+    keys = [{"Id": {"S": f"CLUSTER_CONFIG.{instance_id}"}} for instance_id in compute_nodes]
+    returned_items = [
+        {"Id": {"S": f"CLUSTER_CONFIG.{instance_id}"}, "Data": {"M": ddb_records[instance_id]}}
+        for instance_id in ddb_records
+    ]
+    return MockedBoto3Request(
+        method="batch_get_item",
+        response={"Responses": {table_name: returned_items}},
+        expected_params={
+            "RequestItems": {
+                table_name: {
+                    "Keys": keys,
+                },
+            },
+        },
+        generate_error=False,
+        error_code=None,
+    )
+
+
+def _event(request_type: str):
+    return _build_lambda_event(
+        request_type,
+        {
+            "ClusterName": "CLUSTER_NAME",
+            "TableName": "TABLE_NAME",
+            "ConfigVersion": "EXPECTED_CONFIG_VERSION",
+        },
+    )
+
+
+def _cfn_resource_stub(boto3_stubber):
+    boto3_stubber("lambda", [])
+    boto3_stubber("events", [])
+    boto3_stubber("logs", [])
+
+
+@pytest.mark.parametrize(
+    "compute_nodes, ddb_records, expected_error",
+    [
+        pytest.param(
+            [],
+            {},
+            None,
+            id="Create request with no compute nodes",
+        ),
+        pytest.param(
+            ["i-123456789"],
+            {},
+            "Check failed due to the following erroneous records:\n"
+            "  * missing records (1): ['i-123456789']\n"
+            "  * incomplete records (0): []\n"
+            "  * wrong records (0): []",
+            id="Create request with missing DDB records",
+        ),
+        pytest.param(
+            ["i-123456789"],
+            {"i-123456789": {"UNEXPECTED_KEY": {"S": "UNEXPECTED_KEY_VALUE"}}},
+            "Check failed due to the following erroneous records:\n"
+            "  * missing records (0): []\n"
+            "  * incomplete records (1): ['i-123456789']\n"
+            "  * wrong records (0): []",
+            id="Create request with malformed DDB records",
+        ),
+        pytest.param(
+            ["i-123456789"],
+            {"i-123456789": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION"}}},
+            "Check failed due to the following erroneous records:\n"
+            "  * missing records (0): []\n"
+            "  * incomplete records (0): []\n"
+            "  * wrong records (1): ['i-123456789']",
+            id="Create request with wrong cluster config version",
+        ),
+        pytest.param(
+            ["i-123456789"],
+            {"i-123456789": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}}},
+            None,
+            id="Create request with correct cluster config version",
+        ),
+    ],
+)
+def test_create_update(boto3_stubber, compute_nodes, ddb_records, expected_error):
+    _cfn_resource_stub(boto3_stubber)
+
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute"], compute_nodes)])
+
+    boto3_stubber(
+        "dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", compute_nodes, ddb_records)] if compute_nodes else []
+    )
+
+    if expected_error is not None:
+        with pytest.raises(RuntimeError) as exc:
+            create_update(_event("Create"), {})
+        assert_that(str(exc.value)).is_equal_to(expected_error)
+    else:
+        create_update(_event("Create"), {})
+
+
+def test_delete(mocker, boto3_stubber):
+    _cfn_resource_stub(boto3_stubber)
+
+    mock_check_compute_nodes_config_version = mocker.patch("wait_cluster_ready.check_compute_nodes_config_version")
+
+    delete(_event("Delete"), {})
+
+    mock_check_compute_nodes_config_version.assert_not_called()

--- a/cli/tests/pcluster/resources/custom_resources/custom_resources_code/utils.py
+++ b/cli/tests/pcluster/resources/custom_resources/custom_resources_code/utils.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import wraps
+
+
+def do_nothing_decorator(*args, **kwargs):
+    """
+    Decorate by doing nothing.
+
+    This decorator is useful to patch real decorators for testing, e.g. the retry decorator.
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
+
+
+def _build_lambda_event(request_type: str, properties: {} = None):
+    """
+    Create an event for Custom Resource Lambda.
+
+    :param request_type: type of request, i.e. Create|Update|Delete
+    :param properties: properties passed to the Custom Resource from CloudFormation template.
+    :return: the event.
+    """
+    return {"RequestType": request_type, "ResourceProperties": properties}

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -175,6 +175,10 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     )
     cluster.update(str(updated_config_file), force_update="true")
 
+    # Verify that compute nodes stored the deployed config version on DDB
+    last_cluster_config_version = get_deployed_config_version(cluster)
+    assert_instance_config_version_on_ddb(cluster, last_cluster_config_version)
+
     # Here is the expected list of nodes.
     # the cluster:
     # queue1-st-c5xlarge-1
@@ -315,6 +319,9 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         postupdate_script="failed_postupdate.sh",
     )
     cluster.update(str(failed_update_config_file), raise_on_error=False, log_error=False)
+
+    # Verify that compute nodes stored the deployed config version on DDB
+    assert_instance_config_version_on_ddb(cluster, last_cluster_config_version)
 
     _check_rollback_with_expected_error_message(region, cluster)
 


### PR DESCRIPTION
### Description of changes
1. Add custom resource to check that all compute nodes have the expected cluster config version.
This custom resource will be added only when using SLURM scheduler because compute nodes updates will be supported only with SLURM.
1. Added more checks on the cluster config version in integ test `test_update_slurm`.
1. Added a TODO in cleanup_resource to remind that it could use a new function introduced in this PR to reduce code duplication.


The creation of such DDB records has been introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/2618

### Tests
* Manually created, empty update (forced), deleted a cluster: all operations succeeded and the custom resource was executed as expected.
* Executed existing unit tests.
* Executed integ test `test_update_slurm`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
