### PR TITLE
[Isolated] Adding time of 25 seconds before checking the num of nodes

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1162,6 +1162,8 @@ def _test_partition_states(
     # Assert no nodes in inactive partition
     wait_for_num_nodes_in_scheduler(scheduler_commands, desired=0, filter_by_partition=inactive_partition)
     # Assert active partition is not affected
+    if "us-iso" in region:
+        time.sleep(25)
     assert_num_nodes_in_scheduler(scheduler_commands, desired=num_static_nodes, filter_by_partition=active_partition)
     # set inactive partition back to active and wait for nodes to spin up
     scheduler_commands.set_partition_state(inactive_partition, "up")


### PR DESCRIPTION
### Description of changes
* [Isolated] Adding time of 25 seconds before checking the num of nodes](https://github.com/aws/aws-parallelcluster/commit/996c5fbe802e43d6d65f15d20f7569491f48e9ee)


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
