### PR TITLE
Allow configuration of custom Slurm accounting port for external slurmdbd

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2743,6 +2743,20 @@ class Database(Resource):
             )
 
 
+class ExternalSlurmdbd(Resource):
+    """Represent the External Slurmdbd settings."""
+
+    def __init__(
+        self,
+        host: str = None,
+        port: int = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.host = Resource.init_param(host)
+        self.port = Resource.init_param(port, default=6819)
+
+
 class SlurmSettings(Resource):
     """Represent the Slurm settings."""
 
@@ -2756,7 +2770,7 @@ class SlurmSettings(Resource):
         custom_slurm_settings: List[Dict] = None,
         custom_slurm_settings_include_file: str = None,
         munge_key_secret_arn: str = None,
-        external_slurmdbd: str = None,
+        external_slurmdbd: ExternalSlurmdbd = None,
         **kwargs,
     ):
         super().__init__()
@@ -2770,7 +2784,7 @@ class SlurmSettings(Resource):
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
         self.custom_slurm_settings_include_file = Resource.init_param(custom_slurm_settings_include_file)
         self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
-        self.external_slurmdbd = Resource.init_param(external_slurmdbd)
+        self.external_slurmdbd = external_slurmdbd
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -51,6 +51,7 @@ from pcluster.config.cluster_config import (
     ExistingFileCache,
     ExistingFsxOntap,
     ExistingFsxOpenZfs,
+    ExternalSlurmdbd,
     FlexibleInstanceType,
     GpuHealthCheck,
     HeadNode,
@@ -1710,7 +1711,7 @@ class DnsSchema(BaseSchema):
 
 
 class DatabaseSchema(BaseSchema):
-    """Represent the schema of the DirectoryService."""
+    """Represent the schema of the Slurm Accounting settings."""
 
     uri = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     user_name = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
@@ -1734,6 +1735,18 @@ class DatabaseSchema(BaseSchema):
         return Database(**data)
 
 
+class ExternalSlurmdbdSchema(BaseSchema):
+    """Represent the schema of the External Slurmdbd settings."""
+
+    host = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    port = fields.Int(required=False, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return ExternalSlurmdbd(**data)
+
+
 class SlurmSettingsSchema(BaseSchema):
     """Represent the schema of the Scheduling Settings."""
 
@@ -1751,7 +1764,7 @@ class SlurmSettingsSchema(BaseSchema):
     custom_slurm_settings = fields.List(fields.Dict, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     custom_slurm_settings_include_file = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP})
-    external_slurmdbd = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    external_slurmdbd = fields.Nested(ExternalSlurmdbdSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -83,6 +83,10 @@ Scheduling:
       Uri: test.databaseserver.com #required
       UserName: test_admin # required
       PasswordSecretArn: arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx  # required
+      DatabaseName: test_database_name
+    ExternalSlurmdbd:
+      Host: test.slurmdbd.host #required
+      Port: 6819
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -21,6 +21,7 @@ from pcluster.config.cluster_config import (
     BaseQueue,
     CapacityReservationTarget,
     Database,
+    ExternalSlurmdbd,
     RootVolume,
     SharedEbs,
     SlurmComputeResource,
@@ -345,7 +346,10 @@ def test_custom_slurm_settings_include_file_only_validator(
         ),
         pytest.param(
             None,
-            "test.slurmdbd.host",
+            ExternalSlurmdbd(
+                host="test.slurmdbd.host",
+                port=6819,
+            ),
             None,
             id="Case with external slurmdbd",
         ),
@@ -365,7 +369,10 @@ def test_custom_slurm_settings_include_file_only_validator(
                 user_name="databaseadmin",
                 password_secret_arn="fake-password-secret-arn",
             ),
-            "test.slurmdbd.host",
+            ExternalSlurmdbd(
+                host="test.slurmdbd.host",
+                port=6819,
+            ),
             "Database and ExternalSlurmdbd cannot be defined at the same time within SlurmSettings.",
             id="Bad case with Slurm Accounting (via Database) and external slurmdbd",
         ),

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -466,13 +466,13 @@ class ExternalSlurmdbdStack(Stack):
     def _add_outputs(self):
         CfnOutput(
             self,
-            "SlurmDbdPrivateIP",
+            "SlurmdbdPrivateIP",
             description="Secondary Private IP Address of the slurmdbd instance",
             value=self.slurmdbd_private_ip.value_as_string,
         )
         CfnOutput(
             self,
-            "SlurmDbdPort",
+            "SlurmdbdPort",
             description="Port used to connect to slurmdbd service",
             value="6819",  # this should be parametrized
         )
@@ -487,4 +487,11 @@ class ExternalSlurmdbdStack(Stack):
             "SSHClientSG",
             description="Security Group ID that allows SSH traffic from the HeadNode to slurmdbd instance",
             value=self._ssh_client_sg.security_group_id,
+        )
+        CfnOutput(
+            self,
+            "SlurmdbdConfigS3BucketName",
+            description="S3 Bucket where a copy of the slurmdbd configuration files can be stored and re-used when "
+            "re-provisioning the slurmdbd instance",
+            value=self.s3_bucket.bucket_name,
         )

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -115,6 +115,7 @@ class ExternalSlurmdbdStack(Stack):
     def _add_cfn_init_config(self):
         dna_json_content = {
             "slurmdbd_ip": self.slurmdbd_private_ip.value_as_string,
+            "slurmdbd_port": self.slurmdbd_port.value_as_number,
             "dbms_uri": self.dbms_uri.value_as_string,
             "dbms_username": self.dbms_username.value_as_string,
             "dbms_database_name": self.dbms_database_name.value_as_string,
@@ -218,9 +219,17 @@ class ExternalSlurmdbdStack(Stack):
             vpc=self.vpc,
         )
 
+        self.slurmdbd_port = CfnParameter(
+            self,
+            "SlurmdbdPort",
+            type="Number",
+            description="The port the slurmdbd service listens to.",
+            default=6819,
+        )
+
         slurmdbd_server_sg.add_ingress_rule(
             peer=slurmdbd_client_sg,
-            connection=ec2.Port.tcp(6819),
+            connection=ec2.Port.tcp(self.slurmdbd_port.value_as_number),
             description="Allow Slurm accounting traffic from the cluster head node",
         )
 
@@ -472,9 +481,9 @@ class ExternalSlurmdbdStack(Stack):
         )
         CfnOutput(
             self,
-            "SlurmdbdPort",
+            "SlurmdbdPortOut",
             description="Port used to connect to slurmdbd service",
-            value="6819",  # this should be parametrized
+            value=self.slurmdbd_port.value_as_string,
         )
         CfnOutput(
             self,


### PR DESCRIPTION
### Description of changes
* Change how the ExternalSlurmdbd settings are exposed in the ParallelCluster config yaml file, by exposing a new subsection with two subparameters, `Host` and `Port`.
  * DISCLAIMER: the Slurmdbd port is not configurable when using `SlurmSettings/Database`.
* Allow the configuration of the Slurmdbd port in the external slurmdbd CFN/CDK template.
* Expose External Slurmdbd stack S3 bucket as CFN stack output (separate commit).

### Tests
* Manually tested that the S3 bucket name is displayed among the external slurmdbd stack outputs.
* Manually tested that the value passed as CfnParameter `SlurmdbdPort` is correctly propagated to the security groups and the slurmdbd instance dna.json.
* Manually tested functioning of `ExternalSlurmdbd/Host` and `ExternalSlurmdbd/Port` subparameters.
* Updated existing unit tests for the new configuration parameters.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2641

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
