### PR TITLE
[DFSM] Add permission `dynamodb:BatchGetItem` to the head node policies used by tests.

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -890,6 +890,7 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Query
               - dynamodb:GetItem
+              - dynamodb:BatchGetItem
               - dynamodb:PutItem
               - dynamodb:UpdateItem
               - dynamodb:BatchWriteItem

--- a/tests/integration-tests/resources/traditional_instance_policy.json
+++ b/tests/integration-tests/resources/traditional_instance_policy.json
@@ -48,6 +48,7 @@
         "dynamodb:UpdateItem",
         "dynamodb:Query",
         "dynamodb:GetItem",
+        "dynamodb:BatchGetItem",
         "dynamodb:BatchWriteItem",
         "dynamodb:DeleteItem",
         "dynamodb:DescribeTable"

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -555,6 +555,7 @@ def _create_permission_boundary(permission_boundary_name):
                         "dynamodb:CreateTable",
                         "dynamodb:DeleteTable",
                         "dynamodb:GetItem",
+                        "dynamodb:BatchGetItem",
                         "dynamodb:PutItem",
                         "dynamodb:UpdateItem",
                         "dynamodb:Query",


### PR DESCRIPTION
### Description of changes
Add permission `dynamodb:BatchGetItem` to the head node policies used by tests.
This new permission has been introduced in https://github.com/aws/aws-parallelcluster/pull/6070/files


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
