### PR TITLE
[DFSM][Test] Make the 'test_dynamic_file_systems_update' and 'test_update_slurm' cover the live updates of compute nodes.

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -220,7 +220,7 @@ class Cluster:
             )
             raise
 
-    def describe_cluster_instances(self, node_type=None, queue_name=None):
+    def describe_cluster_instances(self, node_type=None, queue_name=None, query=None):
         """Run pcluster describe-cluster-instances and return the result"""
         cmd_args = ["pcluster", "describe-cluster-instances", "--cluster-name", self.name]
         if node_type:
@@ -235,11 +235,13 @@ class Cluster:
             cmd_args.extend(["--node-type", node_type])
         if queue_name:
             cmd_args.extend(["--queue-name", queue_name])
+        if query:
+            cmd_args.extend(["--query", query])
         try:
             result = run_pcluster_command(cmd_args, log_error=False, custom_cli_credentials=self.custom_cli_credentials)
             response = json.loads(result.stdout)
             logging.info("Get cluster {0} instances successfully".format(self.name))
-            return response["instances"]
+            return response if query else response["instances"]
         except subprocess.CalledProcessError as e:
             logging.error("Failed when getting cluster instances with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
             raise

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -375,9 +375,12 @@ def assert_instance_config_version_on_ddb(
             table_name = f"parallelcluster-{cluster.name}"
             item_id = f"CLUSTER_CONFIG.{instance_id}"
             item = get_ddb_item(cluster.region, table_name, {"Id": item_id})
-            assert_that(item).is_not_none()
+            assert_that(item, f"DDB record for #{instance_id} (#{node_type}) exists").is_not_none()
             cluster_config_version_on_ddb = item["Data"]["cluster_config_version"]
-            assert_that(cluster_config_version_on_ddb).is_equal_to(expected_cluster_config_version)
+            assert_that(
+                cluster_config_version_on_ddb,
+                f"DDB record for #{instance_id} (#{node_type}) has the correct config version",
+            ).is_equal_to(expected_cluster_config_version)
         logging.info(
             f"Verified that all {n_nodes} nodes ({node_type}) stored the expected config version on DDB: "
             f"{expected_cluster_config_version}"

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -22,7 +22,7 @@ from assertpy import assert_that
 from botocore.exceptions import ClientError
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from retrying import retry
-from time_utils import seconds
+from time_utils import minutes, seconds
 from utils import get_instance_info, run_command
 
 from tests.common.osu_common import PRIVATE_OSES
@@ -494,3 +494,10 @@ def assert_no_file_handler_leak(init_compute_ip_to_num_files, remote_command_exe
             assert_that(current_compute_ip_to_num_files[compute_ip]).is_equal_to(
                 init_compute_ip_to_num_files[compute_ip]
             )
+
+
+@retry(wait_fixed=minutes(3), stop_max_delay=minutes(9))
+def _wait_for_login_fleet_stop(cluster):
+    """Wait for the login fleet to be stopped"""
+    login_nodes = cluster.get_cluster_instance_ids(node_type="LoginNode")
+    assert_that(login_nodes).is_length(0)

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -183,6 +183,15 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
 
     # Verify that compute and login nodes stored the deployed config version on DDB
     last_cluster_config_version = get_deployed_config_version(cluster)
+    # This check must be retried because the last update added a new static node
+    # and the update workflow does not wait for new static nodes to complete their bootstrap, by design.
+    # On the other hand, the update workflow waits for existing nodes to complete their update recipes.
+    # As a consequence, the stack may reach the UPDATE_COMPLETE state
+    # without waiting for new static nodes to complete their bootstrap recipes.
+    retry(wait_fixed=seconds(10), stop_max_delay=minutes(3))(assert_instance_config_version_on_ddb)(
+        cluster, last_cluster_config_version
+    )
+
     assert_instance_config_version_on_ddb(cluster, last_cluster_config_version)
 
     # Here is the expected list of nodes.

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update.yaml
@@ -9,9 +9,20 @@ HeadNode:
   Iam:
     S3Access:
       - BucketName: {{ bucket_name }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: {{ login_nodes_count }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
 Scheduling:
+  {% if queue_update_strategy %}
   SlurmSettings:
-    QueueUpdateStrategy: DRAIN
+    QueueUpdateStrategy: {{ queue_update_strategy }}
+  {% endif %}
   Scheduler: slurm
   SlurmQueues:
     - Name: queue1
@@ -41,6 +52,7 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
 SharedStorage:
+{% if new_raid_mount_dir %}
   - MountDir: {{ new_raid_mount_dir }}
     StorageType: Ebs
     Name: manage-raid
@@ -53,18 +65,24 @@ SharedStorage:
         Type: 0
         NumberOfVolumes: 5
       DeletionPolicy: {{ new_raid_deletion_policy }}
+{% endif %}
+{% if new_ebs_mount_dir %}
   - MountDir: {{ new_ebs_mount_dir }}
     Name: /manage-ebs
     StorageType: Ebs
     EbsSettings:
       VolumeType: gp3
       DeletionPolicy: {{ new_ebs_deletion_policy }}
+{% endif %}
+{% if existing_ebs_mount_dir %}
   - MountDir: {{ existing_ebs_mount_dir }}
     Name: existing_ebs
     StorageType: Ebs
     EbsSettings:
       VolumeType: gp2
       VolumeId: {{ volume_id }}
+{% endif %}
+{% if new_efs_mount_dir %}
   - MountDir: {{ new_efs_mount_dir }}
     Name: manage-efs
     StorageType: Efs
@@ -74,12 +92,16 @@ SharedStorage:
       ThroughputMode: provisioned
       ProvisionedThroughput: 200
       DeletionPolicy: {{ new_efs_deletion_policy }}
+{% endif %}
+{% if existing_efs_mount_dir %}
   - MountDir: {{ existing_efs_mount_dir }}
     Name: existing_efs
     StorageType: Efs
     EfsSettings:
       FileSystemId: {{ existing_efs_id }}
-  {% if fsx_supported %}
+{% endif %}
+{% if fsx_supported %}
+{% if new_lustre_mount_dir %}
   - MountDir: {{ new_lustre_mount_dir }}
     Name: manage-fsx
     StorageType: FsxLustre
@@ -90,24 +112,34 @@ SharedStorage:
       DeploymentType: PERSISTENT_1
       PerUnitStorageThroughput: 200
       DeletionPolicy: {{ new_lustre_deletion_policy }}
+{% endif %}
+{% if fsx_lustre_mount_dir %}
   - MountDir: {{ fsx_lustre_mount_dir }}
     Name: existingfsx
     StorageType: FsxLustre
     FsxLustreSettings:
       FileSystemId: {{ existing_fsx_lustre_fs_id }}
+{% endif %}
+{% if fsx_open_zfs_mount_dir %}
   - MountDir: {{ fsx_open_zfs_mount_dir }}
     Name: existingopenzfs
     StorageType: FsxOpenZfs
     FsxOpenZfsSettings:
       VolumeId: {{ fsx_open_zfs_volume_id }}
+{% endif %}
+{% if fsx_ontap_mount_dir %}
   - MountDir: {{ fsx_ontap_mount_dir }}
     Name: existingontap
     StorageType: FsxOntap
     FsxOntapSettings:
       VolumeId: {{ fsx_ontap_volume_id }}
+{% endif %}
+{% if file_cache_mount_dir %}
   - MountDir: {{ file_cache_mount_dir }}
     Name: existingfilecache
     StorageType: FileCache
     FileCacheSettings:
       FileCacheId: {{ existing_file_cache_id }}
-  {% endif %}
+{% endif %}
+{% endif %}
+

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
@@ -9,9 +9,20 @@ HeadNode:
   Iam:
     S3Access:
       - BucketName: {{ bucket_name }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: {{ login_nodes_count }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
 Scheduling:
+  {% if queue_update_strategy %}
   SlurmSettings:
-    QueueUpdateStrategy: TERMINATE
+    QueueUpdateStrategy: {{ queue_update_strategy }}
+  {% endif %}
   Scheduler: slurm
   SlurmQueues:
     - Name: queue1

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
@@ -6,6 +6,15 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: {{ login_nodes_count }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
 Scheduling:
   Scheduler: slurm
   SlurmQueues:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -27,7 +27,7 @@ LoginNodes:
   Pools:
     - Name: login
       InstanceType: {{ instance }}
-      Count: 0
+      Count: 1
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -23,6 +23,18 @@ HeadNode:
         EnableWriteAccess: true  # New parameter
     AdditionalIamPolicies: # New section
       - Policy: {{ additional_policy_arn }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: 0
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
+      Iam:
+        AdditionalIamPolicies: # New section
+          - Policy: {{ additional_policy_arn }}
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -24,7 +24,7 @@ LoginNodes:
   Pools:
     - Name: login
       InstanceType: {{ instance }}
-      Count: 0
+      Count: 1
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -20,6 +20,15 @@ HeadNode:
   Iam:
     S3Access:
       - BucketName: {{ resource_bucket }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: 0
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
 Scheduling:
   Scheduler: slurm
   SlurmSettings:


### PR DESCRIPTION
### Description of changes
Make the 'test_dynamic_file_systems_update' and 'test_update_slurm' cover the live updates of compute nodes.
In particular:
1. removed the forced update as we allowed the update under certain conditions in https://github.com/aws/aws-parallelcluster/pull/6060
2. removed a retry in post-rollback assertion to check DDB records because we fixed the rollback path in https://github.com/aws/aws-parallelcluster-cookbook/pull/2634

### Tests
* Executed `test_update_slurm`
* Executed `test_dynamic_file_systems_update`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
