### PR TITLE
Change test_slurm gpu instance type to g4dn.2xlarge

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -75,7 +75,7 @@ def test_slurm(
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
     scaledown_idletime = 3
-    gpu_instance_type = "g3.4xlarge"
+    gpu_instance_type = "g4dn.2xlarge"
     gpu_instance_type_info = get_instance_info(gpu_instance_type, region)
     # For OSs running _test_mpi_job_termination, spin up 2 compute nodes at cluster creation to run test
     # Else do not spin up compute node and start running regular slurm tests
@@ -199,7 +199,7 @@ def test_slurm_from_login_nodes_in_private_network(
     """Test Slurm features in login nodes inside a private network."""
 
     scaledown_idletime = 3
-    gpu_instance_type = "g3.4xlarge"
+    gpu_instance_type = "g4dn.2xlarge"
     gpu_instance_type_info = get_instance_info(gpu_instance_type, region)
     compute_node_bootstrap_timeout = 1600
     cluster_config = pcluster_config_reader(


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6034

### Description of changes
Change test_slurm gpu instance type to g4dn.2xlarge, which is more available that g3.4xlarge

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
