### PR TITLE
Shorten the action needed message shown on resizing of the compute fleet

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -122,10 +122,8 @@ def actions_needed_queue_update_strategy(change, _):
 
 def actions_needed_resize_update_strategy_on_remove(*_):
     return (
-        "Stop the compute fleet with the pcluster update-compute-fleet command, "
-        "or set QueueUpdateStrategy to TERMINATE in the configuration used for the 'update-cluster' operation. "
-        "Be aware that this update will remove nodes from the scheduler and terminates the EC2 instances "
-        "associated. Jobs running on the removed nodes will terminate"
+        "Stop the compute fleet or set QueueUpdateStrategy:TERMINATE in config "
+        "to remove nodes from the scheduler, terminate the associated instances & any running jobs"
     )
 
 

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -485,10 +485,8 @@ def test_condition_checker_resize_update_strategy_on_remove(
         "All compute nodes must be stopped or QueueUpdateStrategy must be set to TERMINATE"
     )
     assert_that(UpdatePolicy.RESIZE_UPDATE_STRATEGY_ON_REMOVE.action_needed(change_mock, patch_mock)).is_equal_to(
-        "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy to "
-        "TERMINATE in the configuration used for the 'update-cluster' operation. Be aware that this update will remove "
-        "nodes from the scheduler and terminates the EC2 instances associated. Jobs running on the removed nodes will "
-        "terminate"
+        "Stop the compute fleet or set QueueUpdateStrategy:TERMINATE in config "
+        "to remove nodes from the scheduler, terminate the associated instances & any running jobs"
     )
     cluster_has_running_capacity_mock.assert_called()
 

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -173,7 +173,7 @@ def test_cluster_update_invalid(
     for cluster_config_path, error in [
         # CloudFormation truncates error messages,
         # so we cannot specify the full error message here, but only a part of it.
-        ("pcluster.config.reducemaxcount.yaml", "Jobs running on the removed nodes will terminate"),
+        ("pcluster.config.reducemaxcount.yaml", "Stop the compute fleet or set QueueUpdateStrategy:TERMINATE"),
         ("pcluster.config.negativemaxcount.yaml", "Must be greater than or equal to 1."),
         ("pcluster.config.wrongscripturi.yaml", "s3 url 's3://invalid' is invalid."),
     ]:


### PR DESCRIPTION
### Description of changes
* Shorten the action needed message shown on resizing of the compute fleet

### Tests
* Unit Test


release-3.9 -> https://github.com/aws/aws-parallelcluster/pull/6144
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
