### PR TITLE
Unset proxies in test_runner

### DIFF
--- a/cli/tests/pcluster/models/test_cluster_resources.py
+++ b/cli/tests/pcluster/models/test_cluster_resources.py
@@ -62,7 +62,7 @@ class TestClusterLogsFiltersParser:
         logs_filters = ClusterLogsFiltersParser(mock_head_node, filters)
 
         for attr in expected_attrs:
-            assert_that(getattr(logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
         assert_that(expected_filters_size).is_equal_to(len(logs_filters.filters_list))
 
     @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ class TestExportClusterLogsFiltersParser:
         )
 
         for attr in expected_attrs:
-            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
         "attrs, event_in_window, expected_error",

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -74,7 +74,7 @@ class TestLogGrouptimeFiltersParser:
         )
 
         for attr in expected_attrs:
-            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))
+            assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
         "attrs, event_in_window, log_stream_prefix, expected_error",

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -762,6 +762,14 @@ def _check_args(args):
             raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(args.tests_config))
 
 
+def unset_proxies():
+    """Unset proxies"""
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("https_proxy", None)
+
+
 def _run_sequential(args):
     # Redirect stdout to file
     if not args.show_output:
@@ -787,6 +795,9 @@ def main():
 
     _check_args(args)
     logger.info("Parsed test_runner parameters {0}".format(args))
+
+    # Unset any proxies used to avoid network issues with tests, such as DCV
+    unset_proxies()
 
     _make_logging_dirs(args.output_dir)
 

--- a/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
+++ b/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
@@ -50,7 +50,7 @@ def generate_plots(datadir, outdir, configurations, nodes):
         # Box Plots
         box_plots = {}
         for configuration in configurations:
-            positions = all_positions[configurations.index(configuration) :: n_configurations]  # noqa: E203
+            positions = all_positions[configurations.index(configuration) :: n_configurations]  # noqa: E203, B038
             box_plots[configuration] = ax.boxplot(
                 data[configuration],
                 patch_artist=True,

--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -157,7 +157,7 @@ class EBSSnapshotsFactory:
                 )
                 ssh_conn.open()
                 tries = 0
-            except BaseException:
+            except BaseException:  # noqa: B036
                 logging.info("SSH connection error - retrying...")
                 tries -= 1
                 time.sleep(20)


### PR DESCRIPTION
### Description of changes
* Unset any proxies before integration tests run in test_runner so they are ran in the appropriate environment
  * Specifically, this is because we ran into DCV test errors when using proxies to run the test
* Placed after the URL validation so that the proxies can be used for validating the URLs then not used during the actual tests

### Tests
* Ran DCV test in China jenkins, succeeded

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
