### PR TITLE
Fix DRA configuration to allow for no auto import or export policy to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.10.0
+------
+
+**BUG FIXES**
+- Fix DRA configuration to make `AutoExportPolicy` and `AutoImportPolicy` optional.
+
 3.9.0
 ------
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1017,6 +1017,28 @@ class ClusterCdkStack:
         if shared_fsx.data_repository_associations:
             for dra in shared_fsx.data_repository_associations:
                 dra_id = "{0}{1}".format(dra.name, create_hash_suffix(dra.name))
+                s3 = None
+                if dra.auto_export_policy and dra.auto_import_policy:
+                    s3 = fsx.CfnDataRepositoryAssociation.S3Property(
+                        auto_export_policy=fsx.CfnDataRepositoryAssociation.AutoExportPolicyProperty(
+                            events=dra.auto_export_policy
+                        ),
+                        auto_import_policy=fsx.CfnDataRepositoryAssociation.AutoImportPolicyProperty(
+                            events=dra.auto_import_policy
+                        ),
+                    )
+                elif dra.auto_import_policy:
+                    s3 = fsx.CfnDataRepositoryAssociation.S3Property(
+                        auto_import_policy=fsx.CfnDataRepositoryAssociation.AutoImportPolicyProperty(
+                            events=dra.auto_import_policy
+                        ),
+                    )
+                elif dra.auto_export_policy:
+                    s3 = fsx.CfnDataRepositoryAssociation.S3Property(
+                        auto_export_policy=fsx.CfnDataRepositoryAssociation.AutoExportPolicyProperty(
+                            events=dra.auto_export_policy
+                        ),
+                    )
                 fsx.CfnDataRepositoryAssociation(
                     self.stack,
                     dra_id,
@@ -1025,14 +1047,7 @@ class ClusterCdkStack:
                     file_system_id=fsx_id,
                     file_system_path=dra.file_system_path,
                     imported_file_chunk_size=dra.imported_file_chunk_size,
-                    s3=fsx.CfnDataRepositoryAssociation.S3Property(
-                        auto_export_policy=fsx.CfnDataRepositoryAssociation.AutoExportPolicyProperty(
-                            events=dra.auto_export_policy
-                        ),
-                        auto_import_policy=fsx.CfnDataRepositoryAssociation.AutoImportPolicyProperty(
-                            events=dra.auto_import_policy
-                        ),
-                    ),
+                    s3=s3,
                     tags=[CfnTag(key="Name", value=dra.name)],
                 )
 

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -200,13 +200,30 @@ SharedStorage:
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
       DataRepositoryAssociations:
-        - Name: dra
+        - Name: dra1
           BatchImportMetaDataOnCreate: false
-          DataRepositoryPath: s3://bucket/folder
-          FileSystemPath: /
+          DataRepositoryPath: s3://bucket/folder1
+          FileSystemPath: /one
           ImportedFileChunkSize: 1024
           AutoExportPolicy: [ NEW, CHANGED, DELETED ]
           AutoImportPolicy: [ NEW, CHANGED, DELETED ]
+        - Name: dra2
+          BatchImportMetaDataOnCreate: false
+          DataRepositoryPath: s3://bucket/folder2
+          FileSystemPath: /two
+          ImportedFileChunkSize: 1024
+          AutoImportPolicy: [ NEW, DELETED ]
+        - Name: dra3
+          BatchImportMetaDataOnCreate: false
+          DataRepositoryPath: s3://bucket/folder3
+          FileSystemPath: /three
+          ImportedFileChunkSize: 1024
+          AutoExportPolicy: [ DELETED ]
+        - Name: dra4
+          BatchImportMetaDataOnCreate: false
+          DataRepositoryPath: s3://bucket/folder4
+          FileSystemPath: /four
+          ImportedFileChunkSize: 1024
   - MountDir: /my/mount/point4
     Name: name4
     StorageType: FsxOpenZfs


### PR DESCRIPTION
### Description of changes
* Fix DRA configuration to allow for no auto import or export policy to be specified
* Fixes `"message": "type of argument events must be a sequence; got NoneType instead"` error when auto import and export policy is not included in the config file.

### Tests
* Launched a cluster with no auto import or export policy
* Launched a cluster with only an auto import policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
