### PR TITLE
[Test] Add permission logs:ListTagsForResource to the role assumed by…

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -488,6 +488,7 @@ Resources:
               - logs:CreateLogGroup
               - logs:TagResource
               - logs:UntagResource
+              - logs:ListTagsForResource
               - logs:DescribeMetricFilters
               - logs:PutMetricFilter
               - logs:deleteMetricFilter


### PR DESCRIPTION
### Description of changes
Add permission `logs:ListTagsForResource` to the role assumed by the integration testing framework.
This permission is required during the update of all custom resources.
The lack of this permission is not blocking the actual update because the update request is retried without tagging info.

Example of error:
```
Encountered a permissions error performing a tagging operation, please add required tag permissions. 
Retrying request without including tags. 
See https://repost.aws/knowledge-center/cloudformation-tagging-permission-error for how to resolve. 
Resource handler returned message: "User: arn:aws:sts::***:assumed-role/integ-tests-iam-user-role-2-ParallelClusterUserRole-***/eu-west-1_integration_tests_session is not authorized to perform: logs:ListTagsForResource on resource: arn:aws:logs:eu-west-1:***:log-group:/aws/lambda/pcluster-WaitClusterReady-*** 
because no identity-based policy allows the logs:ListTagsForResource action (Service: CloudWatchLogs, Status Code: 400, Request ID: ***)"
```

### Tests
* Verified that the error has been fixed by running the integ test `test_update_slurm`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
