### PR TITLE
Support RHEL9 and Rocky9: fix missing changes

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -58,7 +58,7 @@ OS_TO_IMAGE_NAME_PART_MAP = {
     "rocky9": "rocky9-hvm",
 }
 # We do not publicly publish/release Parallelcluster AMI of below OSSes
-PRIVATE_OSES = ["rocky8"]
+PRIVATE_OSES = ["rocky8", "rocky9"]
 
 IMAGE_NAME_PART_TO_OS_MAP = {value: key for key, value in OS_TO_IMAGE_NAME_PART_MAP.items()}
 

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -209,9 +209,9 @@ phases:
                     yum versionlock kernel-abi-stablelists
                   fi
               
-                  if [[ ${!OS} == "rocky8" ]] ; then
+                  if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                     yum versionlock rocky-release rocky-repos
-                  elif [[ ${!OS} == "rhel8" ]] ; then
+                  elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
                     yum versionlock redhat-release
                   fi
                   echo "Kernel version locked"
@@ -312,9 +312,9 @@ phases:
                   yum versionlock delete kernel-abi-stablelists
                 fi
             
-                if [[ ${!OS} == "rocky8" ]] ; then
+                if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                   yum versionlock delete rocky-release
-                elif [[ ${!OS} == "rhel8" ]] ; then
+                elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
                   yum versionlock delete redhat-release
                 fi
                 echo "Kernel version unlocked"

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -1,6 +1,7 @@
 {%- import 'common.jinja2' as common with context -%}
 {{- common.OSS_COMMERCIAL_ARM.append("centos7") or "" -}}
 {{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
+{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
 ---
 test-suites:
   ad_integration:
@@ -62,7 +63,7 @@ test-suites:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
     test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
       dimensions:
         - regions: ["ap-east-1"]
@@ -161,7 +162,7 @@ test-suites:
           oss: ["ubuntu2204", "rhel8"]
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
@@ -190,7 +191,7 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update:
       dimensions:
-        - oss: {{ common.NOT_RELEASED_OSES }}
+        - oss: ["rocky8"]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update_invalid:
@@ -210,7 +211,7 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_delete_retain:
       dimensions:
-        - oss: {{ common.NOT_RELEASED_OSES }}
+        - oss: ["rocky9"]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
@@ -224,7 +225,7 @@ test-suites:
         # DCV on GPU enabled instance
         - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
           instances: ["g4dn.2xlarge"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: ["slurm"]
         # DCV on ARM + GPU
         - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
@@ -284,7 +285,7 @@ test-suites:
           schedulers: ["slurm"]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: ["hpc6id.32xlarge"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: [ "slurm" ]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
@@ -319,7 +320,7 @@ test-suites:
     test_iam_image.py::test_iam_roles:
       dimensions:
         - regions: ["eu-south-1"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_iam.py::test_s3_read_write_resource:
       dimensions:
@@ -353,7 +354,7 @@ test-suites:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
     test_structured_log_events.py::test_custom_compute_action_failure:
       dimensions:
         - regions: ["af-south-1"]
@@ -396,7 +397,7 @@ test-suites:
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: ["slurm"]
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -418,7 +419,7 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: ["slurm"]
     test_placement_group.py::test_placement_group:
       dimensions:
@@ -455,7 +456,7 @@ test-suites:
           schedulers: ["slurm"]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: ["slurm"]
     test_scaling.py::test_job_level_scaling:
       dimensions:
@@ -508,7 +509,7 @@ test-suites:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:
@@ -532,7 +533,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:
@@ -634,7 +635,7 @@ test-suites:
           schedulers: ["slurm"]
         - regions: [ "us-gov-west-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: [ "slurm" ]
     test_fsx_lustre.py::test_multi_az_fsx:
       dimensions:
@@ -665,7 +666,7 @@ test-suites:
       dimensions:
         - regions: [ "ca-central-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: [ "slurm" ]
     # The checks performed in test_efs_same_az is similar to test_multiple_efs.
     # We should consider this when assigning dimensions to each test.
@@ -698,7 +699,7 @@ test-suites:
         - regions: [ "ap-south-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
@@ -719,7 +720,7 @@ test-suites:
       dimensions:
         - regions: [ "us-east-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: [ "slurm" ]
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -764,7 +765,7 @@ test-suites:
       dimensions:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: ["slurm"]
     test_api.py::test_custom_image:
       dimensions:
@@ -818,7 +819,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-south-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: [ "slurm" ]
     test_update.py::test_dynamic_file_systems_update:
       dimensions:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -91,7 +91,7 @@ test-suites:
           oss: ["ubuntu2204", "rhel8"]
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
@@ -159,7 +159,7 @@ test-suites:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
     test_structured_log_events.py::test_custom_compute_action_failure:
       dimensions:
         - regions: ["af-south-1"]
@@ -183,7 +183,7 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: ["slurm"]
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
@@ -253,7 +253,7 @@ test-suites:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky9"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:
@@ -265,7 +265,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.NOT_RELEASED_OSES }}
+          oss: ["rocky8"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:

--- a/tests/integration-tests/tests/common/osu_common.py
+++ b/tests/integration-tests/tests/common/osu_common.py
@@ -20,7 +20,7 @@ from utils import render_jinja_template
 
 OSU_COMMON_DATADIR = pathlib.Path(__file__).parent / "data/osu/"
 SUPPORTED_MPIS = ["openmpi", "intelmpi"]
-PRIVATE_OSES = ["rocky8"]
+PRIVATE_OSES = ["rocky8", "rocky9"]
 
 
 def compile_osu(mpi_variant, remote_command_executor):


### PR DESCRIPTION
This PR fixes minor bugs from https://github.com/aws/aws-parallelcluster/pull/6018

1. Add Rocky9 and RHEL9 to the kernel pinning logic. This was missed because the kernel pinning logic is new.
2. Only test one NOT_RELEASED_OSES to keep the number of tests from increasing


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
