### PR TITLE
[Test] Use bigger instance types in test 'test_update_compute_ami'.

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
@@ -23,8 +23,8 @@ Scheduling:
           MaxCount: 2
         - Name: queue1-i2
           Instances:
-            - InstanceType: t2.medium
-            - InstanceType: t3.micro
+            - InstanceType: t3.medium
+            - InstanceType: c5.large
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
@@ -19,8 +19,8 @@ Scheduling:
           MaxCount: 2
         - Name: queue1-i2
           Instances:
-            - InstanceType: t2.medium
-            - InstanceType: t3.micro
+            - InstanceType: t3.medium
+            - InstanceType: c5.large
           MinCount: 1
           MaxCount: 2
       Networking:


### PR DESCRIPTION
### Description of changes
Use bigger instance types in test `test_update_compute_ami`.
In particular replaced t3.micro/t2.medium with (1GB) with t3.medium/c5.large (8GB) to prevent fluctuations in reported avail memory, exampke of error with t3.micro:

```
[2024-03-07T11:45:06.617] error: Setting node queue1-st-queue1-i2-1 state to INVAL with reason:Low RealMemory (reported:710 < 75.00% of configured:972)
```

### Tests
*  `test_update_compute_ami` succeeded.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
