### PR TITLE
[Storage][1-click] Use FSxLustre version 2.12 for File Cache in 1-click template for storage

### DIFF
--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -428,7 +428,7 @@ Resources:
               return (
                 fsx.create_file_cache(
                   FileCacheType="LUSTRE",
-                  FileCacheTypeVersion="2.15",
+                  FileCacheTypeVersion="2.12",
                   StorageCapacity=1200,
                   SubnetIds=[subnet_id],
                   SecurityGroupIds=[securitygroup_id],


### PR DESCRIPTION
### Description of changes
Use FSxLustre version 2.12 for File Cache in 1-click template for storage as this is the only supported version (See [docs](https://docs.aws.amazon.com/cli/latest/reference/fsx/create-file-cache.html)).

### Tests
No need to test this change. The integ test was succeeding when FileCache was using Lustre 2.12.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
