### PR TITLE
External Slurmdbd stack improvements

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -53,14 +53,6 @@ class ExternalSlurmdbdStack(Stack):
         )
         self.subnet = ec2.Subnet.from_subnet_id(self, "subnet", subnet_id=self.subnet_id.value_as_string)
 
-        # define Target Group
-        self._external_slurmdbd_target_group = self._add_external_slurmdbd_target_group()
-
-        # define Network Load Balancer (NLB)
-        self._external_slurmdbd_nlb = self._add_external_slurmdbd_load_balancer(
-            target_group=self._external_slurmdbd_target_group
-        )
-
         # Define additional CloudFormation parameters for dna.json to pass to cookbook
         self.dbms_uri = CfnParameter(self, "DBMSUri", type="String", description="DBMS URI for Slurmdbd.")
         self.dbms_username = CfnParameter(
@@ -124,7 +116,6 @@ class ExternalSlurmdbdStack(Stack):
             "munge_key_secret_arn": self.munge_key_secret_arn.value_as_string,
             "region": self.region,
             "stack_name": self.stack_name,
-            "nlb_dns_name": self._external_slurmdbd_nlb.load_balancer_dns_name,
             "is_external_slurmdbd": True,
         }
 
@@ -181,21 +172,6 @@ class ExternalSlurmdbdStack(Stack):
                 }
             },
         }
-
-    def _add_external_slurmdbd_target_group(self):
-        return elbv2.NetworkTargetGroup(
-            self,
-            # TODO: add resource name!
-            "External-Slurmdbd-TG",
-            health_check=elbv2.HealthCheck(
-                port="6819",
-                protocol=elbv2.Protocol.TCP,
-            ),
-            port=6819,
-            protocol=elbv2.Protocol.TCP,
-            target_type=elbv2.TargetType.INSTANCE,
-            vpc=self.vpc,
-        )
 
     def _add_management_security_groups(self):
         server_sg = ec2.SecurityGroup(
@@ -326,24 +302,6 @@ class ExternalSlurmdbdStack(Stack):
         launch_template.add_metadata("AWS::CloudFormation::Init", self._cfn_init_config)
 
         return launch_template
-
-    def _add_external_slurmdbd_load_balancer(
-        self,
-        target_group,
-    ):
-        nlb = elbv2.NetworkLoadBalancer(
-            self,
-            "External-Slurmdbd-NLB",
-            vpc=self.vpc,
-            vpc_subnets=ec2.SubnetSelection(subnets=[self.subnet]),
-            internet_facing=False,
-        )
-
-        # add listener to NLB
-        listener = nlb.add_listener("External-Slurmdbd-Listener", port=6819)
-        listener.add_target_groups("External-Slurmdbd-Target", target_group)
-
-        return nlb
 
     def _add_slurmdbd_primary_instance(self):
         return ec2.CfnInstance(

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -90,19 +90,19 @@ class ExternalSlurmdbdStack(Stack):
         self._launch_template = self._add_external_slurmdbd_launch_template()
 
         # define EC2 Auto Scaling Group (ASG)
-        # self._external_slurmdbd_asg = self._add_external_slurmdbd_auto_scaling_group()
+        self._external_slurmdbd_asg = self._add_external_slurmdbd_auto_scaling_group()
 
         # define Primary Slurmdbd Instance (not via ASG)
-        self._primary_slurmdbd_instance = self._add_slurmdbd_primary_instance()
+        # self._primary_slurmdbd_instance = self._add_slurmdbd_primary_instance()
 
         # define external slurmdbd hosted zone
-        self._hosted_zone = self._add_hosted_zone()
+        # self._hosted_zone = self._add_hosted_zone()
 
         # Add DNS record to hosted zone
-        self._add_instance_to_dns(
-            ip_addr=self._primary_slurmdbd_instance.attr_private_ip,
-            name="slurmdbd",
-        )
+        # self._add_instance_to_dns(
+        #     ip_addr=self._primary_slurmdbd_instance.attr_private_ip,
+        #     name="slurmdbd",
+        # )
 
     def _add_cfn_init_config(self):
         dna_json_content = {

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -49,7 +49,7 @@ class ExternalSlurmdbdStack(Stack):
         self.vpc = ec2.Vpc.from_lookup(self, "VPC", vpc_id=self.vpc_id.value_as_string)
 
         self.subnet_id = CfnParameter(
-            self, "SubnetId", type="String", description="The Subnet to be used for the Slurmdbd stack."
+            self, "SubnetId", type="AWS::EC2::Subnet::Id", description="The Subnet to be used for the Slurmdbd stack."
         )
         self.subnet = ec2.Subnet.from_subnet_id(self, "subnet", subnet_id=self.subnet_id.value_as_string)
 
@@ -232,7 +232,9 @@ class ExternalSlurmdbdStack(Stack):
     def _add_external_slurmdbd_launch_template(self):
         # Define a CfnParameter for the AMI ID
         # This AMI should be Parallel Cluster AMI, which has installed Slurm and related software
-        ami_id_param = CfnParameter(self, "AmiId", type="String", description="The AMI id for the EC2 instance.")
+        ami_id_param = CfnParameter(
+            self, "AmiId", type="AWS::EC2::Image::Id", description="The AMI id for the EC2 instance."
+        )
         instance_type_param = CfnParameter(
             self,
             "InstanceType",
@@ -242,7 +244,7 @@ class ExternalSlurmdbdStack(Stack):
         key_name_param = CfnParameter(
             self,
             "KeyName",
-            type="String",
+            type="AWS::EC2::KeyPair::KeyName",
             description="The SSH key name to access the instance (for management purposes only)",
         )
         self.slurmdbd_private_ip = CfnParameter(
@@ -258,7 +260,7 @@ class ExternalSlurmdbdStack(Stack):
             description="Subnet prefix to assign with the private IP to the slurmdbd instance",
         )
         dbms_client_sg_id = CfnParameter(
-            self, "DBMSClientSG", type="String", description="DBMS Client Security Group Id"
+            self, "DBMSClientSG", type="AWS::EC2::SecurityGroup::Id", description="DBMS Client Security Group Id"
         )
 
         launch_template_data = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(

--- a/cloudformation/external-slurmdbd/resources/user_data.sh
+++ b/cloudformation/external-slurmdbd/resources/user_data.sh
@@ -60,4 +60,8 @@ if [ "${CustomCookbookUrl}" != "NONE" ]; then
   vendor_cookbook
 fi
 
-/opt/aws/bin/cfn-init -s ${StackName} -v -c default -r LaunchTemplate --region ${Region}
+# This is necessary to find the cfn-init application
+export PATH=/opt/aws/bin:${!PATH}
+[ -f /etc/profile.d/pcluster.sh ] && . /etc/profile.d/pcluster.sh
+
+cfn-init -s ${StackName} -v -c default -r LaunchTemplate --region ${Region}


### PR DESCRIPTION
### Description of changes
* Various small improvements to the external slurmdbd stack:
  * Remove the NLB-related elements from the POC stack (option discarded);
  * Disable Route53 setup in POC stack (possibly to be removed in the future);
  * Use the static secondary private IP of the slurmdbd instance for the `DbdAddr` slurmdbd parameter (see also [changes in Cookbook](https://github.com/aws/aws-parallelcluster-cookbook/pull/2625));
  * Use AWS-specific CFN parameter types for subnet IDs, AMI IDs, etc.
  * Fix `PATH` in the user_data.sh of the external slurmdbd instance.

### Tests
* Manually tested the changes on my POC stack.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2625

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
