### PR TITLE
[Tests] Reduce tests dimensions for released version

### DIFF
--- a/tests/integration-tests/configs/new_instance_types.yaml
+++ b/tests/integration-tests/configs/new_instance_types.yaml
@@ -77,7 +77,7 @@ test-suites:
       dimensions:
         - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
-          oss: ["alinux2", "rhel8", "ubuntu2004"]
+          oss: ["ubuntu2004"]
           schedulers: ["slurm"]
   configure:
     test_pcluster_configure.py::test_pcluster_configure:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -6,11 +6,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-southeast-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "rhel8"]
-          schedulers: ["slurm"]
-        - regions: ["eu-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "centos7"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
   arm_pl:
     test_arm_pl.py::test_arm_pl:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -76,11 +76,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-    test_pcluster_configure.py::test_region_without_t2micro:
-      dimensions:
-        - regions: ["eu-north-1"] # must be regions that do not have t2.micro
-          oss: ["rhel8"]
-          schedulers: ["slurm"]
     test_pcluster_configure.py::test_efa_and_placement_group:
       dimensions:
         - regions: ["us-west-2"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -181,13 +181,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
-  intel_hpc:
-    test_intel_hpc.py::test_intel_hpc:
-      dimensions:
-        - regions: ["us-east-2"]
-          instances: ["c5.18xlarge"]
-          oss: ["centos7"]
-          schedulers: ["slurm"]
   log_rotation:
     test_log_rotation.py::test_log_rotation:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -43,28 +43,10 @@ test-suites:
   cloudwatch_logging:
     test_cloudwatch_logging.py::test_cloudwatch_logging:
       dimensions:
-        # 1) run the test for all the schedulers with alinux2
-        - regions: ["cn-northwest-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: {{ common.SCHEDULERS_TRAD }}
-        - regions: ["us-gov-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
-        # 2) run the test for all OSes with slurm
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204", "rhel8"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
-        - regions: ["ap-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["centos7"]
-        - regions: ["ap-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: {{ common.NOT_RELEASED_OSES }}
     test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
       dimensions:
         - regions: ["ap-east-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -76,12 +76,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-    test_pcluster_configure.py::test_efa_unsupported:
-      dimensions:
-        - regions: ["us-east-1"]
-          instances: {{ common.INSTANCES_EFA_UNSUPPORTED_X86 }}
-          oss: ["rhel8"]
-          schedulers: ["slurm"]
   create:
     test_create.py::test_create_wrong_os:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -174,13 +174,6 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
-  health_checks:
-    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
-      dimensions:
-        - regions: ["eu-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
   iam:
     test_iam.py::test_iam_policies:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -175,12 +175,6 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
   iam:
-    test_iam.py::test_iam_policies:
-      dimensions:
-        - regions: ["eu-north-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm", "awsbatch"]
     test_iam.py::test_iam_roles:
       dimensions:
         - regions: ["eu-west-3"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -181,12 +181,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2204"]
           schedulers: ["slurm"]
-    test_dcv.py::test_dcv_with_remote_access:
-      dimensions:
-        - regions: ["ap-southeast-2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
-          schedulers: ["slurm"]
   disable_hyperthreading:
     test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -143,25 +143,9 @@ test-suites:
   dcv:
     test_dcv.py::test_dcv_configuration:
       dimensions:
-        # DCV on GPU enabled instance
         - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
           instances: ["g4dn.2xlarge"]
-          oss: {{ common.NOT_RELEASED_OSES }}
-          schedulers: ["slurm"]
-        # DCV on ARM + GPU
-        - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
-          instances: ["g5g.2xlarge"]
           oss: ["rhel8"]
-          schedulers: ["slurm"]
-        # DCV in cn regions and non GPU enabled instance
-        - regions: ["cn-northwest-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
-        # DCV in gov-cloud regions and non GPU enabled instance
-        - regions: ["us-gov-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
           schedulers: ["slurm"]
   disable_hyperthreading:
     test_disable_hyperthreading.py::test_hit_disable_hyperthreading:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -76,12 +76,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-    test_pcluster_configure.py::test_efa_and_placement_group:
-      dimensions:
-        - regions: ["us-west-2"]
-          instances: {{ common.INSTANCES_EFA_SUPPORTED_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_pcluster_configure.py::test_efa_unsupported:
       dimensions:
         - regions: ["us-east-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -170,22 +170,10 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["sa-east-1"]
-          instances: ["c5n.9xlarge"]
-          oss: ["rhel8"]
-          schedulers: ["slurm"]
         - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
-          instances: ["c6gn.16xlarge"]
-          oss: ["ubuntu2204"]
-          schedulers: ["slurm"]
-        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
-          instances: [{{ common.instance("instance_type_1") }}]
-          oss: ["centos7"]
-          schedulers: [ "slurm" ]
   health_checks:
     test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -95,24 +95,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{common.OSS_COMMERCIAL_X86}}
           schedulers: ["slurm"]
-    test_create.py::test_cluster_creation_with_problematic_preinstall_script:
-      dimensions:
-        - regions: ["ap-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          schedulers: ["slurm"]
-          oss: ["ubuntu2204"]
-    test_create.py::test_cluster_creation_timeout:
-      dimensions:
-        - regions: ["ap-northeast-2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["alinux2"]
-    test_create.py::test_cluster_creation_with_invalid_ebs:
-      dimensions:
-        - regions: ["ap-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          schedulers: ["slurm"]
-          oss: ["ubuntu2004"]
     test_create.py::test_create_disable_sudo_access_for_default_user:
       dimensions:
         - regions: [ "ap-northeast-2" ]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -175,29 +175,12 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
   iam:
-    test_iam.py::test_iam_roles:
-      dimensions:
-        - regions: ["eu-west-3"]
-          schedulers: ["awsbatch", "slurm"]
-          oss: ["alinux2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-    test_iam_image.py::test_iam_roles:
-      dimensions:
-        - regions: ["eu-south-1"]
-          oss: {{ common.NOT_RELEASED_OSES }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_iam.py::test_s3_read_write_resource:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
-    test_iam.py::test_iam_resource_prefix:
-      dimensions:
-        - regions: [ "eu-north-1" ]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "alinux2" ]
-          schedulers: [ "slurm" ]
   intel_hpc:
     test_intel_hpc.py::test_intel_hpc:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -76,12 +76,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
-      dimensions:
-        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_pcluster_configure.py::test_region_without_t2micro:
       dimensions:
         - regions: ["eu-north-1"] # must be regions that do not have t2.micro


### PR DESCRIPTION
### Description of changes

With this change we're reducing tests dimensions for released version.
* when the test is verifying different OSes or architecture dimensions we're reducing dimensions keeping a single test as "AWS Api canary" (AD, CW, DCV, EFA).
* when the test is verifying our code logic we are removing it because, once released our code and AMIs are stable so it's useless to test them.

Released version test changes (removes 30 tests):
- Reduce dimensions of AD integration tests (4 --> 1)
- Reduce dimensions of CloudWatch logging tests (6 --> 1)
- Remove test of pcluster configure with bad subnets (1 --> 0)
- Remove test of pcluster configure for a region without t2.micro (1 --> 0)
- Remove test of pcluster configure for EFA/PG settings (1 --> 0)
- Remove test of pcluster configure when EFA is not supported (1 --> 0)
- Remove DCV tests for different ports and access-from (1 --> 0)
- Remove cluster creation tests verifying internal logic (3 --> 0)
- Reduce dimensions of DCV tests (4 --> 1)
- Reduce EFA tests dimensions (4 --> 1)
- Remove GPU health check test (1 --> 0)
- Remove IAM Policy test(2 --> 0)
- Remove IAM Roles test (4 --> 0)
- Remove Intel HPC test (1 --> 0)

New instance type test changes:
- Reduce EFA tests dimensions when testing a new instance type (3 --> 1)

Details in the commit messages.

### Tests
Executed `python -m test_runner develop.yaml ... --dryrun` to verify number of tests and configuration syntax
* released: pre: 255 tests, after: 236 tests
