### PR TITLE
[DFSM] Remove unnecessary definition of interval from cfn-hup configuration.

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -60,7 +60,6 @@ write_files:
       region=${AWS::Region}
       url=${CloudFormationUrl}
       role=${CfnInitRole}
-      interval=2
   - path: /etc/cfn/hooks.d/parallelcluster-update.conf
     permissions: '0400'
     owner: root:root

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -57,7 +57,6 @@ write_files:
       region=${AWS::Region}
       url=${CloudFormationUrl}
       role=${CfnInitRole}
-      interval=2
   - path: /etc/cfn/hooks.d/parallelcluster-update.conf
     permissions: '0400'
     owner: root:root

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1415,11 +1415,7 @@ class ClusterCdkStack:
                     },
                     "/etc/cfn/cfn-hup.conf": {
                         "content": Fn.sub(
-                            "[main]\n"
-                            "stack=${StackId}\n"
-                            "region=${Region}\n"
-                            "url=${CloudFormationUrl}\n"
-                            "interval=2\n",
+                            "[main]\nstack=${StackId}\nregion=${Region}\nurl=${CloudFormationUrl}",
                             {
                                 "StackId": self.stack.stack_id,
                                 "Region": self.stack.region,


### PR DESCRIPTION
### Description of changes
Remove unnecessary definition of interval from cfn-hup configuration.
Such interval is not necessary because it is optional (see [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-hup.html) and we run cfn-hup in no-daemon mode (see [code](https://github.com/aws/aws-parallelcluster-cookbook/blob/e584a5b7d37d460b0c7dcfebeb5a23ec23eda1e4/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hup-runner.sh.erb#L12)), so the interval is actually ignored  and may be source of misunderstanding.

This Pr is related to https://github.com/aws/aws-parallelcluster-cookbook/pull/2660, where we set the actual polling interval to 60 seconds.

### Tests
* Manual: cluster creation + in-place updates adding EFS storage.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
