### PR TITLE
Add log_group_name to dna.json for ExternalSlurmDbd

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -86,6 +86,8 @@ class ExternalSlurmdbdStack(Stack):
         self._instance_profile = self._add_instance_profile(self._role.ref, "ExternalSlurmdbdInstanceProfile")
 
         # create Launch Template
+        # This defines the dna.json and so it depends on many of the previous steps.
+        # It should be launched just before the ASG that should be the last before the outputs.
         self._launch_template = self._add_external_slurmdbd_launch_template()
 
         # define EC2 Auto Scaling Group (ASG)
@@ -114,6 +116,7 @@ class ExternalSlurmdbdStack(Stack):
             "dbms_password_secret_arn": self.dbms_password_secret_arn.value_as_string,
             "munge_key_secret_arn": self.munge_key_secret_arn.value_as_string,
             "region": self.region,
+            "log_group_name": self._log_group.log_group_name,
             "stack_name": self.stack_name,
             "is_external_slurmdbd": True,
         }
@@ -389,7 +392,7 @@ class ExternalSlurmdbdStack(Stack):
         return logs.LogGroup(
             self,
             "SlurmdbdLogGroup",
-            log_group_name=f"/aws/slurmdbd/{self.stack_name}",
+            log_group_name=f"/aws/parallelcluster/external-slurmdbd/{self.stack_name}",
             retention=logs.RetentionDays.ONE_WEEK,
         )
 


### PR DESCRIPTION
### Description of changes
Add log_group_name to dna.json created for ExternalSlurmDbd stack.

This parameter will be set in the CW Agent configuration and will be used by the agent when creating the log-streams and sending the logs.

### Tests
* CDK app synthesized in my personal account. 
* Logs emitted in the SlurmDbdInstances where visible in CloudWatch

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [Cookbook changes](https://github.com/aws/aws-parallelcluster-cookbook/pull/2630).

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
