### PR TITLE
[release-3.9] Use CloudFormation constant to retrieve Stack ARN for Instance Roles

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -19,6 +19,7 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as awslambda
 from aws_cdk import aws_logs as logs
+from aws_cdk import core
 from aws_cdk.aws_iam import ManagedPolicy, PermissionsBoundary
 from aws_cdk.core import Arn, ArnFormat, CfnDeletionPolicy, CfnTag, Construct, Fn, Stack
 
@@ -656,10 +657,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                     "cloudformation:SignalResource",
                 ],
                 effect=iam.Effect.ALLOW,
-                resources=[
-                    self._format_arn(service="cloudformation", resource=f"stack/{Stack.of(self).stack_name}/*"),
-                    self._format_arn(service="cloudformation", resource=f"stack/{Stack.of(self).stack_name}-*/*"),
-                ],
+                resources=[core.Aws.STACK_ID],
             ),
             iam.PolicyStatement(
                 sid="DcvLicense",
@@ -938,9 +936,7 @@ class LoginNodesIamResources(NodeIamResourcesBase):
                     "cloudformation:DescribeStackResource",
                 ],
                 effect=iam.Effect.ALLOW,
-                resources=[
-                    self._format_arn(service="cloudformation", resource=f"stack/{Stack.of(self).stack_name}-*/*"),
-                ],
+                resources=[core.Aws.STACK_ID],
             ),
             iam.PolicyStatement(
                 sid="DynamoDBTable",
@@ -999,9 +995,7 @@ class ComputeNodeIamResources(NodeIamResourcesBase):
                     "cloudformation:DescribeStackResource",
                 ],
                 effect=iam.Effect.ALLOW,
-                resources=[
-                    self._format_arn(service="cloudformation", resource=f"stack/{Stack.of(self).stack_name}-*/*"),
-                ],
+                resources=[core.Aws.STACK_ID],
             ),
             iam.PolicyStatement(
                 sid="DynamoDBTable",

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -759,18 +759,7 @@ class IamPolicyAssertion:
                             "Action": "cloudformation:DescribeStackResource",
                             "Effect": "Allow",
                             "Resource": {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        "arn:",
-                                        {"Ref": "AWS::Partition"},
-                                        ":cloudformation:",
-                                        {"Ref": "AWS::Region"},
-                                        ":",
-                                        {"Ref": "AWS::AccountId"},
-                                        ":stack/clustername-*/*",
-                                    ],
-                                ]
+                                "Ref": "AWS::StackId",
                             },
                             "Sid": "CloudFormation",
                         },

--- a/cli/tests/pcluster/templates/test_queues_stack.py
+++ b/cli/tests/pcluster/templates/test_queues_stack.py
@@ -48,18 +48,7 @@ from tests.pcluster.utils import get_asset_content_with_resource_name
                             "Action": "cloudformation:DescribeStackResource",
                             "Effect": "Allow",
                             "Resource": {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        "arn:",
-                                        {"Ref": "AWS::Partition"},
-                                        ":cloudformation:",
-                                        {"Ref": "AWS::Region"},
-                                        ":",
-                                        {"Ref": "AWS::AccountId"},
-                                        ":stack/clustername-*/*",
-                                    ],
-                                ]
+                                "Ref": "AWS::StackId",
                             },
                             "Sid": "CloudFormation",
                         },


### PR DESCRIPTION
1. Use CloudFormation constant to retrieve Stack ARN for Instance Roles. Assuming `self._format_arn(service="cloudformation", resource=f"stack/{Stack.of(self).stack_name}-*/*")` represents the names of the substack is wrong because the name could be truncated by CloudFormation. For example, the main stack is: arn:aws:cloudformation:eu-west-1:000:stack/integ-tests-u7brkajrdgec5ys8-performance-test/123-d743-11ee-a184-123 The nested stack is arn:aws:cloudformation:eu-west-1:000:stack/integ-tests-u7brkajrdgec5ys8-performance-te-ComputeFleetQueuesNestedStackQueuesNestedS-7R1JJ4IR4CM6/123-d743-11ee-a184-123
2. Remove nested stack DescribeStackResources permission on head nodes. This is a side improvement to keep the commit simple. According to node package and cookbook package, head node does not need DescribeStackResources permission of nested stacks.

### Tests


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
