### PR TITLE
Fix ParallelClusterClusterPolicy permissions for CloudFormation actions for PCAPI

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -423,7 +423,7 @@ Resources:
           - Action:
               - cloudformation:CreateStack
             Resource: !Sub
-              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - arn:${AWS::Partition}:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
               - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
             Effect: Allow
             Condition:
@@ -433,12 +433,12 @@ Resources:
           - Action:
               - cloudformation:UpdateStack
             Resource: !Sub
-              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - arn:${AWS::Partition}:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
               - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
             Effect: Allow
             Condition:
-              ForAnyValue:StringLike:
-                aws:ResourceTag/parallelcluster:cluster-name: "*"
+              ForAnyValue:StringEquals:
+                aws:TagKeys: [ "parallelcluster:cluster-name" ]
             Sid: CloudFormationUpdate
           - Action:
               - cloudformation:DeleteStack
@@ -448,7 +448,7 @@ Resources:
               - cloudformation:GetTemplate
               - cloudformation:ListStacks
             Resource: !Sub
-              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - arn:${AWS::Partition}:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
               - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
             Effect: Allow
             Sid: CloudFormationReadAndDelete


### PR DESCRIPTION
### Description of changes
* Originally found out there was a problem because a user had permission errors when updating a cluster in PCUI
* The CloudFormation permissions were not showing up in the policy, so fixed the problems
* This was not detected by integration tests before because other policies in the role allow for Creating and Deleting stacks, and the updating stack part of the integration test was only a dry-run.

### Tests
* test_api:test_cluster_slurm still passes
* Started PCUI with this commit and was able to update stack successfully
  * Checked the corresponding ParallelClusterClusterPolicy and the policy has the appropriate permissions now

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
