### PR TITLE
[develop] Change test_build_image test to use Rocky8 instead of Rocky9

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -162,7 +162,7 @@ test-suites:
           oss: ["ubuntu2204", "rhel8", "rhel8.9"]
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: ["rocky8"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)


### PR DESCRIPTION
It is known that Rocky9 build-image fails if the parent image does not have the latest kernel. This is caused by a problem in Rocky9 release process and cannot be addressed by ParallelCluster. See details here https://forums.rockylinux.org/t/older-packages-missing-in-repositories/12267/8.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
