### PR TITLE
Fix S3 bucket name for external slurmdbd stack

### DIFF
--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -424,7 +424,7 @@ class ExternalSlurmdbdStack(Stack):
         return s3.CfnBucket(
             self,
             id="ExternalSlurmdbdS3Bucket",
-            bucket_name=self.stack_name.lower(),
+            bucket_name=(self.stack_name.lower() + "-" + self.account + "-" + self.region),
             public_access_block_configuration=s3.CfnBucket.PublicAccessBlockConfigurationProperty(
                 block_public_acls=True,
                 block_public_policy=True,


### PR DESCRIPTION
### Description of changes
* Fix S3 bucket name for external slurmdbd stack

### Tests
* Manually tested on my POC stack

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
