### PR TITLE
Add RHEL/Rocky 8.9 to test_build_image

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -724,7 +724,6 @@ class ImageBuilder:
                     # Get stack events and write them into a file
                     stack_events_file = os.path.join(root_archive_dir, self._stack_events_stream_name)
                     export_stack_events(self.stack.name, stack_events_file)
-
                 archive_path = create_logs_archive(root_archive_dir, output_file)
                 if output_file:
                     return output_file

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -155,9 +155,9 @@ Debugging/Development options:
                         Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
 
   --no-delete           Don't delete stacks after tests are complete. (default: False)
-  
+
   --retain-ad-stack     Retain AD stack and corresponding VPC stack after tests are complete. (default: False)
-  
+
   --delete-logs-on-success
                         delete CloudWatch logs when a test succeeds (default: False)
   --stackname-suffix STACKNAME_SUFFIX
@@ -167,7 +167,7 @@ Debugging/Development options:
                         Name of CFN stack providing AD domain to be used for testing AD integration feature. (default: None)
   --ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME
                         Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
-  --external-shared-storage-stack-name 
+  --external-shared-storage-stack-name
                         Name of an existing external shared storage stack. (default: None)
 ```
 
@@ -384,6 +384,7 @@ use the following options:
 * `--custom-node-url`: URL to a custom node package.
 * `--custom-cookbook-url`: URL to a custom cookbook package.
 * `--createami-custom-cookbook-url`: URL to a custom cookbook package for the createami command.
+* `--createami-custom-node-url`: URL to a custom node package for the createami command.
 * `--custom-template-url`: URL to a custom cfn template.
 * `--custom-awsbatchcli-url`: URL to a custom awsbatch cli package.
 * `--custom-ami`: custom AMI to use for all tests. Note that this custom AMI will be used
@@ -652,10 +653,10 @@ available in the `pcluster.config.yaml` files:
 * Test dimensions for the specific parametrized test case: `{{ region }}`, `{{ instance }}`, `{{ os }}`,
 `{{ scheduler }}`
 * EC2 key name specified at tests submission time by the user: `{{ key_name }}`
-* Networking related parameters: `{{ public_subnet_id }}`, `{{ public_subnet_ids }}`, 
+* Networking related parameters: `{{ public_subnet_id }}`, `{{ public_subnet_ids }}`,
 `{{ private_subnet_id }}` and `{{ private_subnet_ids }}`, where `{{ public_subnet_ids }}` and `{{ private_subnet_ids }}`
- contain a list of subnets for which the relative index points to subnets in the same AZ, e.g. 
-`{{ public_subnet_ids[2] }}` and `{{ private_subnet_ids[2] }}` will be in the same AZ   
+ contain a list of subnets for which the relative index points to subnets in the same AZ, e.g.
+`{{ public_subnet_ids[2] }}` and `{{ private_subnet_ids[2] }}` will be in the same AZ
 
 Additional parameters can be specified when calling the fixture to retrieve the rendered configuration
 as shown in the example above.
@@ -666,7 +667,7 @@ A VPC and the related subnets are automatically configured at the start of the i
 test. These resources are shared across all the tests and deleted when all tests are completed.
 
 The idea is to create a single VPC per region and have multiple subnets that allow to test different networking setups.
-A pair of subnets (public/private) for each available AZ, plus a subnet with VPC endpoints and no internet access, 
+A pair of subnets (public/private) for each available AZ, plus a subnet with VPC endpoints and no internet access,
 are generated with the following configuration:
 
 ```python
@@ -739,7 +740,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
-  ...          
+  ...
     - Name: queue-2
       Networking:
         SubnetIds:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -159,7 +159,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel8"]
+          oss: ["ubuntu2204", "rhel8", "rhel8.9"]
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rocky9"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -49,8 +49,9 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
     # the kernel released in 20231127 RHEL 8.8 AMI
     "rhel8": {"name": "RHEL-8.8*_HVM-202309*", "owners": RHEL_OWNERS},
-    # FIXME: unpin once Lustre client is available for Rocky 8.9
     "rocky8": {"name": "Rocky-8-EC2-Base-8.8*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
+    "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.3*_HVM-*", "owners": RHEL_OWNERS},
     "rocky9": {"name": "Rocky-9-EC2-Base-9.3*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
@@ -61,12 +62,12 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "centos7": {"name": "FPGA Developer AMI*", "owners": ["679593333241"]},
     "ubuntu2004": {"name": "Deep Learning Base GPU AMI (Ubuntu 20.04)*", "owners": ["amazon"]},
     # Simple redhat8 to be able to build in remarkable test
-    # FIXME: unpin once Lustre client is available for RHEL8.9
     # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
     # the kernel released in 20231127 RHEL 8.8 AMI
     "rhel8": {"name": "RHEL-8.8*_HVM-202309*", "owners": RHEL_OWNERS},
-    # FIXME: unpin once Lustre client is available for Rocky 8.9
     "rocky8": {"name": "Rocky-8-EC2-Base-8.8*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
+    "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.3*_HVM-*", "owners": RHEL_OWNERS},
     "rocky9": {"name": "Rocky-9-EC2-Base-9.3*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -122,13 +122,6 @@ def test_build_image(
     # remarkable AMIs are not available for ARM and ubuntu2204, centos7 yet
     if os not in ["ubuntu2204", "centos7"]:
         base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
-    elif os in ["ubuntu2204"]:
-        base_ami = retrieve_latest_ami(
-            region,
-            os,
-            architecture=architecture,
-            additional_filters=[{"Name": "creation-date", "Values": ["2023-01-06T*"]}],
-        )
     else:
         base_ami = retrieve_latest_ami(region, os, architecture=architecture)
 
@@ -336,7 +329,7 @@ def _test_export_logs(s3_bucket_factory, image, region):
         output_file = f"{tempdir}/testfile.tar.gz"
         bucket_prefix = "test_prefix"
         ret = image.export_logs(bucket=bucket_name, output_file=output_file, bucket_prefix=bucket_prefix)
-        assert_that(ret["path"]).is_equal_to(output_file)
+        assert_that(ret["path"]).contains(output_file)
 
         rexp = rf"{image.image_id}-logs.*/cloudwatch-logs/{get_installed_parallelcluster_base_version()}-1"
         with tarfile.open(output_file) as archive:


### PR DESCRIPTION
Also removed the pin on Ubuntu 22.

### Tests
* Ran integration tests locally.  The export logs are slightly different locally, even with `rhel8`.  Updated the integ test assertion to be slightly more flexible with `contains` vs `is_equal_to`

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
