### PR TITLE
[develop] Fix URL encoding for pcluster API client example

### DIFF
--- a/api/client/resources/sigv4_auth.py
+++ b/api/client/resources/sigv4_auth.py
@@ -15,6 +15,7 @@
 import boto3
 import botocore
 import json
+import urllib.parse
 
 
 def sigv4_auth(method, host, path, queries, body, headers):
@@ -22,7 +23,7 @@ def sigv4_auth(method, host, path, queries, body, headers):
     endpoint = host.replace('https://', '').replace('http://', '')
     _api_id, _service, region, _domain = endpoint.split('.', maxsplit=3)
 
-    request_parameters = '&'.join([f"{k}={v}" for k, v in queries])
+    request_parameters = urllib.parse.urlencode(queries)
     url = f"{host}{path}?{request_parameters}"
 
     session = botocore.session.Session()

--- a/api/client/src/pcluster_client/sigv4_auth.py
+++ b/api/client/src/pcluster_client/sigv4_auth.py
@@ -15,6 +15,7 @@
 import boto3
 import botocore
 import json
+import urllib.parse
 
 
 def sigv4_auth(method, host, path, queries, body, headers):
@@ -22,7 +23,7 @@ def sigv4_auth(method, host, path, queries, body, headers):
     endpoint = host.replace('https://', '').replace('http://', '')
     _api_id, _service, region, _domain = endpoint.split('.', maxsplit=3)
 
-    request_parameters = '&'.join([f"{k}={v}" for k, v in queries])
+    request_parameters = urllib.parse.urlencode(queries)
     url = f"{host}{path}?{request_parameters}"
 
     session = botocore.session.Session()


### PR DESCRIPTION
### Description of changes
* Fix URL encoding for pcluster API client example, that was causing an error when using additional parameters like next_token. The next_token may contain special chars like "/" that needs to be encoded before passing the request to the API gateway.

The new client was generated by running the command `./gradlew generatePythonClient`.

### Tests
* Tested with example at https://github.com/aws/aws-parallelcluster/blob/develop/api/client/example.py

### References
* https://github.com/aws/aws-parallelcluster/tree/develop/api/client/src

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
