### PR TITLE
Add parameters to scaling stress test

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -125,6 +125,10 @@ AMI selection parameters:
 
 Benchmarks:
   --benchmarks          Run benchmarks tests. Benchmarks tests will be run together with functionality tests. (default: False)
+  
+Scaling test options:
+    --scaling-test-config SCALING_TEST_CONFIG
+                        Path to the config file containing scaling stress test parameters  (default: None)
 
 CloudFormation / Custom Resource options:
   --cluster-custom-resource-service-token CLUSTER_CUSTOM_RESOURCE_SERVICE_TOKEN

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -160,6 +160,7 @@ def pytest_addoption(parser):
         "--retain-ad-stack", action="store_true", default=False, help="Retain AD stack and corresponding VPC stack."
     )
     parser.addoption("--benchmarks", action="store_true", default=False, help="enable benchmark tests")
+    parser.addoption("--scaling-test-config", help="Path to scaling test config file")
     parser.addoption("--stackname-suffix", help="set a suffix in the integration tests stack names")
     parser.addoption(
         "--delete-logs-on-success", help="delete CloudWatch logs when a test succeeds", action="store_true"

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -316,7 +316,7 @@ def _init_argparser():
     scaling_group.add_argument(
         "--scaling-test-config",
         help="config file with scaling test parameters",
-        default=TEST_DEFAULTS.get("scaling_test_config")
+        default=TEST_DEFAULTS.get("scaling_test_config"),
     )
 
     custom_resource_group = parser.add_argument_group("CloudFormation / Custom Resource options")

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -76,6 +76,7 @@ TEST_DEFAULTS = {
     "benchmarks": False,
     "benchmarks_target_capacity": 200,
     "benchmarks_max_time": 30,
+    "scaling_test_config": None,
     "stackname_suffix": "",
     "delete_logs_on_success": False,
     "tests_root_dir": "./tests",
@@ -311,13 +312,19 @@ def _init_argparser():
         type=int,
     )
 
+    scaling_group = parser.add_argument_group("Scaling stress test options")
+    scaling_group.add_argument(
+        "--scaling-test-config",
+        help="config file with scaling test parameters",
+        default=TEST_DEFAULTS.get("scaling_test_config")
+    )
+
     custom_resource_group = parser.add_argument_group("CloudFormation / Custom Resource options")
     custom_resource_group.add_argument(
         "--cluster-custom-resource-service-token",
         help="ServiceToken (ARN) Cluster CloudFormation custom resource provider",
         default=TEST_DEFAULTS.get("cluster_custom_resource_service_token"),
     )
-
     custom_resource_group.add_argument(
         "--resource-bucket",
         help="Name of bucket to use to to retrieve standard hosted resources like CloudFormation templates.",
@@ -551,6 +558,9 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
         pytest_args.append("--html={0}/{1}/results.html".format(args.output_dir, out_dir))
         pytest_args.append("--self-contained-html")
         pytest_args.append("--capture=tee-sys")
+
+    if args.scaling_test_config:
+        pytest_args.extend(["--scaling-test-config", args.scaling_test_config])
 
     _set_custom_packages_args(args, pytest_args)
     _set_ami_args(args, pytest_args)

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/scaling_test_config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/scaling_test_config.yaml
@@ -1,0 +1,4 @@
+MaxMonitoringTimeInMins: 20
+ScalingTargets: [1000, 2000, 3000, 4000]
+SharedHeadNodeStorageType: 'Efs'
+HeadNodeInstanceType: 'c5.24xlarge'

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/scaling_test_config_schema.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling_stress_test/scaling_test_config_schema.yaml
@@ -1,0 +1,16 @@
+type: map
+mapping:
+  MaxMonitoringTimeInMins:
+    type: int
+    required: true
+  ScalingTargets:
+    type: seq
+    required: true
+    sequence:
+      - type: int
+  SharedHeadNodeStorageType:
+    type: str
+    required: true
+  HeadNodeInstanceType:
+    type: str
+    required: true


### PR DESCRIPTION
### Description of changes
* Added the test parameters into a config file to be passed into test_runner
  * Didn't add `scaling_strategy` because wanted to have separate tests. If I added it into the config, would have to use a `pytest_generate_tests` hook that accesses the scaling_strategy without validating the config file with the schema (since validating it requires access to the fixture test_datadir)
* Also edited the test slightly to have clearer assertion messages and an exception handler if the cluster didn't scale up to the target nodes within the max time limit

### Tests
* Ran the test as part of the performance tests in Jenkins
  * New functionality with the config and validating with the schema works 
  * Tests technically do not pass because the time it takes to start up is much longer than the baselines. But adjusting the baselines as necessary will be for a future PR since this one is just for passing in parameters from Jenkins. So left the baselines and default parameters as-is for now

### References
* Follows up on the stress test added in this PR: https://github.com/aws/aws-parallelcluster/pull/6027

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
