### PR TITLE
Removing /etc/chef/client.rb from user_data.sh as its set in the AMI's already

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -51,10 +51,6 @@ datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
 write_files:
-  - path: /etc/chef/client.rb
-    permissions: '0644'
-    owner: root:root
-    content: cookbook_path ['/etc/chef/cookbooks']
   - path: /etc/cfn/cfn-hup.conf
     permissions: '0400'
     owner: root:root

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -48,10 +48,6 @@ datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
 write_files:
-  - path: /etc/chef/client.rb
-    permissions: '0644'
-    owner: root:root
-    content: cookbook_path ['/etc/chef/cookbooks']
   - path: /etc/cfn/cfn-hup.conf
     permissions: '0400'
     owner: root:root

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1356,12 +1356,6 @@ class ClusterCdkStack:
                         "group": "root",
                         "encoding": "plain",
                     },
-                    "/etc/chef/client.rb": {
-                        "mode": "000644",
-                        "owner": "root",
-                        "group": "root",
-                        "content": "cookbook_path ['/etc/chef/cookbooks']",
-                    },
                     # A nosec comment is appended to the following line in order to disable the B108 check.
                     # The file is needed by the product
                     # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -102,8 +102,8 @@ Scheduling:
           InstanceType: c5.xlarge
           Tags:
             {% for i in range(number_of_tags) %}
-            - Key: computetag{{ i }}
-              Value: computetag{{ i }}
+            - Key: extremely_long_computetag_key{{ i }}
+              Value: extremely_long_computetag_value{{ i }}
             {% endfor %}
         {% endfor %}
       CustomActions:
@@ -177,8 +177,8 @@ Scheduling:
               Id: String
           Tags:
             {% for i in range(number_of_tags) %}
-            - Key: computetag{{ i }}
-              Value: computetag{{ i }}
+            - Key: extremely_long_computetag_key{{ i }}
+              Value: extremely_long_computetag_value{{ i }}
             {% endfor %}
         {% endfor %}
       Iam:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -161,8 +161,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -239,8 +239,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -317,8 +317,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -395,8 +395,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -473,8 +473,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -551,8 +551,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -629,8 +629,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -707,8 +707,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -785,8 +785,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -863,8 +863,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -941,8 +941,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1019,8 +1019,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1097,8 +1097,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1175,8 +1175,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1253,8 +1253,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1331,8 +1331,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1409,8 +1409,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1487,8 +1487,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1565,8 +1565,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1643,8 +1643,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1721,8 +1721,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1799,8 +1799,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1877,8 +1877,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1955,8 +1955,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2033,8 +2033,8 @@ Scheduling:
       SpotPrice: null
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2111,8 +2111,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2179,8 +2179,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2247,8 +2247,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2315,8 +2315,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2383,8 +2383,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2451,8 +2451,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2519,8 +2519,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2587,8 +2587,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2655,8 +2655,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2723,8 +2723,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2791,8 +2791,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2859,8 +2859,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2927,8 +2927,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -2995,8 +2995,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3063,8 +3063,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3131,8 +3131,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3199,8 +3199,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3267,8 +3267,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3335,8 +3335,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3403,8 +3403,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3471,8 +3471,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3539,8 +3539,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3607,8 +3607,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3675,8 +3675,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3743,8 +3743,8 @@ Scheduling:
       SpotPrice: 1.1
       StaticNodePriority: 1
       Tags:
-      - Key: computetag0
-        Value: computetag0
+      - Key: extremely_long_computetag_key0
+        Value: extremely_long_computetag_value0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:


### PR DESCRIPTION
Reducing ComputeFleet Template size which exceeds over 1MB
Removing /etc/chef/client.rb from user_data.sh as its no longer needed.


### Tests
* Unit Tests
* Passing Integ test `test_create_imds_secured`

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
