### PR TITLE
[Tests] Reduce tests dimensions for released and develop versions

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -104,9 +104,9 @@ class Ec2Client(Boto3Client):
                 )
             )
             for capacity_reservation in response:
-                self.capacity_reservations_cache[
-                    capacity_reservation.get("CapacityReservationId")
-                ] = CapacityReservationInfo(capacity_reservation)
+                self.capacity_reservations_cache[capacity_reservation.get("CapacityReservationId")] = (
+                    CapacityReservationInfo(capacity_reservation)
+                )
                 result.append(CapacityReservationInfo(capacity_reservation))
         return result
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1867,9 +1867,11 @@ class BaseClusterConfig(Resource):
         mount_dir_instance_types_dict = defaultdict(set)
         if self.head_node.instance_type_info.instance_storage_supported():
             mount_dir_instance_types_dict[
-                self.head_node.local_storage.ephemeral_volume.mount_dir
-                if self.head_node.local_storage.ephemeral_volume
-                else DEFAULT_EPHEMERAL_DIR
+                (
+                    self.head_node.local_storage.ephemeral_volume.mount_dir
+                    if self.head_node.local_storage.ephemeral_volume
+                    else DEFAULT_EPHEMERAL_DIR
+                )
             ].add(self.head_node.instance_type)
 
         scheduling = self.scheduling
@@ -1878,9 +1880,11 @@ class BaseClusterConfig(Resource):
                 instance_types_with_instance_storage = queue.instance_types_with_instance_storage
                 if instance_types_with_instance_storage:
                     mount_dir_instance_types_dict[
-                        queue.compute_settings.local_storage.ephemeral_volume.mount_dir
-                        if queue.compute_settings.local_storage.ephemeral_volume
-                        else DEFAULT_EPHEMERAL_DIR
+                        (
+                            queue.compute_settings.local_storage.ephemeral_volume.mount_dir
+                            if queue.compute_settings.local_storage.ephemeral_volume
+                            else DEFAULT_EPHEMERAL_DIR
+                        )
                     ].update(instance_types_with_instance_storage)
 
         return mount_dir_instance_types_dict

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -542,9 +542,9 @@ class AwsBatchConstruct(Construct):
             "PclusterCodeBuildDockerImageBuilderProj",
             artifacts=codebuild.CfnProject.ArtifactsProperty(type="NO_ARTIFACTS"),
             environment=codebuild.CfnProject.EnvironmentProperty(
-                compute_type="BUILD_GENERAL1_LARGE"
-                if self._condition_use_arm_code_build_image()
-                else "BUILD_GENERAL1_SMALL",
+                compute_type=(
+                    "BUILD_GENERAL1_LARGE" if self._condition_use_arm_code_build_image() else "BUILD_GENERAL1_SMALL"
+                ),
                 environment_variables=[
                     codebuild.CfnProject.EnvironmentVariableProperty(
                         name="AWS_REGION",
@@ -567,9 +567,11 @@ class AwsBatchConstruct(Construct):
                         value=self._docker_build_wait_condition_handle.ref,
                     ),
                 ],
-                image="aws/codebuild/amazonlinux2-aarch64-standard:2.0"
-                if self._condition_use_arm_code_build_image()
-                else "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                image=(
+                    "aws/codebuild/amazonlinux2-aarch64-standard:2.0"
+                    if self._condition_use_arm_code_build_image()
+                    else "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+                ),
                 type="ARM_CONTAINER" if self._condition_use_arm_code_build_image() else "LINUX_CONTAINER",
                 privileged_mode=True,
             ),
@@ -625,9 +627,11 @@ class AwsBatchConstruct(Construct):
             function_id="ManageDockerImages",
             bucket=self.bucket,
             config=self.config,
-            execution_role=manage_docker_images_lambda_execution_role.attr_arn
-            if manage_docker_images_lambda_execution_role
-            else self.config.iam.roles.lambda_functions_role,
+            execution_role=(
+                manage_docker_images_lambda_execution_role.attr_arn
+                if manage_docker_images_lambda_execution_role
+                else self.config.iam.roles.lambda_functions_role
+            ),
             handler_func="manage_docker_images",
             timeout=60,
         ).lambda_func
@@ -690,9 +694,11 @@ class AwsBatchConstruct(Construct):
             function_id="BuildNotification",
             bucket=self.bucket,
             config=self.config,
-            execution_role=build_notification_lambda_execution_role.attr_arn
-            if build_notification_lambda_execution_role
-            else self.config.iam.roles.lambda_functions_role,
+            execution_role=(
+                build_notification_lambda_execution_role.attr_arn
+                if build_notification_lambda_execution_role
+                else self.config.iam.roles.lambda_functions_role
+            ),
             handler_func="send_build_notification",
             timeout=60,
         ).lambda_func

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -804,11 +804,11 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 iam.PolicyStatement(
                     sid="AllowGettingDirectorySecretValue",
                     actions=[
-                        "secretsmanager:GetSecretValue"
-                        if password_secret_arn.service == "secretsmanager"
-                        else "ssm:GetParameter"
-                        if password_secret_arn.service == "ssm"
-                        else None
+                        (
+                            "secretsmanager:GetSecretValue"
+                            if password_secret_arn.service == "secretsmanager"
+                            else "ssm:GetParameter" if password_secret_arn.service == "ssm" else None
+                        )
                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[self._config.directory_service.password_secret_arn],
@@ -1035,12 +1035,14 @@ class PclusterLambdaConstruct(Construct):
             role=execution_role,
             runtime="python3.9",
             timeout=timeout,
-            vpc_config=awslambda.CfnFunction.VpcConfigProperty(
-                security_group_ids=config.lambda_functions_vpc_config.security_group_ids,
-                subnet_ids=config.lambda_functions_vpc_config.subnet_ids,
-            )
-            if config.lambda_functions_vpc_config
-            else None,
+            vpc_config=(
+                awslambda.CfnFunction.VpcConfigProperty(
+                    security_group_ids=config.lambda_functions_vpc_config.security_group_ids,
+                    subnet_ids=config.lambda_functions_vpc_config.subnet_ids,
+                )
+                if config.lambda_functions_vpc_config
+                else None
+            ),
         )
 
     def _stack_unique_id(self):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -520,9 +520,11 @@ class ClusterCdkStack:
             function_id="CleanupResources",
             bucket=self.bucket,
             config=self.config,
-            execution_role=cleanup_resources_lambda_role.attr_arn
-            if cleanup_resources_lambda_role
-            else self.config.iam.roles.lambda_functions_role,
+            execution_role=(
+                cleanup_resources_lambda_role.attr_arn
+                if cleanup_resources_lambda_role
+                else self.config.iam.roles.lambda_functions_role
+            ),
             handler_func="cleanup_resources",
         ).lambda_func
 
@@ -814,12 +816,12 @@ class ClusterCdkStack:
                 )
 
                 if sg_type == "Storage":
-                    ingress_rule.cfn_options.deletion_policy = (
-                        ingress_rule.cfn_options.update_replace_policy
-                    ) = storage_deletion_policy
-                    egress_rule.cfn_options.deletion_policy = (
-                        egress_rule.cfn_options.update_replace_policy
-                    ) = storage_deletion_policy
+                    ingress_rule.cfn_options.deletion_policy = ingress_rule.cfn_options.update_replace_policy = (
+                        storage_deletion_policy
+                    )
+                    egress_rule.cfn_options.deletion_policy = egress_rule.cfn_options.update_replace_policy = (
+                        storage_deletion_policy
+                    )
 
         return storage_security_group
 
@@ -986,9 +988,9 @@ class ClusterCdkStack:
                 file_system_type_version=shared_fsx.file_system_type_version,
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
-            fsx_resource.cfn_options.deletion_policy = (
-                fsx_resource.cfn_options.update_replace_policy
-            ) = convert_deletion_policy(shared_fsx.deletion_policy)
+            fsx_resource.cfn_options.deletion_policy = fsx_resource.cfn_options.update_replace_policy = (
+                convert_deletion_policy(shared_fsx.deletion_policy)
+            )
 
             fsx_id = fsx_resource.ref
 
@@ -1210,9 +1212,9 @@ class ClusterCdkStack:
                         get_user_data_content("../resources/head_node/user_data.sh"),
                         {
                             **{
-                                "DisableMultiThreadingManually": "true"
-                                if head_node.disable_simultaneous_multithreading_manually
-                                else "false",
+                                "DisableMultiThreadingManually": (
+                                    "true" if head_node.disable_simultaneous_multithreading_manually else "false"
+                                ),
                                 "CloudFormationUrl": cloudformation_url,
                             },
                             **get_common_user_data_env(head_node, self.config),
@@ -1272,17 +1274,19 @@ class ClusterCdkStack:
                     "fsx_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.FSX]),
                     "volume": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EBS),
                     "scheduler": self.config.scheduling.scheduler,
-                    "ephemeral_dir": head_node.local_storage.ephemeral_volume.mount_dir
-                    if head_node.local_storage.ephemeral_volume
-                    else DEFAULT_EPHEMERAL_DIR,
+                    "ephemeral_dir": (
+                        head_node.local_storage.ephemeral_volume.mount_dir
+                        if head_node.local_storage.ephemeral_volume
+                        else DEFAULT_EPHEMERAL_DIR
+                    ),
                     "ebs_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.EBS]),
                     "proxy": head_node.networking.proxy.http_proxy_address if head_node.networking.proxy else "NONE",
                     "node_type": "HeadNode",
                     "cluster_user": OS_MAPPING[self.config.image.os]["user"],
                     "ddb_table": self.dynamodb_table_status.ref if not self._condition_is_batch() else "NONE",
-                    "log_group_name": self.log_group.log_group_name
-                    if self.config.monitoring.logs.cloud_watch.enabled
-                    else "NONE",
+                    "log_group_name": (
+                        self.log_group.log_group_name if self.config.monitoring.logs.cloud_watch.enabled else "NONE"
+                    ),
                     "dcv_enabled": "head_node" if self.config.is_dcv_enabled else "false",
                     "dcv_port": head_node.dcv.port if head_node.dcv else "NONE",
                     "enable_intel_hpc_platform": "true" if self.config.is_intel_hpc_platform_enabled else "false",
@@ -1313,9 +1317,9 @@ class ClusterCdkStack:
                     "install_intel_python": str(
                         get_attr(self.config, "additional_packages.intel_software.python")
                     ).lower(),
-                    "disable_sudo_access_for_default_user": "true"
-                    if self.config.disable_sudo_access_default_user
-                    else "false",
+                    "disable_sudo_access_for_default_user": (
+                        "true" if self.config.disable_sudo_access_default_user else "false"
+                    ),
                     **(
                         get_slurm_specific_dna_json_for_head_node(self.config, self.scheduler_resources)
                         if self._condition_is_slurm()

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -204,11 +204,13 @@ class ImageBuilderCdkStack(Stack):
             self,
             "CfnParamUpdateOsAndReboot",
             type="String",
-            default="true"
-            if self.config.build
-            and self.config.build.update_os_packages
-            and self.config.build.update_os_packages.enabled
-            else "false",
+            default=(
+                "true"
+                if self.config.build
+                and self.config.build.update_os_packages
+                and self.config.build.update_os_packages.enabled
+                else "false"
+            ),
             description="UpdateOsAndReboot",
         )
 
@@ -324,13 +326,13 @@ class ImageBuilderCdkStack(Stack):
             "Name": (self.config.image.name if self.config.image and self.config.image.name else self.image_id)
             + AMI_NAME_REQUIRED_SUBSTRING,
             "AmiTags": ami_tags,
-            "LaunchPermissionConfiguration": json.loads(
-                self.config.dev_settings.distribution_configuration.launch_permission
-            )
-            if self.config.dev_settings
-            and self.config.dev_settings.distribution_configuration
-            and self.config.dev_settings.distribution_configuration.launch_permission
-            else None,
+            "LaunchPermissionConfiguration": (
+                json.loads(self.config.dev_settings.distribution_configuration.launch_permission)
+                if self.config.dev_settings
+                and self.config.dev_settings.distribution_configuration
+                and self.config.dev_settings.distribution_configuration.launch_permission
+                else None
+            ),
         }
         distributions = []
         for region in self._get_distribution_regions():
@@ -588,9 +590,11 @@ class ImageBuilderCdkStack(Stack):
             tags=build_tags,
             resource_tags=build_tags,
             instance_profile_name=instance_profile_name or Fn.ref("InstanceProfile"),
-            terminate_instance_on_failure=self.config.dev_settings.terminate_instance_on_failure
-            if self.config.dev_settings and self.config.dev_settings.terminate_instance_on_failure is not None
-            else True,
+            terminate_instance_on_failure=(
+                self.config.dev_settings.terminate_instance_on_failure
+                if self.config.dev_settings and self.config.dev_settings.terminate_instance_on_failure is not None
+                else True
+            ),
             instance_types=[self.config.build.instance_type],
             security_group_ids=self.config.build.security_group_ids,
             subnet_id=self.config.build.subnet_id,
@@ -796,12 +800,14 @@ class ImageBuilderCdkStack(Stack):
             timeout=900,
             environment=lambda_env,
             tags=build_tags,
-            vpc_config=awslambda.CfnFunction.VpcConfigProperty(
-                security_group_ids=self.config.lambda_functions_vpc_config.security_group_ids,
-                subnet_ids=self.config.lambda_functions_vpc_config.subnet_ids,
-            )
-            if self.config.lambda_functions_vpc_config
-            else None,
+            vpc_config=(
+                awslambda.CfnFunction.VpcConfigProperty(
+                    security_group_ids=self.config.lambda_functions_vpc_config.security_group_ids,
+                    subnet_ids=self.config.lambda_functions_vpc_config.subnet_ids,
+                )
+                if self.config.lambda_functions_vpc_config
+                else None
+            ),
         )
         permission = awslambda.CfnPermission(
             self,

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -131,12 +131,12 @@ class Pool(Construct):
                             **{
                                 "BaseOS": self._config.image.os,
                                 "ClusterName": self.stack_name,
-                                "ClusterDNSDomain": str(self._cluster_hosted_zone.name)
-                                if self._cluster_hosted_zone
-                                else "",
-                                "ClusterHostedZone": str(self._cluster_hosted_zone.ref)
-                                if self._cluster_hosted_zone
-                                else "",
+                                "ClusterDNSDomain": (
+                                    str(self._cluster_hosted_zone.name) if self._cluster_hosted_zone else ""
+                                ),
+                                "ClusterHostedZone": (
+                                    str(self._cluster_hosted_zone.ref) if self._cluster_hosted_zone else ""
+                                ),
                                 "CustomNodePackage": self._config.custom_node_package or "",
                                 "CustomAwsBatchCliPackage": self._config.custom_aws_batch_cli_package or "",
                                 "CWLoggingEnabled": "true" if self._config.is_cw_logging_enabled else "false",
@@ -207,9 +207,9 @@ class Pool(Construct):
                                 "LaunchingLifecycleHookName": (
                                     f"{self._login_nodes_stack_id}-LoginNodesLaunchingLifecycleHook"
                                 ),
-                                "DisableSudoAccessForDefault": "true"
-                                if self._config.disable_sudo_access_default_user
-                                else "false",
+                                "DisableSudoAccessForDefault": (
+                                    "true" if self._config.disable_sudo_access_default_user else "false"
+                                ),
                             },
                             **get_common_user_data_env(self._pool, self._config),
                         },

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -156,9 +156,9 @@ class QueuesStack(NestedStack):
                 associate_public_ip_address=queue.networking.assign_public_ip,
                 interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                 groups=queue_lt_security_groups,
-                subnet_id=queue.networking.subnet_ids[0]
-                if isinstance(compute_resource, SlurmComputeResource)
-                else None,
+                subnet_id=(
+                    queue.networking.subnet_ids[0] if isinstance(compute_resource, SlurmComputeResource) else None
+                ),
             )
         ]
 
@@ -170,9 +170,9 @@ class QueuesStack(NestedStack):
                     associate_public_ip_address=False,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,
-                    subnet_id=queue.networking.subnet_ids[0]
-                    if isinstance(compute_resource, SlurmComputeResource)
-                    else None,
+                    subnet_id=(
+                        queue.networking.subnet_ids[0] if isinstance(compute_resource, SlurmComputeResource) else None
+                    ),
                 )
             )
 
@@ -229,9 +229,9 @@ class QueuesStack(NestedStack):
                         get_user_data_content("../resources/compute_node/user_data.sh"),
                         {
                             **{
-                                "DisableMultiThreadingManually": "true"
-                                if compute_resource.disable_simultaneous_multithreading_manually
-                                else "false",
+                                "DisableMultiThreadingManually": (
+                                    "true" if compute_resource.disable_simultaneous_multithreading_manually else "false"
+                                ),
                                 "BaseOS": self._config.image.os,
                                 "OSUser": OS_MAPPING[self._config.image.os]["user"],
                                 "ClusterName": self.stack_name,
@@ -330,17 +330,19 @@ class QueuesStack(NestedStack):
                         self._shared_storage_mount_dirs[SharedStorageType.FSX]
                     ),
                     "scheduler": self._config.scheduling.scheduler,
-                    "ephemeral_dir": queue.compute_settings.local_storage.ephemeral_volume.mount_dir
-                    if isinstance(queue, SlurmQueue) and queue.compute_settings.local_storage.ephemeral_volume
-                    else DEFAULT_EPHEMERAL_DIR,
+                    "ephemeral_dir": (
+                        queue.compute_settings.local_storage.ephemeral_volume.mount_dir
+                        if isinstance(queue, SlurmQueue) and queue.compute_settings.local_storage.ephemeral_volume
+                        else DEFAULT_EPHEMERAL_DIR
+                    ),
                     "ebs_shared_dirs": to_comma_separated_string(
                         self._shared_storage_mount_dirs[SharedStorageType.EBS]
                     ),
                     "proxy": queue.networking.proxy.http_proxy_address if queue.networking.proxy else "NONE",
                     "slurm_ddb_table": self._dynamodb_table.ref if self._dynamodb_table else "NONE",
-                    "log_group_name": self._log_group.log_group_name
-                    if self._config.monitoring.logs.cloud_watch.enabled
-                    else "NONE",
+                    "log_group_name": (
+                        self._log_group.log_group_name if self._config.monitoring.logs.cloud_watch.enabled else "NONE"
+                    ),
                     "dns_domain": str(self._cluster_hosted_zone.name) if self._cluster_hosted_zone else "",
                     "hosted_zone": str(self._cluster_hosted_zone.ref) if self._cluster_hosted_zone else "",
                     "node_type": "ComputeFleet",
@@ -350,9 +352,9 @@ class QueuesStack(NestedStack):
                     "log_rotation_enabled": "true" if self._config.is_log_rotation_enabled else "false",
                     "scheduler_queue_name": queue.name,
                     "scheduler_compute_resource_name": compute_resource.name,
-                    "enable_efa_gdr": "compute"
-                    if compute_resource.efa and compute_resource.efa.gdr_support
-                    else "NONE",
+                    "enable_efa_gdr": (
+                        "compute" if compute_resource.efa and compute_resource.efa.gdr_support else "NONE"
+                    ),
                     "custom_node_package": self._config.custom_node_package or "",
                     "custom_awsbatchcli_package": self._config.custom_aws_batch_cli_package or "",
                     "use_private_hostname": str(
@@ -360,9 +362,9 @@ class QueuesStack(NestedStack):
                     ).lower(),
                     "head_node_private_ip": self._head_eni.attr_primary_private_ip_address,
                     "directory_service": {"enabled": str(self._config.directory_service is not None).lower()},
-                    "disable_sudo_access_for_default_user": "true"
-                    if self._config.disable_sudo_access_default_user
-                    else "false",
+                    "disable_sudo_access_for_default_user": (
+                        "true" if self._config.disable_sudo_access_default_user else "false"
+                    ),
                 }
             },
             indent=4,

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -283,9 +283,11 @@ class SlurmConstruct(Construct):
             function_id="CleanupRoute53",
             bucket=self.bucket,
             config=self.config,
-            execution_role=cleanup_route53_lambda_execution_role.attr_arn
-            if cleanup_route53_lambda_execution_role
-            else self.config.iam.roles.lambda_functions_role,
+            execution_role=(
+                cleanup_route53_lambda_execution_role.attr_arn
+                if cleanup_route53_lambda_execution_role
+                else self.config.iam.roles.lambda_functions_role
+            ),
             handler_func="cleanup_resources",
         ).lambda_func
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -340,16 +340,16 @@ def split_resource_prefix(resource_prefix):
     if resource_prefix:
         split_index = resource_prefix.rfind("/") + 1
         return (
-            None
-            if split_index == 0
-            else resource_prefix
-            if split_index == len(resource_prefix)
-            else resource_prefix[:split_index],
-            None
-            if split_index == len(resource_prefix)
-            else resource_prefix
-            if split_index == 0
-            else resource_prefix[split_index:],
+            (
+                None
+                if split_index == 0
+                else resource_prefix if split_index == len(resource_prefix) else resource_prefix[:split_index]
+            ),
+            (
+                None
+                if split_index == len(resource_prefix)
+                else resource_prefix if split_index == 0 else resource_prefix[split_index:]
+            ),
         )
     return None, None
 

--- a/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
+++ b/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
@@ -109,8 +109,10 @@ class Pcluster3ConfigConverter(object):
         """Read config from config file or from string."""
         try:
             self.config_parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
-            self.config_parser.read_string(self.config_file) if self.input_as_string else self.config_parser.read(
-                self.config_file
+            (
+                self.config_parser.read_string(self.config_file)
+                if self.input_as_string
+                else self.config_parser.read(self.config_file)
             )
         except (configparser.ParsingError, configparser.DuplicateOptionError) as e:
             _error("Error parsing configuration file {0}.\n{1}".format(self.config_file, str(e)))

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -3,6 +3,7 @@ This module loads pytest fixtures and plugins needed by all tests.
 
 It's very useful for fixtures that need to be shared among all tests.
 """
+
 import logging
 import os
 import sys

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -72,9 +72,13 @@ def test_list_instance_types(boto3_stubber, generate_error):
         MockedBoto3Request(
             method="describe_instance_type_offerings",
             expected_params={},
-            response=dummy_message
-            if generate_error
-            else {"InstanceTypeOfferings": [{"InstanceType": instance_type} for instance_type in dummy_instance_types]},
+            response=(
+                dummy_message
+                if generate_error
+                else {
+                    "InstanceTypeOfferings": [{"InstanceType": instance_type} for instance_type in dummy_instance_types]
+                }
+            ),
             generate_error=generate_error,
         )
     ]

--- a/cli/tests/pcluster/aws/test_elb.py
+++ b/cli/tests/pcluster/aws/test_elb.py
@@ -54,9 +54,9 @@ def test_list_load_balancers(boto3_stubber, generate_error):
         MockedBoto3Request(
             method="describe_load_balancers",
             expected_params={"Marker": dummy_next_marker},
-            response=dummy_message
-            if generate_error
-            else {"LoadBalancers": [dummy_load_balancer_2], "ResponseMetadata": {}},
+            response=(
+                dummy_message if generate_error else {"LoadBalancers": [dummy_load_balancer_2], "ResponseMetadata": {}}
+            ),
             generate_error=generate_error,
         ),
     ]
@@ -98,9 +98,9 @@ def test_describe_tags(boto3_stubber, generate_error):
         MockedBoto3Request(
             method="describe_tags",
             expected_params={"ResourceArns": dummy_load_balancer_arns},
-            response=dummy_message
-            if generate_error
-            else {"TagDescriptions": dummy_tags_description, "ResponseMetadata": {}},
+            response=(
+                dummy_message if generate_error else {"TagDescriptions": dummy_tags_description, "ResponseMetadata": {}}
+            ),
             generate_error=generate_error,
         )
     ]
@@ -177,9 +177,11 @@ def test_describe_target_health(boto3_stubber, generate_error):
         MockedBoto3Request(
             method="describe_target_health",
             expected_params={"TargetGroupArn": "dummy_target_arn"},
-            response=dummy_message
-            if generate_error
-            else {"TargetHealthDescriptions": dummy_targets_health, "ResponseMetadata": {}},
+            response=(
+                dummy_message
+                if generate_error
+                else {"TargetHealthDescriptions": dummy_targets_health, "ResponseMetadata": {}}
+            ),
             generate_error=generate_error,
         )
     ]

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -780,9 +780,9 @@ def _test_storage(base_conf, target_conf):
                 "Name": f"{storage_name}4",
                 "MountDir": f"/{storage_name}4",
                 "StorageType": storage_type,
-                f"{storage_type}Settings": {"Encrypted": True}
-                if storage_type in ("Ebs", "Efs")
-                else {"DeploymentType": "PERSISTENT_2"},
+                f"{storage_type}Settings": (
+                    {"Encrypted": True} if storage_type in ("Ebs", "Efs") else {"DeploymentType": "PERSISTENT_2"}
+                ),
             }
         )
 

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -242,9 +242,11 @@ class TestCluster:
                 "stack_name": FAKE_NAME,
                 "template_url": template_url,
             },
-            side_effect=AWSClientError(function_name="update_stack_from_url", message=error_message)
-            if error_message is not None
-            else None,
+            side_effect=(
+                AWSClientError(function_name="update_stack_from_url", message=error_message)
+                if error_message is not None
+                else None
+            ),
         )
 
         # mock bucket initialize

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -143,9 +143,11 @@ def test_get_supported_batch_instance_types(mocker, raise_error_parsing_function
     # Mock all functions called by the function
     parsing_function_patch = mocker.patch(
         "pcluster.aws.batch.BatchClient.get_supported_instance_types_and_families",
-        side_effect=BatchErrorMessageParsingException
-        if raise_error_parsing_function
-        else lambda: dummy_batch_instance_types + dummy_batch_instance_families,
+        side_effect=(
+            BatchErrorMessageParsingException
+            if raise_error_parsing_function
+            else lambda: dummy_batch_instance_types + dummy_batch_instance_families
+        ),
     )
     supported_instance_types_patch = mocker.patch(
         "pcluster.aws.ec2.Ec2Client.list_instance_types", return_value=dummy_all_instance_types

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -1138,9 +1138,11 @@ def test_capacity_reservation_resource_group_validator(
     )
     mocker.patch(
         "pcluster.aws.resource_groups.ResourceGroupsClient.get_group_configuration",
-        side_effect=AWSClientError("mock-func", "mock-error")
-        if group_configuration == "AWSClientError"
-        else lambda group: group_configuration,
+        side_effect=(
+            AWSClientError("mock-func", "mock-error")
+            if group_configuration == "AWSClientError"
+            else lambda group: group_configuration
+        ),
     )
 
     mocker.patch(

--- a/cli/tests/pcluster/validators/test_kms_validators.py
+++ b/cli/tests/pcluster/validators/test_kms_validators.py
@@ -31,9 +31,9 @@ def test_kms_key_validator(mocker, kms_key_id, expected_message):
     mock_aws_api(mocker)
     mocker.patch(
         "pcluster.aws.kms.KmsClient.describe_key",
-        side_effect=AWSClientError(function_name="describe_key", message=expected_message)
-        if expected_message
-        else None,
+        side_effect=(
+            AWSClientError(function_name="describe_key", message=expected_message) if expected_message else None
+        ),
     )
 
     actual_failures = KmsKeyValidator().execute(kms_key_id)

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -1,4 +1,5 @@
 """Additional pytest configuration."""
+
 import os
 import random
 import string

--- a/cloudformation/tests/test_cfn_validation.py
+++ b/cloudformation/tests/test_cfn_validation.py
@@ -1,4 +1,5 @@
 """Test that all of the templates are in a valid format."""
+
 import json
 import os
 

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -789,7 +789,7 @@ test-suites:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
-          schedulers: ["slurm", "awsbatch"]
+          schedulers: ["slurm"]
   tags:
     test_tag_propagation.py::test_tag_propagation:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -832,10 +832,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["slurm"]
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204"]
-          schedulers: ["slurm"]
     test_update.py::test_multi_az_create_and_update:
       dimensions:
         - regions: ["eu-west-2"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -397,10 +397,6 @@ test-suites:
         # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
         # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
-          schedulers: ["slurm"]
-        - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["rhel8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -265,7 +265,7 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
     test_dns.py::test_existing_hosted_zone:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -84,20 +84,10 @@ test-suites:
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: ["af-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
-          schedulers: ["slurm"]
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        # Do not run on ARM + Batch
-        # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-        - regions: ["us-gov-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
     test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
       dimensions:
         - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -55,20 +55,10 @@ test-suites:
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: ["af-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
-          schedulers: ["slurm"]
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        # Do not run on ARM + Batch
-        # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-        - regions: ["us-gov-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
   create:
     test_create.py::test_create_wrong_os:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -132,12 +132,6 @@ test-suites:
           oss: ["ubuntu2204"]
           schedulers: ["slurm"]
   dns:
-    test_dns.py::test_hit_no_cluster_dns_mpi:
-      dimensions:
-        - regions: ["af-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm"]
     test_dns.py::test_existing_hosted_zone:
       dimensions:
         - regions: ["eu-south-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -179,12 +179,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
-    test_networking.py::test_public_network_topology:
-      dimensions:
-        - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
-    test_networking.py::test_public_private_network_topology:
-      dimensions:
-        - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
     test_cluster_networking.py::test_cluster_in_no_internet_subnet:
       dimensions:
         # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -209,13 +209,6 @@ test-suites:
     test_api.py::test_official_images:
       dimensions:
         - regions: ["sa-east-1"]
-  resource_bucket:
-    test_resource_bucket.py::test_resource_bucket:
-      dimensions:
-        - regions: ["us-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm", "awsbatch"]
   scaling:
     test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -179,26 +179,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
-    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
-      dimensions:
-        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
-        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
-        - regions: ["us-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
-          schedulers: ["slurm"]
-        - regions: ["us-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
-          schedulers: ["slurm"]
-        - regions: ["cn-north-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
-          schedulers: ["slurm"]
-        - regions: ["us-gov-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
-          schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
         - regions: ["ap-northeast-2"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -404,12 +404,14 @@ def clusters_factory(request, region):
     def _cluster_factory(cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, **kwargs):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster = Cluster(
-            name=request.config.getoption("cluster")
-            if request.config.getoption("cluster")
-            else "integ-tests-{0}{1}{2}".format(
-                random_alphanumeric().upper() if upper_case_cluster_name else random_alphanumeric(),
-                "-" if request.config.getoption("stackname_suffix") else "",
-                request.config.getoption("stackname_suffix"),
+            name=(
+                request.config.getoption("cluster")
+                if request.config.getoption("cluster")
+                else "integ-tests-{0}{1}{2}".format(
+                    random_alphanumeric().upper() if upper_case_cluster_name else random_alphanumeric(),
+                    "-" if request.config.getoption("stackname_suffix") else "",
+                    request.config.getoption("stackname_suffix"),
+                )
             ),
             config_file=cluster_config,
             ssh_key=request.config.getoption("key_path"),
@@ -506,9 +508,11 @@ def images_factory(request):
     def _image_factory(image_id, image_config, region, **kwargs):
         image_config_file = _write_config_to_outdir(request, image_config, "image_configs")
         image = Image(
-            image_id="-".join([image_id, request.config.getoption("stackname_suffix")])
-            if request.config.getoption("stackname_suffix")
-            else image_id,
+            image_id=(
+                "-".join([image_id, request.config.getoption("stackname_suffix")])
+                if request.config.getoption("stackname_suffix")
+                else image_id
+            ),
             config_file=image_config_file,
             region=region,
         )

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -697,16 +697,16 @@ def _split_resource_prefix(resource_prefix):
     if resource_prefix:
         split_index = resource_prefix.rfind("/") + 1
         return (
-            None
-            if split_index == 0
-            else resource_prefix
-            if split_index == len(resource_prefix)
-            else resource_prefix[:split_index],
-            None
-            if split_index == len(resource_prefix)
-            else resource_prefix
-            if split_index == 0
-            else resource_prefix[split_index:],
+            (
+                None
+                if split_index == 0
+                else resource_prefix if split_index == len(resource_prefix) else resource_prefix[:split_index]
+            ),
+            (
+                None
+                if split_index == len(resource_prefix)
+                else resource_prefix if split_index == 0 else resource_prefix[split_index:]
+            ),
         )
     return None, None
 

--- a/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
@@ -175,8 +175,4 @@ def _test_api_deletion(api_stack):
 )
 def _wait_for_image_build(image_builder_pipeline):
     image_builder = boto3.client("imagebuilder")
-    return image_builder.list_image_pipeline_images(
-        imagePipelineArn=image_builder_pipeline,
-    )[
-        "imageSummaryList"
-    ][0]
+    return image_builder.list_image_pipeline_images(imagePipelineArn=image_builder_pipeline)["imageSummaryList"][0]


### PR DESCRIPTION
Released version test changes (removes 18 tests):
- Reduce dimensions of pcluster configure tests (2 --> 1)
- Reduce dimensions of DNS tests (5 --> 0)
- Remove network topology tests for released version (6 --> 0)
- Reduce dimensions for tests in no-internet subnets (4 --> 0)
- Reduce dimensions for custom Resource Bucket test (2 --> 0)

Develop version test changes (removes 5 tests):
- Reduce dimensions of pcluster configure tests (2 --> 1)
- Reduce dimensions of DNS tests (6 --> 5)
- Reduce dimensions for tests in no-internet subnets (4 --> 3)
- Reduce dimensions for custom Resource Bucket test (2 --> 1)
- Reduce dimensions for dynamic file system update test (2 --> 1)

### Tests

Executed `python -m test_runner develop.yaml ... --dryrun` to verify number of tests and configuration syntax
* released: pre: 221 tests, after: 207 tests
* develop: pre: 262 tests, after: 256 tests

### References
* Follow up of https://github.com/aws/aws-parallelcluster/pull/6040 and https://github.com/aws/aws-parallelcluster/pull/6038