### PR TITLE
Add validator for OS and instance type compatibility

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -141,6 +141,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeAcceleratorManufacturerValidator,
     InstanceTypeBaseAMICompatibleValidator,
     InstanceTypeMemoryInfoValidator,
+    InstanceTypeOSCompatibleValidator,
     InstanceTypePlacementGroupValidator,
     InstanceTypeValidator,
     KeyPairValidator,
@@ -1579,6 +1580,11 @@ class BaseClusterConfig(Resource):
                 instance_type=self.head_node.instance_type,
                 image=self.head_node_ami,
             )
+            self._register_validator(
+                InstanceTypeOSCompatibleValidator,
+                instance_type=self.head_node.instance_type,
+                os=self.image.os,
+            )
         if self.head_node.image and self.head_node.image.custom_ami:
             self._register_validator(
                 AmiOsCompatibleValidator, os=self.image.os, image_id=self.head_node.image.custom_ami
@@ -2927,6 +2933,11 @@ class SlurmClusterConfig(BaseClusterConfig):
                         instance_type=pool.instance_type,
                         image=self.login_nodes_ami[pool.name],
                     )
+                    self._register_validator(
+                        InstanceTypeOSCompatibleValidator,
+                        instance_type=pool.instance_type,
+                        os=self.image.os,
+                    )
 
         if self.scheduling.settings and self.scheduling.settings.dns and self.scheduling.settings.dns.hosted_zone_id:
             self._register_validator(
@@ -3036,6 +3047,11 @@ class SlurmClusterConfig(BaseClusterConfig):
                         InstanceTypeBaseAMICompatibleValidator,
                         instance_type=instance_type,
                         image=queue_image,
+                    )
+                    self._register_validator(
+                        InstanceTypeOSCompatibleValidator,
+                        instance_type=instance_type,
+                        os=self.image.os,
                     )
                     self._register_validator(
                         InstanceTypeAcceleratorManufacturerValidator,

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -25,6 +25,7 @@ SUPPORTED_SCHEDULERS = ["slurm", "awsbatch"]
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm"]
 SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8", "rhel9", "rocky9"]
 SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "awsbatch": ["alinux2"]}
+UNSUPPORTED_OSES_FOR_MICRO_NANO = ["ubuntu2004", "ubuntu2204", "rhel8", "rocky8", "rhel9", "rocky9"]
 DELETE_POLICY = "Delete"
 RETAIN_POLICY = "Retain"
 DELETION_POLICIES = [DELETE_POLICY, RETAIN_POLICY]


### PR DESCRIPTION
### Description of changes
* Add validator for OS and instance type compatibility
* Warns against using micro or nano instance types with certain OSes

### Tests
* Tried to launch clusters with different OSes and instance types to see if I got the expected warning
* Created a unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
