### PR TITLE
[develop] Fix DeviceIndex value to 1 on secondary interfaces for compute nodes

### DIFF
--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -153,6 +153,7 @@ class QueuesStack(NestedStack):
         compute_lt_nw_interfaces = [
             ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
                 device_index=0,
+                network_card_index=0,
                 associate_public_ip_address=queue.networking.assign_public_ip,
                 interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                 groups=queue_lt_security_groups,
@@ -165,7 +166,7 @@ class QueuesStack(NestedStack):
         for network_card_index in compute_resource.network_cards_index_list[1:]:
             compute_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=0,
+                    device_index=1,
                     network_card_index=network_card_index,
                     associate_public_ip_address=False,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,


### PR DESCRIPTION
This is done according to EC2 doc https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/p5-instances-started.html:

P5 instances deliver 3200 Gbps of networking bandwidth by using multiple EFA interfaces. P5 instances support 32 network cards. We recommend that you define a single EFA network interface per network card. To configure these interfaces at launch we recommend the following settings:

    For network interface 0, specify device index 0

    For network interfaces 1 through 31, specify device index 1

### Tests
* test_multiple_nics is consistently passing

### References
Same logic has been done for the head node 
https://github.com/aws/aws-parallelcluster/pull/4455

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
