### PR TITLE
[Tests] Remove useless and old tests

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -818,11 +818,6 @@ test-suites:
           schedulers: ["slurm"]
           oss: ["ubuntu2004"]
   update:
-    test_update.py::test_update_awsbatch:
-      dimensions:
-        - regions: ["eu-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
     test_update.py::test_update_slurm:
       dimensions:
         - regions: ["eu-central-1"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -798,12 +798,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.NOT_RELEASED_OSES }}
           schedulers: ["slurm"]
-    test_api.py::test_cluster_awsbatch:
-      dimensions:
-        - regions: ["sa-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
     test_api.py::test_custom_image:
       dimensions:
         - regions: ["sa-east-1"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -578,12 +578,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
-    test_slurm.py::test_scontrol_update_nodelist_sorting:
-      dimensions:
-        - regions: ["ca-central-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_slurm_accounting.py::test_slurm_accounting:
       dimensions:
         - regions: ["ap-south-1"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -14,13 +14,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2204", "centos7"]
           schedulers: ["slurm"]
-  arm_pl:
-    test_arm_pl.py::test_arm_pl:
-      dimensions:
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
-          schedulers: ["slurm"]
   capacity_reservations:
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -590,12 +590,6 @@ test-suites:
           instances:  {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["slurm"]
-    test_slurm.py::test_slurm_reconfigure_race_condition:
-      dimensions:
-        - regions: [ "af-south-1" ]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
-          schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_custom_partitions:
       dimensions:
         - regions: ["ap-northeast-2"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -178,12 +178,6 @@ test-suites:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.NOT_RELEASED_OSES }}
-    test_createami.py::test_kernel4_build_image_run_cluster:
-      dimensions:
-        - regions: ["eu-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["alinux2"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -384,12 +384,6 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-    test_slurm.py::test_scontrol_update_nodelist_sorting:
-      dimensions:
-        - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
     test_slurm_accounting.py::test_slurm_accounting:
       dimensions:
         - regions: {{ REGIONS }}

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -396,12 +396,6 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-    test_slurm.py::test_slurm_reconfigure_race_condition:
-      dimensions:
-        - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
     test_slurm.py::test_slurm_custom_config_parameters:
       dimensions:
         - regions: {{ REGIONS }}

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -12,13 +12,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2204", "centos7"]
           schedulers: ["slurm"]
-  arm_pl:
-    test_arm_pl.py::test_arm_pl:
-      dimensions:
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
-          schedulers: ["slurm"]
   capacity_reservations:
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -171,12 +171,6 @@ test-suites:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.NOT_RELEASED_OSES }}
-    test_createami.py::test_kernel4_build_image_run_cluster:
-      dimensions:
-        - regions: ["eu-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["alinux2"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -402,12 +402,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
-    test_api.py::test_cluster_awsbatch:
-      dimensions:
-        - regions: ["sa-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
     test_api.py::test_custom_image:
       dimensions:
         - regions: ["sa-east-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -735,11 +735,6 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm", "awsbatch"]
   update:
-    test_update.py::test_update_awsbatch:
-      dimensions:
-        - regions: ["eu-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
     test_update.py::test_update_slurm:
       dimensions:
         - regions: ["eu-central-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -541,12 +541,6 @@ test-suites:
           instances:  {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["slurm"]
-    test_slurm.py::test_slurm_reconfigure_race_condition:
-      dimensions:
-        - regions: [ "af-south-1" ]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
-          schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_custom_partitions:
       dimensions:
         - regions: ["ap-northeast-2"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -529,12 +529,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
-    test_slurm.py::test_scontrol_update_nodelist_sorting:
-      dimensions:
-        - regions: ["ca-central-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_slurm_accounting.py::test_slurm_accounting:
       dimensions:
         - regions: ["ap-south-1"]

--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -125,7 +125,7 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_reconfigure_race_condition:
-       dimensions:
+      dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]

--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -143,11 +143,6 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
   update:
-    test_update.py::test_update_awsbatch:
-      dimensions:
-        - regions: ["eu-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
     test_update.py::test_update_slurm:
       dimensions:
         - regions: ["eu-central-1"]

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl.py
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl.py
@@ -19,7 +19,12 @@ from remote_command_executor import RemoteCommandExecutor
 
 @pytest.mark.usefixtures("region", "instance", "scheduler")
 def test_arm_pl(os, pcluster_config_reader, clusters_factory, test_datadir):
-    """Test Arm Performance Library"""
+    """
+    Test Arm Performance Library and GCC are correctly installed, the version and try to use them.
+
+    Important: This test is not executed because the code has been moved into a Kitchen test for ARM PL chef resource.
+    See: aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+    """
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -193,8 +193,13 @@ def test_kernel4_build_image_run_cluster(
     Test build image for given region and os and run a job in a new cluster created from the new images.
 
     Also check that the build instance has the desired ImdsSupport setting (IMDSv2, v1.0 is optional).
-    """
 
+    Note: This test has been introduced to verify the build-image with Amazon Linux based on kernel 4,
+    because the base AMI for Amazon Linux were based on kernel 5.10.
+
+    At the moment this test is no longer relevant,
+    kernel 5.10 in Amazon Linux 2 has been introduced on Nov 2021 and kernel 4.14 is now EOL.
+    """
     # Get base AMI from kernel4
     base_ami = retrieve_latest_ami(region, os, ami_type="kernel4", architecture=architecture)
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -2727,6 +2727,8 @@ def test_slurm_reconfigure_race_condition(
     slurmctld daemon and immediately performs a scontrol reconfigure.
 
     See https://bugs.schedmd.com/show_bug.cgi?id=13953
+
+    Note: This test is no longer executed because the issue has been fixed in the release 22.05.7.
     """
 
     scale_down_idle_time_mins = 1

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -996,6 +996,8 @@ def test_scontrol_update_nodelist_sorting(
     nodenames and the assigned addresses.
 
     See https://bugs.schedmd.com/show_bug.cgi?id=15731
+
+    Note: This test is no longer executed because the issue in Slurm has been fixed in 23.05 release.
     """
 
     max_count_cr1 = max_count_cr2 = 4


### PR DESCRIPTION
# Description of changes

This patch removes a set of tests that are useless because already covered by Kitchen tests, or because they were useful in past but less relevant in this moment.
Removed:
* 4 test_arm_pl tests (4 OSes) --> covered by kitchen
* 1 test_kernel4_build_image_run_cluster --> old kernel, replaced on 2021
* 1 test_scontrol_update_nodelist_sorting --> old Slurm version bug
* 1 test_slurm_reconfigure_race_condition --> old Slurm version bug
* 1 test_api - test_cluster_awsbatch
* 1 test_update_awsbatch

Details below. It's easy to look at the changes commit by commit.

## [Tests] Remove tests for ARM Performance Library

These checks have been moved to Kitchen tests for ARM PL chef custom resource
and executed at AMI build time. There is 100% overlapping.

`tag:install_arm_pl_installed`:
* verifies ARM PL library is correctly installed
* checks version of ARM PL according to the OS
* loads armpl module and gcc module and assert the module is loaded
* verifies EULA docs are correctly linked in the module output
* tests ARM PL examples

`tag:install_arm_pl_gcc_installed`:
* verifies GCC is correctly installed
* checks version of ARM PL and GCC according to the OS

### References

* https://github.com/aws/aws-parallelcluster-cookbook/blob/release-3.8/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb


## [Tests] Remove test for build AMI with Kernel 4

This test has been introduced to verify the build-image with Amazon Linux based on kernel 4,
because the base AMI for Amazon Linux were based on kernel 5.10.

At the moment this test is no longer relevant,
kernel 5.10 in Amazon Linux 2 has been introduced on Nov 2021 and kernel 4.14 is now EOL.

### References

* https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-linux-2-ami-kernel-5-10/
* https://github.com/aws/aws-parallelcluster/pull/4043
* https://en.wikipedia.org/wiki/Linux_kernel_version_history


## [Tests] Remove test for dynamics nodes not powering down after an update

In Slurm 21.08 cloud nodes were not get powered-down after their
SuspendTime has expired if a cluster update is performed, which restarts the
slurmctld daemon and immediately performs a scontrol reconfigure.

This was causing a race condition between restart of slurmctld and scontrol reconfigure.

The issue has been fixed in Slurm 22.05.7 release, included in Pcluster 3.4.0, so this test is no longer useful.

### References

* https://github.com/aws/aws-parallelcluster/pull/4746
* https://bugs.schedmd.com/show_bug.cgi?id=13953

## [Tests] Remove test for scontrol update nodelist sorting bug

In Slurm 22.05.7 the `scontrol update node` logic was modified and a sorting routine was
introduced, which modified the order of the nodes in the nodelist,
this was causing mismatches between the Slurm nodenames and the assigned addresses.

The issue has been fixed in 22.05.8 release, included in Pcluster 3.5.0 so this test is no longer useful.

### References

* https://github.com/aws/aws-parallelcluster/pull/4786
* https://bugs.schedmd.com/show_bug.cgi?id=15731

## [Tests] Remove test for updating a cluster with AWS Batch as a scheduler

## [Tests] Remove test for Pcluster API with AWS Batch as a scheduler

# Tests
Executed `python -m test_runner develop.yaml ... --dryrun` to verify number of tests and configuration syntax

* develop: pre: 266 tests, after: 262 tests
* released: pre: 258 tests, after: 255 tests
