### PR TITLE
[release-3.9][integ-tests] Remove tests for Rocky, Remove build-image tests for Ubuntu22

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -77,7 +77,7 @@ test-suites:
         - regions: [ "ap-northeast-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: [ "rocky8", "ubuntu2204" ]
+          oss: [ "rhel8", "ubuntu2204" ]
   createami:
     test_createami.py::test_invalid_config:
       dimensions:
@@ -88,10 +88,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel8"]
-        - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: ["ubuntu2004", "rhel8"]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
@@ -159,7 +156,7 @@ test-suites:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["rocky9"]
+          oss: ["rhel9"]
     test_structured_log_events.py::test_custom_compute_action_failure:
       dimensions:
         - regions: ["af-south-1"]
@@ -183,7 +180,7 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
@@ -253,7 +250,7 @@ test-suites:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: ["rhel9"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:
@@ -265,7 +262,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: ["rhel8"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:


### PR DESCRIPTION
Rocky AMIs are not publicly released, therefore this commit removes tests for Rocky. Ubuntu22 build-image test is failing because of Lustre client, therefore this commit change the test to use Ubuntu20. This commit will only be applied to release-3.9 branch. We will improve the testing process on develop branch separately.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
