### PR TITLE
[Isolated] Not using same Subnet again while creating Storage mount t…

### DIFF
--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -118,6 +118,12 @@ Conditions:
   CreateFsxOntap: !Equals [!Ref CreateFsxOntap, 'true']
   CreateFsxOpenZfs: !Equals [!Ref CreateFsxOpenZfs, 'true']
   CreateFileCache: !Equals [!Ref CreateFileCache, 'true']
+  UniqueSubnetThree: !Or
+    - !Equals [!Ref SubnetOne, !Ref SubnetThree]
+    - !Equals [!Ref SubnetTwo, !Ref SubnetThree]
+  CreateMountTargetSubnetThree: !And
+    - !Condition CreateEfs
+    - !Not [!Condition UniqueSubnetThree]
   NoStorage: !And
     - !Not [!Equals [!Ref CreateEbs, 'true']]
     - !Not [!Equals [!Ref CreateEfs, 'true']]
@@ -161,7 +167,7 @@ Resources:
       SubnetId: !Ref SubnetTwo
   MountTargetResourceEfs0SubnetThree:
     Type: 'AWS::EFS::MountTarget'
-    Condition: CreateEfs
+    Condition: CreateMountTargetSubnetThree
     Properties:
       FileSystemId: !Ref EfsFileSystem
       SecurityGroups:
@@ -363,7 +369,7 @@ Resources:
           ToPort: 20003
       VpcId: !Ref Vpc
     Type: 'AWS::EC2::SecurityGroup'
-    
+
   # File Cache
   FileCacheSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -104,6 +104,12 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+    test_create.py::test_create_disable_sudo_access_for_default_user:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
### Description of changes
* Adding Conditions in storage-stack.yaml to create `MountTargetResourceEfs0SubnetThree` only if the Subnet is Unique

Isolated Regions have less than 3 subnets. This results in Failure when we use an existing subnet for  MountTargetResourceEfs0SubnetThree creation as we cannot create more than 1 Mount Targets for same FS in same AZ

* Add `test_create_disable_sudo_access_for_default_user` for Isolated region testingtesting

### Tests

* test_dynamic_file_systems_update in commercial


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
