### PR TITLE
[Tests] Remove rocky8 from released tests

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -262,7 +262,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["alinux2"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:


### PR DESCRIPTION
### Description of changes
* I wrongly re-introduced it as part of config tests refactoring.
* Test started to fail once images in optin region has been deleted.

### References
* https://github.com/aws/aws-parallelcluster/pull/6051