### PR TITLE
[DFSM] Allow dynamic file system mounting as live update on compute nodes for external EFS/FSx* storage.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -72,6 +72,7 @@ OPENZFS = "OPENZFS"
 ONTAP = "ONTAP"
 FILECACHE = "FILECACHE"
 
+EFS = "Efs"
 FSX_LUSTRE = "FsxLustre"
 FSX_OPENZFS = "FsxOpenZfs"
 FSX_ONTAP = "FsxOntap"


### PR DESCRIPTION
### Description of changes
Allow dynamic file system mounting as live update on compute nodes for external EFS/FSx* storage.
Added/revised unit tests.

### Tests
* Dryrun update in the following cases:
  * add/remove external EFS/FSx: accepted as expected
  * add/remove managed EFS/FSx: rejected as expected
  * add/remove external/managed EBS: rejected as expected 
  * add/remove /home: rejected as expected
* Unit tests.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
