### PR TITLE
Add wait time to allow time for job state to switch to pending

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -925,6 +925,7 @@ def _test_update_queue_strategy_with_running_job(
         # requeue job in queue2 to launch new instances for nodes
         remote_command_executor.run_remote_command(f"scontrol requeue {queue2_job_id}")
     elif queue_update_strategy == "TERMINATE":
+        time.sleep(60)
         scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
 
     # Be sure the queue2 job is running even after the forced termination: we need the nodes active so that we


### PR DESCRIPTION
### Description of changes
* Fix test_queue_parameters_update by adding 1 minute wait time to allow time for job state to switch to pending

### Tests
* Ran test on Jenkins