### PR TITLE
[CloudFormation] Reduce the size of the compute fleet template

### DIFF
--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -230,6 +230,18 @@ class QueuesStack(NestedStack):
                         get_user_data_content("../resources/compute_node/user_data.sh"),
                         {
                             **{
+                                # Disable multithreading using logic from
+                                # https://aws.amazon.com/blogs/compute/disabling-intel-hyper-threading-technology-on-amazon-linux/
+                                # thread_siblings_list contains a comma (,) or dash (-) separated list of CPU hardware
+                                # threads within the same core as cpu
+                                # e.g. 0-1 or 0,1
+                                # cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list
+                                #     | tr '-' ','       # convert hyphen (-) to comma (,), to account that
+                                #                        # some kernels and CPU architectures use a hyphen
+                                #                        # instead of a comma
+                                #     | cut -s -d, -f2-  # split over comma (,) and take the right part
+                                #     | tr ',' '\n'      # convert remaining comma (,) into new lines
+                                #     | sort -un         # sort and unique
                                 "DisableMultiThreadingManually": (
                                     "true" if compute_resource.disable_simultaneous_multithreading_manually else "false"
                                 ),

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -28,6 +28,7 @@ from pcluster.constants import (
     MAX_EXISTING_STORAGE_COUNT,
     MAX_NEW_STORAGE_COUNT,
     MAX_NUMBER_OF_COMPUTE_RESOURCES_PER_CLUSTER,
+    MAX_NUMBER_OF_QUEUES,
 )
 from pcluster.models.s3_bucket import S3FileFormat, format_content
 from pcluster.schemas.cluster_schema import ClusterSchema
@@ -129,8 +130,7 @@ def test_cluster_config_limits(mocker, capsys, tmpdir, pcluster_config_reader, t
     mock_bucket(mocker)
     mock_bucket_object_utils(mocker)
 
-    # TODO We must restore the actual maximum defined in constants.MAX_NUMBER_OF_QUEUES, which is 50.
-    max_number_of_queues = 46
+    max_number_of_queues = MAX_NUMBER_OF_QUEUES
 
     # The max number of queues cannot be used with the max number of compute resources
     # (it will exceed the max number of compute resources per cluster)

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -1937,6 +1937,162 @@ Scheduling:
     ComputeResources:
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
+      DisableSimultaneousMultithreading: false
+      DynamicNodePriority: 1000
+      Efa:
+        Enabled: false
+        GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
+      InstanceType: c5.xlarge
+      MaxCount: 10
+      MinCount: 0
+      Name: compute-resource-ondemand-230
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
+      SchedulableMemory: null
+      SpotPrice: null
+      StaticNodePriority: 1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions:
+      OnNodeConfigured:
+        Args:
+        - arg0
+        Script: https://test.tgz
+      OnNodeStart:
+        Args:
+        - arg0
+        Script: https://test.tgz
+    CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
+    Iam:
+      AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AdministratorAccess
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access:
+      - BucketName: string1
+        EnableWriteAccess: false
+        KeyName: null
+    Image:
+      CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
+    Name: queue-ondemand-23
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: null
+        Id: null
+        Name: null
+      Proxy: null
+      SecurityGroups:
+      - sg-34567890
+      SubnetIds:
+      - subnet-12345678
+    Tags:
+    - Key: String0
+      Value: String0
+  - CapacityReservationTarget: null
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - CapacityReservationTarget: null
+      CustomSlurmSettings: {}
+      DisableSimultaneousMultithreading: false
+      DynamicNodePriority: 1000
+      Efa:
+        Enabled: false
+        GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
+      InstanceType: c5.xlarge
+      MaxCount: 10
+      MinCount: 0
+      Name: compute-resource-ondemand-240
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
+      SchedulableMemory: null
+      SpotPrice: null
+      StaticNodePriority: 1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions:
+      OnNodeConfigured:
+        Args:
+        - arg0
+        Script: https://test.tgz
+      OnNodeStart:
+        Args:
+        - arg0
+        Script: https://test.tgz
+    CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
+    Iam:
+      AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AdministratorAccess
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access:
+      - BucketName: string1
+        EnableWriteAccess: false
+        KeyName: null
+    Image:
+      CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
+    Name: queue-ondemand-24
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: null
+        Id: null
+        Name: null
+      Proxy: null
+      SecurityGroups:
+      - sg-34567890
+      SubnetIds:
+      - subnet-12345678
+    Tags:
+    - Key: String0
+      Value: String0
+  - CapacityReservationTarget: null
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - CapacityReservationTarget: null
+      CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
       DynamicNodePriority: 1000
       Efa:
@@ -3480,6 +3636,142 @@ Scheduling:
       CustomAmi: ami-23456789
     JobExclusiveAllocation: false
     Name: queue-spot-22
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: true
+      PlacementGroup:
+        Enabled: true
+        Id: String
+        Name: null
+      Proxy:
+        HttpProxyAddress: https://proxy-address:port
+      SecurityGroups:
+      - sg-34567890
+      SubnetIds:
+      - subnet-12345678
+    Tags:
+    - Key: String0
+      Value: String0
+  - CapacityReservationTarget: null
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - CapacityReservationTarget: null
+      CustomSlurmSettings: {}
+      DisableSimultaneousMultithreading: true
+      DynamicNodePriority: 1000
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
+      InstanceType: c5.2xlarge
+      MaxCount: 15
+      MinCount: 1
+      Name: compute-resource-spot-230
+      Networking:
+        PlacementGroup:
+          Enabled: true
+          Id: String
+          Name: null
+      SchedulableMemory: null
+      SpotPrice: 1.1
+      StaticNodePriority: 1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume:
+          MountDir: /scratch
+        RootVolume:
+          Encrypted: true
+          Iops: 100
+          Size: 35
+          Throughput: null
+          VolumeType: gp2
+    CustomActions: null
+    CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
+      InstanceRole: null
+      S3Access: null
+    Image:
+      CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
+    Name: queue-spot-23
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: true
+      PlacementGroup:
+        Enabled: true
+        Id: String
+        Name: null
+      Proxy:
+        HttpProxyAddress: https://proxy-address:port
+      SecurityGroups:
+      - sg-34567890
+      SubnetIds:
+      - subnet-12345678
+    Tags:
+    - Key: String0
+      Value: String0
+  - CapacityReservationTarget: null
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - CapacityReservationTarget: null
+      CustomSlurmSettings: {}
+      DisableSimultaneousMultithreading: true
+      DynamicNodePriority: 1000
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
+      InstanceType: c5.2xlarge
+      MaxCount: 15
+      MinCount: 1
+      Name: compute-resource-spot-240
+      Networking:
+        PlacementGroup:
+          Enabled: true
+          Id: String
+          Name: null
+      SchedulableMemory: null
+      SpotPrice: 1.1
+      StaticNodePriority: 1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume:
+          MountDir: /scratch
+        RootVolume:
+          Encrypted: true
+          Iops: 100
+          Size: 35
+          Throughput: null
+          VolumeType: gp2
+    CustomActions: null
+    CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
+      InstanceRole: null
+      S3Access: null
+    Image:
+      CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
+    Name: queue-spot-24
     Networking:
       AdditionalSecurityGroups: null
       AssignPublicIp: true

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -44,8 +44,7 @@ def test_multiple_jobs_submission(
     max_jobs_execution_time = 9
     # Test using the max no of queues because the scheduler and node daemon operations take slight longer
     # with multiple queues
-    # FIXME We must restore the actual maximum defined in constants.MAX_NUMBER_OF_QUEUES, which is 50.
-    no_of_queues = 46
+    no_of_queues = 50
 
     cluster_config = pcluster_config_reader(
         scaledown_idletime=scaledown_idletime,


### PR DESCRIPTION
### Description of changes
Reduce the size of the CloudFormation template by removing unnecessary comments from compute node user data.


Restored the maximum number of queues used by unit and integ test from 46 to 50.

### Tests
* Unit tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
