### PR TITLE
[DFSM][Test] Fix test_update_slurm

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -375,9 +375,12 @@ def assert_instance_config_version_on_ddb(
             table_name = f"parallelcluster-{cluster.name}"
             item_id = f"CLUSTER_CONFIG.{instance_id}"
             item = get_ddb_item(cluster.region, table_name, {"Id": item_id})
-            assert_that(item).is_not_none()
+            assert_that(item, f"DDB record for {instance_id} ({node_type}) exists").is_not_none()
             cluster_config_version_on_ddb = item["Data"]["cluster_config_version"]
-            assert_that(cluster_config_version_on_ddb).is_equal_to(expected_cluster_config_version)
+            assert_that(
+                cluster_config_version_on_ddb,
+                f"DDB record for {instance_id} ({node_type}) has the correct config version",
+            ).is_equal_to(expected_cluster_config_version)
         logging.info(
             f"Verified that all {n_nodes} nodes ({node_type}) stored the expected config version on DDB: "
             f"{expected_cluster_config_version}"


### PR DESCRIPTION
### Description of changes
Fix 'test_update_slurm' by retrying assertion on cluster config DDB records. 
Retries are necessary because, by design, the stack update does not wait for static fleet updates.

Also added description to assertions to facilitate troubleshooting.

### Tests
* Integ test `test_update_slurm` succeeded (when run with the fixes in https://github.com/aws/aws-parallelcluster-cookbook/pull/2661).

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
