### PR TITLE
Simplify Ubuntu kernel pinning during build image OS update

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -215,18 +215,6 @@ phases:
                     yum versionlock redhat-release
                   fi
                   echo "Kernel version locked"
-              
-                elif [[ ${!PLATFORM} == DEBIAN ]]; then
-                  # Install LTS kernel packages
-                  # linux-aws-lts-22.04 depends on linux-image-aws-lts-22.04 and linux-headers-aws-lts-22.04
-                  # linux-image-aws-lts-22.04 depends on linux-image-5.15.0-10xx-aws, that depends on linux-modules-5.15.0-10xx-aws
-                  # linux-headers-aws-lts-22.04 depends on linux-headers-5.15.0-10xx-aws
-                  UBUNTU_VERSION=$(lsb_release -sr)
-                  DEBIAN_FRONTEND=noninteractive apt-get -y install linux-aws-lts-${!UBUNTU_VERSION}
-
-                  # remove not updated meta-packages
-                  apt-get -y remove linux-image-aws linux-aws linux-headers-aws
-                  echo "Kernel updated to LTS version"
                 fi
               fi
 
@@ -238,6 +226,7 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y update
@@ -251,7 +240,11 @@ phases:
 
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 DEBIAN_FRONTEND=noninteractive apt-get -y update
-                DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade
+                if [[ ${!DISABLE_KERNEL_UPDATE} == true ]]; then
+                  DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+                else
+                  DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade
+                fi
                 apt-get --purge autoremove -y
               fi
 
@@ -287,7 +280,6 @@ phases:
               
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 if [[ ${!DISABLE_KERNEL_UPDATE} != true ]]; then
-                   # already installed to LTS version
                    apt-get -y install linux-aws linux-headers-aws linux-image-aws
                 fi
               fi


### PR DESCRIPTION
Previously we were installing LTS kernel to pin the kernel. This is only valid when the base AMI has a kernel equal or older than the LTS kernel. If the base AMI has new kernels, the installed LTS kernel is not used and just taking disk space and possibly dissatisfies security scanning, although CVEs on not-in-use kernels are not exploitable. This commit simplifies the code and avoid installing a kernel that is not going to be used.

This commit uses `--with-new-pkgs` to control if the kernel is upgraded. Because kernel upgrade usually requires `--with-new-pkgs`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
