### PR TITLE
[Tests] Improve createami test to validate and use the created AMI

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -158,10 +158,8 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel8"]
-        - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          schedulers: ["slurm"]
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -88,9 +88,11 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel8"]
+          schedulers: ["slurm"]
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          schedulers: ["slurm"]
           oss: {{ common.NOT_RELEASED_OSES }}
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -374,9 +374,11 @@ def _test_image_tag_and_volume(image):
     )
     logging.info(image_list)
     assert_that(len(image_list)).is_equal_to(1)
-    volume_size = image_list[0].get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
+
+    created_image = image_list[0]
+    volume_size = created_image.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
     assert_that(volume_size).is_equal_to(200)
-    assert_that(image.image_tags).contains({"key": "dummyImageTag", "value": "dummyImageTag"})
+    assert_that(created_image["Tags"]).contains({"key": "dummyImageTag", "value": "dummyImageTag"})
 
 
 @pytest.fixture()

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -19,7 +19,7 @@ import time
 
 import boto3
 import pytest
-from assertpy import assert_that
+from assertpy import assert_that, soft_assertions
 from botocore.exceptions import ClientError
 from cfn_stacks_factory import CfnStack
 from dateutil.parser import parse as date_parse
@@ -152,14 +152,15 @@ def test_build_image(
         image.image_id, region, lamda_vpc_config["SecurityGroupIds"], lamda_vpc_config["SubnetIds"]
     )
 
-    _test_build_image_success(image)
-    _test_build_instances_tags(image, image.config["Build"]["Tags"], region)
-    _test_build_imds_settings(image, "required", region)
-    _test_image_tag_and_volume(image)
-    _test_list_image_log_streams(image)
-    _test_get_image_log_events(image)
-    _test_list_images(image)
-    _test_export_logs(s3_bucket_factory, image, region)
+    with soft_assertions():
+        _test_build_image_success(image)
+        _test_build_instances_tags(image, image.config["Build"]["Tags"], region)
+        _test_build_imds_settings(image, "required", region)
+        _test_image_tag_and_volume(image)
+        _test_list_image_log_streams(image)
+        _test_get_image_log_events(image)
+        _test_list_images(image)
+        _test_export_logs(s3_bucket_factory, image, region)
 
     _test_cluster_creation(
         image.ec2_image_id, pcluster_config_reader, region, clusters_factory, scheduler_commands_factory

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -23,3 +23,6 @@ DeploymentSettings:
         - {{ private_subnet_id }}
         SecurityGroupIds:
         - {{ default_vpc_security_group_id }}
+
+DevSettings:
+    DisableValidateAndTest: False

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
@@ -12,11 +12,11 @@ HeadNode:
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
-    - Name: queue1
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
-      ComputeResources:
-        - Name: compute-resource1
-          Instances:
-            - InstanceType: {{ instance }}
+  - Name: queue1
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+    ComputeResources:
+      - Name: compute-resource1
+        Instances:
+          - InstanceType: {{ instance }}


### PR DESCRIPTION
### Description of changes
By enabling `DisableValidateAndTest` we're going to execute all the Kitchen tests with `tag:install_` prefix as part of the Image Builder validation phase.

We extended the test to use the generated AMI for a cluster and run a job on it.

We also extended the dimensions to run it on every supported OS and removed scheduler dimension.

### Tests
* Executed the test for all the OSes.
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_COMMERCIAL_X86 }}
          schedulers: ["slurm"]
```
