### PR TITLE
[Custom Resource][Test] Adapt the error messages verified in 'test_cluster_update_invalid' considering that CloudFormation truncates long error messages.

### DIFF
--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -171,7 +171,9 @@ def test_cluster_update_invalid(
     assert_that(reason).contains("Cannot update the ClusterName")
 
     for cluster_config_path, error in [
-        ("pcluster.config.reducemaxcount.yaml", "Stop the compute fleet"),
+        # CloudFormation truncates error messages,
+        # so we cannot specify the full error message here, but only a part of it.
+        ("pcluster.config.reducemaxcount.yaml", "Jobs running on the removed nodes will terminate"),
         ("pcluster.config.negativemaxcount.yaml", "Must be greater than or equal to 1."),
         ("pcluster.config.wrongscripturi.yaml", "s3 url 's3://invalid' is invalid."),
     ]:


### PR DESCRIPTION
### Description of changes
Adapt the error messages verified in 'test_cluster_update_invalid' considering that CloudFormation truncates long error messages. 

**This is a temporary solution to unblock the execution of the test.** It is required because we do not have control over the truncation mechanism provided by CloudFormation.

In particular, in 3.9.0 we made the error message returned when reducing the static fleet size a bit longer, so we should adapt the check accordingly, considering the truncation.

The full error message, which is defined [here](https://github.com/aws/aws-parallelcluster/blob/ce5dc76cfcf846c8824b4598a2c9586a53272984/cli/src/pcluster/config/update_policy.py#L123-L129), would be 

```
Stop the compute fleet with the pcluster update-compute-fleet command, 
or set QueueUpdateStrategy to TERMINATE in the configuration used for the 'update-cluster' operation. 
Be aware that this update will remove nodes from the scheduler and terminates the EC2 instances associated. 
Jobs running on the removed nodes will terminate
```

but the truncated error returned by CloudFormation is:

```
(truncated) e configuration used for the 'update-cluster' operation. 
Be aware that this update will remove nodes from the scheduler and terminates the EC2 instances associated. 
Jobs running on the removed nodes will terminate
```

### Tests
* [ONGOING] `test_cluster_custom_resource.test_cluster_update_invalid` now succeeds.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
