### PR TITLE
[Isolated] Reverting changes w.r.t. Ad integration tests

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -591,16 +591,9 @@ Resources:
   PasswordSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: ReadOnly password for AD
+      Description: Password for Microsoft AD
       Name: !Sub [ "PasswordSecret-${StackIdSuffix}", {StackIdSuffix: !Select [1, !Split ['/', !Ref 'AWS::StackId']]}]
       SecretString: !Ref ReadOnlyPassword
-
-  UserPasswordSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: User password for AD
-      Name: !Sub [ "UserPasswordSecret-${StackIdSuffix}", { StackIdSuffix: !Select [ 1, !Split [ '/', !Ref 'AWS::StackId' ] ] } ]
-      SecretString: !Ref UserPassword
 
   DomainCertificateSecret:
     Type: AWS::SecretsManager::Secret
@@ -920,8 +913,6 @@ Outputs:
     Value: !Ref DomainName
   PasswordSecretArn:
     Value: !Ref PasswordSecret
-  UserPasswordSecretArn:
-    Value: !Ref UserPasswordSecret
   DomainCertificateArn:
     Value: !GetAtt DomainCertificateSetup.DomainCertificateArn
   DomainCertificateSecretArn:

--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -118,6 +118,12 @@ Conditions:
   CreateFsxOntap: !Equals [!Ref CreateFsxOntap, 'true']
   CreateFsxOpenZfs: !Equals [!Ref CreateFsxOpenZfs, 'true']
   CreateFileCache: !Equals [!Ref CreateFileCache, 'true']
+  UniqueSubnetThree: !Or
+    - !Equals [!Ref SubnetOne, !Ref SubnetThree]
+    - !Equals [!Ref SubnetTwo, !Ref SubnetThree]
+  CreateMountTargetSubnetThree: !And
+    - !Condition CreateEfs
+    - !Not [!Condition UniqueSubnetThree]
   NoStorage: !And
     - !Not [!Equals [!Ref CreateEbs, 'true']]
     - !Not [!Equals [!Ref CreateEfs, 'true']]
@@ -161,7 +167,7 @@ Resources:
       SubnetId: !Ref SubnetTwo
   MountTargetResourceEfs0SubnetThree:
     Type: 'AWS::EFS::MountTarget'
-    Condition: CreateEfs
+    Condition: CreateMountTargetSubnetThree
     Properties:
       FileSystemId: !Ref EfsFileSystem
       SecurityGroups:
@@ -363,7 +369,7 @@ Resources:
           ToPort: 20003
       VpcId: !Ref Vpc
     Type: 'AWS::EC2::SecurityGroup'
-    
+
   # File Cache
   FileCacheSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -43,7 +43,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--pre-install PRE_INSTALL] [--post-install POST_INSTALL] [--instance-types-data INSTANCE_TYPES_DATA] [--custom-ami CUSTOM_AMI] [--pcluster-git-ref PCLUSTER_GIT_REF] [--cookbook-git-ref COOKBOOK_GIT_REF]
                       [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
                       [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
-                      [--no-delete] [--retain-ad-stack] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
+                      [--no-delete] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
 
 Run integration tests suite.
 
@@ -155,9 +155,9 @@ Debugging/Development options:
                         Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
 
   --no-delete           Don't delete stacks after tests are complete. (default: False)
-
+  
   --retain-ad-stack     Retain AD stack and corresponding VPC stack after tests are complete. (default: False)
-
+  
   --delete-logs-on-success
                         delete CloudWatch logs when a test succeeds (default: False)
   --stackname-suffix STACKNAME_SUFFIX
@@ -167,7 +167,7 @@ Debugging/Development options:
                         Name of CFN stack providing AD domain to be used for testing AD integration feature. (default: None)
   --ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME
                         Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
-  --external-shared-storage-stack-name
+  --external-shared-storage-stack-name 
                         Name of an existing external shared storage stack. (default: None)
 ```
 
@@ -384,7 +384,6 @@ use the following options:
 * `--custom-node-url`: URL to a custom node package.
 * `--custom-cookbook-url`: URL to a custom cookbook package.
 * `--createami-custom-cookbook-url`: URL to a custom cookbook package for the createami command.
-* `--createami-custom-node-url`: URL to a custom node package for the createami command.
 * `--custom-template-url`: URL to a custom cfn template.
 * `--custom-awsbatchcli-url`: URL to a custom awsbatch cli package.
 * `--custom-ami`: custom AMI to use for all tests. Note that this custom AMI will be used
@@ -653,10 +652,10 @@ available in the `pcluster.config.yaml` files:
 * Test dimensions for the specific parametrized test case: `{{ region }}`, `{{ instance }}`, `{{ os }}`,
 `{{ scheduler }}`
 * EC2 key name specified at tests submission time by the user: `{{ key_name }}`
-* Networking related parameters: `{{ public_subnet_id }}`, `{{ public_subnet_ids }}`,
+* Networking related parameters: `{{ public_subnet_id }}`, `{{ public_subnet_ids }}`, 
 `{{ private_subnet_id }}` and `{{ private_subnet_ids }}`, where `{{ public_subnet_ids }}` and `{{ private_subnet_ids }}`
- contain a list of subnets for which the relative index points to subnets in the same AZ, e.g.
-`{{ public_subnet_ids[2] }}` and `{{ private_subnet_ids[2] }}` will be in the same AZ
+ contain a list of subnets for which the relative index points to subnets in the same AZ, e.g. 
+`{{ public_subnet_ids[2] }}` and `{{ private_subnet_ids[2] }}` will be in the same AZ   
 
 Additional parameters can be specified when calling the fixture to retrieve the rendered configuration
 as shown in the example above.
@@ -667,7 +666,7 @@ A VPC and the related subnets are automatically configured at the start of the i
 test. These resources are shared across all the tests and deleted when all tests are completed.
 
 The idea is to create a single VPC per region and have multiple subnets that allow to test different networking setups.
-A pair of subnets (public/private) for each available AZ, plus a subnet with VPC endpoints and no internet access,
+A pair of subnets (public/private) for each available AZ, plus a subnet with VPC endpoints and no internet access, 
 are generated with the following configuration:
 
 ```python
@@ -740,7 +739,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_ids[0] }}
-  ...
+  ...          
     - Name: queue-2
       Networking:
         SubnetIds:

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -216,16 +216,6 @@ class CfnStacksFactory:
                 try:
                     stack = self.__created_stacks[internal_id]
                     cfn_client = boto3.client("cloudformation", region_name=stack.region)
-                    tags = cfn_client.describe_stacks(StackName=stack.name)["Stacks"][0]["Tags"]
-                    for tag in tags:
-                        if tag.get("Key") == "DO-NOT-DELETE":
-                            logging.info(
-                                "Deletion of stack {0} in region {1} skipped due to DO-NOT-DELETE tag".format(
-                                    name, region
-                                )
-                            )
-                            del self.__created_stacks[internal_id]
-                            return
                     cfn_client.delete_stack(StackName=stack.name)
                     final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
                     self.__assert_stack_status(
@@ -304,18 +294,10 @@ class CfnStacksFactory:
                     "Couldn't find stack with name {0} in region {1}. Skipping update.".format(name, region)
                 )
 
-    def delete_all_stacks(self, excluded_stacks=None):
-        """Destroy all created stacks except for those in excluded_stacks."""
+    def delete_all_stacks(self):
+        """Destroy all created stacks."""
         logging.debug("Destroying all cfn stacks")
         for value in reversed(OrderedDict(self.__created_stacks).values()):
-            if excluded_stacks:
-                excluded = False
-                for stack in excluded_stacks:
-                    if stack in value.name:
-                        excluded = True
-                        break
-                if excluded:
-                    continue
             try:
                 self.delete_stack(value.name, value.region)
             except Exception as e:

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -104,6 +104,12 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+    test_create.py::test_create_disable_sudo_access_for_default_user:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: {{ REGIONS }}

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -156,9 +156,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--no-delete", action="store_true", default=False, help="Don't delete stacks after tests are complete."
     )
-    parser.addoption(
-        "--retain-ad-stack", action="store_true", default=False, help="Retain AD stack and corresponding VPC stack."
-    )
     parser.addoption("--benchmarks", action="store_true", default=False, help="enable benchmark tests")
     parser.addoption("--stackname-suffix", help="set a suffix in the integration tests stack names")
     parser.addoption(
@@ -858,11 +855,7 @@ def cfn_stacks_factory(request):
     factory = CfnStacksFactory(request.config.getoption("credential"))
     yield factory
     if not request.config.getoption("no_delete"):
-        excluded_stacks = []
-        if request.config.getoption("retain_ad_stack"):
-            excluded_stacks.extend(["vpc", "SimpleAD", "MicrosoftAD"])
-            logging.warning("Skipping deletion of AD and VPC stacks because --retain-ad-stack option is set")
-        factory.delete_all_stacks(excluded_stacks)
+        factory.delete_all_stacks()
     else:
         logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -390,6 +390,12 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("directory_stack_name"),
     )
     debug_group.add_argument(
+        "--ldaps-nlb-stack-name",
+        help="Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD "
+        "integration feature.",
+        default=TEST_DEFAULTS.get("ldaps_nlb_stack_name"),
+    )
+    debug_group.add_argument(
         "--slurm-database-stack-name",
         help="Name of CFN stack providing database stack to be used for testing Slurm accounting feature.",
         default=TEST_DEFAULTS.get("slurm_database_stack_name"),
@@ -620,6 +626,9 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.directory_stack_name:
         pytest_args.extend(["--directory-stack-name", args.directory_stack_name])
+
+    if args.ldaps_nlb_stack_name:
+        pytest_args.extend(["--ldaps-nlb-stack-name", args.ldaps_nlb_stack_name])
 
     if args.slurm_database_stack_name:
         pytest_args.extend(["--slurm-database-stack-name", args.slurm_database_stack_name])

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -92,7 +92,6 @@ TEST_DEFAULTS = {
     "lambda_layer_source": None,
     "force_run_instances": False,
     "force_elastic_ip": False,
-    "retain_ad_stack": False,
 }
 
 
@@ -424,12 +423,6 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("force_elastic_ip"),
         action="store_true",
     )
-    debug_group.add_argument(
-        "--retain-ad-stack",
-        action="store_true",
-        help="Retain AD stack and corresponding VPC stack.",
-        default=TEST_DEFAULTS.get("retain_ad_stack"),
-    )
 
     return parser
 
@@ -635,9 +628,6 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.external_shared_storage_stack_name:
         pytest_args.extend(["--external-shared-storage-stack-name", args.external_shared_storage_stack_name])
-
-    if args.retain_ad_stack:
-        pytest_args.append("--retain-ad-stack")
 
 
 def _set_validate_instance_type_args(args, pytest_args):

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -343,6 +343,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stack, store_secret_in_se
         existing_directory_stack_name,
         existing_nlb_stack_name,
         directory_type,
+        test_resources_dir,
         region,
     ):
         if existing_directory_stack_name:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -210,7 +210,7 @@ def _create_directory_stack(
             region=region,
             template=directory_stack_template.read(),
             parameters=params,
-            capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+            capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
         )
     cfn_stacks_factory.create_stack(directory_stack)
     logging.info("Creation of stack %s complete", directory_stack_name)
@@ -338,6 +338,7 @@ def _delete_certificate(certificate_arn, region):
 def directory_factory(request, cfn_stacks_factory, vpc_stack, store_secret_in_secret_manager):  # noqa: C901
     # TODO: use external data file and file locking in order to share directories across processes
     created_directory_stacks = defaultdict(dict)
+    created_certificates = defaultdict(dict)
 
     def _directory_factory(
         existing_directory_stack_name,

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -51,10 +51,10 @@ SharedStorage:
       VolumeId: {{ fsx_ontap_volume_id }}
   {% endif %}
 DirectoryService:
-  DomainName: {{ domain_name }}
+  DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
-  DomainReadOnlyUser: {{ domain_read_only_user }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsCaCert: {{ ldap_tls_ca_cert }}
   LdapTlsReqCert: {{ ldap_tls_req_cert }}
   GenerateSshKeysForUsers: true

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -51,10 +51,10 @@ SharedStorage:
       VolumeId: {{ fsx_ontap_volume_id }}
   {% endif %}
 DirectoryService:
-  DomainName: {{ domain_name }}
+  DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
-  DomainReadOnlyUser: {{ domain_read_only_user }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsCaCert: {{ ldap_tls_ca_cert }}
   LdapTlsReqCert: {{ ldap_tls_req_cert }}
   GenerateSshKeysForUsers: true

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -51,10 +51,10 @@ SharedStorage:
       VolumeId: {{ fsx_ontap_volume_id }}
   {% endif %}
 DirectoryService:
-  DomainName: {{ domain_name }}
+  DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
-  DomainReadOnlyUser: {{ domain_read_only_user }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsCaCert: {{ ldap_tls_ca_cert }}
   LdapTlsReqCert: {{ ldap_tls_req_cert }}
   GenerateSshKeysForUsers: false

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -867,25 +867,3 @@ def retrieve_clustermgtd_conf_path(remote_command_executor):
 def disable_protected_mode(remote_command_executor):
     """Disable protected mode by setting protected_failure_count to -1."""
     set_protected_failure_count(remote_command_executor, -1)
-
-
-def find_stack_by_tag(tag, region, stack_prefix):
-    """Find cloudformation stack with stack_prefix in its name that has a specfic tag"""
-    cfn_client = boto3.client("cloudformation", region_name=region)
-    stacks = cfn_client.describe_stacks()
-
-    for stack in stacks.get("Stacks"):
-        name = stack.get("StackName")
-        tags = stack.get("Tags")
-        creation_date = stack.get("CreationTime")
-        stack_status = stack.get("StackStatus")
-        has_tag = False
-
-        for t in tags:
-            if t["Key"] == tag:
-                has_tag = True
-
-        if stack_status == "CREATE_COMPLETE" and stack_prefix in name and has_tag:
-            logging.info(f"Found stack: {name} (created on {creation_date})")
-            return name
-    return None


### PR DESCRIPTION
### Description of changes

* Reverting commits w.r.t AD integration tests as ACM is not supported in Isoated Regions
* https://github.com/aws/aws-parallelcluster/pull/6032
* https://github.com/aws/aws-parallelcluster/pull/6046
* https://github.com/aws/aws-parallelcluster/pull/6064

Cherry Pick -> https://github.com/aws/aws-parallelcluster/pull/6171

### Tests
* Commercial tests for Microsoft AD passes
* SimpleAD ( not supported in ADC) fails the tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
