### PR TITLE
Unset proxies in test runner

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -753,6 +753,14 @@ def _check_args(args):
             raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(args.tests_config))
 
 
+def unset_proxy():
+    """Unset proxies"""
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("https_proxy", None)
+
+
 def _run_sequential(args):
     # Redirect stdout to file
     if not args.show_output:
@@ -778,6 +786,9 @@ def main():
 
     _check_args(args)
     logger.info("Parsed test_runner parameters {0}".format(args))
+
+    # Unset any proxies used to avoid network issues with tests, such as DCV
+    unset_proxy()
 
     _make_logging_dirs(args.output_dir)
 


### PR DESCRIPTION
### Description of changes
* Unset any proxies before integration tests run in test_runner so they are ran in the appropriate environment
  * Specifically, this is because we ran into DCV test errors when using proxies to run the test
* Placed after the URL validation so that the proxies can be used for validating the URLs then not used during the actual tests

### Tests
* Ran DCV test in China jenkins, succeeded

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
