### PR TITLE
[CodeStyle] Remove unsupported option 'no-space-check' for PyLint.

### DIFF
--- a/cli/.pylintrc
+++ b/cli/.pylintrc
@@ -347,13 +347,6 @@ max-line-length=120
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no


### PR DESCRIPTION
### Description of changes
Remove unsupported option 'no-space-check' for PyLint.

See PyLint error when 'no-spacke-check' is used in `.pylintrc`:

```
.pylintrc:1:0: E0015: Unrecognized option found: no-space-check (unrecognized-option)
```

The above error is blocking PRs ( [example of failure](https://github.com/aws/aws-parallelcluster/actions/runs/7971740769/job/21762068487?pr=6107)).

Removing the unsupport option unblocks the checks without introducing regressions.

### Tests
* Linter success

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
