### PR TITLE
[integ-tests-3.8.0] [Tests] Remove rocky8 tests from released tests

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -88,10 +88,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel8"]
-        - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["ubuntu2204", "rhel8", "alinux2"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
@@ -159,7 +156,7 @@ test-suites:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["alinux2"]
     test_structured_log_events.py::test_custom_compute_action_failure:
       dimensions:
         - regions: ["af-south-1"]
@@ -183,7 +180,7 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
@@ -253,7 +250,7 @@ test-suites:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:


### PR DESCRIPTION
### Description of changes
* I wrongly re-introduced them as part of https://github.com/aws/aws-parallelcluster/pull/6043