### PR TITLE
Add outputs to ExternalSlurmDbd Stack

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -1,7 +1,7 @@
 import json
 
 import pkg_resources
-from aws_cdk import CfnParameter, Fn, Stack
+from aws_cdk import CfnOutput, CfnParameter, Fn, Stack
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
@@ -102,6 +102,8 @@ class ExternalSlurmdbdStack(Stack):
         #     ip_addr=self._primary_slurmdbd_instance.attr_private_ip,
         #     name="slurmdbd",
         # )
+
+        self._add_outputs()
 
     def _add_cfn_init_config(self):
         dna_json_content = {
@@ -415,4 +417,30 @@ class ExternalSlurmdbdStack(Stack):
             resource_records=[ip_addr],
             set_identifier="externalslurmdbdsetidentifier",
             ttl="300",
+        )
+
+    def _add_outputs(self):
+        CfnOutput(
+            self,
+            "SlurmDbdPrivateIP",
+            description="Secondary Private IP Address of the slurmdbd instance",
+            value=self.slurmdbd_private_ip.value_as_string,
+        )
+        CfnOutput(
+            self,
+            "SlurmDbdPort",
+            description="Port used to connect to slurmdbd service",
+            value="6819",  # this should be paramterized
+        )
+        CfnOutput(
+            self,
+            "AccountingClientSG",
+            description="Security Group ID that allows traffic from the slurmctld to slurmdbd",
+            value=self._slurmdbd_client_sg.security_group_id,
+        )
+        CfnOutput(
+            self,
+            "SSHClientSG",
+            description="Security Group ID that allows SSH traffic from the HeadNode to slurmdbd instance",
+            value=self._ssh_client_sg.security_group_id,
         )

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -430,7 +430,7 @@ class ExternalSlurmdbdStack(Stack):
             self,
             "SlurmDbdPort",
             description="Port used to connect to slurmdbd service",
-            value="6819",  # this should be paramterized
+            value="6819",  # this should be parametrized
         )
         CfnOutput(
             self,


### PR DESCRIPTION
### Description of changes

Add output values that should be used in cluster configuration
* SlurmDbdPrivateIP
* SlurmDbdPort
* AccountingClientSG
* SSHClientSG


### Tests
* Deployed stack in my account. The outputs were added in the stacks and the values were correct.

### References
N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
