### PR TITLE
Use the MetricsPublisher in the runtest_makereport hook to publish ph…

### DIFF
--- a/tests/integration-tests/conftest_runtest_hooks.py
+++ b/tests/integration-tests/conftest_runtest_hooks.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+from typing import Optional, Tuple
+
+import pluggy
+import pytest
+from _pytest._code import ExceptionInfo
+from conftest_utils import (
+    add_properties_to_report,
+    publish_test_metrics,
+    runtest_hook_start_end_time,
+    update_failed_tests_config,
+)
+from utils import SetupError, set_logger_formatter
+
+# This file has a special meaning for pytest. See https://docs.pytest.org/en/2.7.3/plugins.html for
+# additional details.
+
+
+def pytest_runtest_logstart(nodeid: str, location: Tuple[str, Optional[int], str]):
+    """Called to execute the test item."""
+    test_name = location[2]
+    set_logger_formatter(
+        logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - %(process)d - {test_name} - %(module)s - %(message)s")
+    )
+    logging.info("Running test %s", test_name)
+
+
+def pytest_runtest_logfinish(nodeid: str, location: Tuple[str, Optional[int], str]):
+    logging.info("Completed test %s", location[2])
+    set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(process)d - %(module)s - %(message)s"))
+
+
+def pytest_runtest_logreport(report: pytest.TestReport):
+    logging.info(f"Starting log report for test {report.nodeid}")
+    # Set the approximate start time for the test
+    logging.info(f"Report keys {list(report.keywords)}")
+    logging.info(f"Report props {list(report.user_properties)}")
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_setup(item: pytest.Item):
+    yield from runtest_hook_start_end_time(item, "setup")
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item):
+    yield from runtest_hook_start_end_time(item, "call")
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item):
+    yield from runtest_hook_start_end_time(item, "teardown")
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    """Making test result information available in fixtures"""
+    # add dimension properties to report
+    add_properties_to_report(item)
+
+    # execute all other hooks to obtain the report object
+    outcome: pluggy.Result = yield
+    rep: pytest.TestReport = outcome.get_result()
+    logging.info(f"rep {rep}")
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    setattr(item, "rep_" + rep.when, rep)
+
+    if rep.when in ["setup", "call"] and rep.failed:
+        exception_info: ExceptionInfo = call.excinfo
+        if exception_info.value and isinstance(exception_info.value, SetupError):
+            rep.when = "setup"
+        try:
+            update_failed_tests_config(item)
+        except Exception as e:
+            logging.error("Failed when generating config for failed tests: %s", e, exc_info=True)
+    # Set the approximate start time for the test
+    logging.info(f"Report keys {list(item.keywords)}")
+    try:
+        publish_test_metrics(rep.when, item, rep)
+    except Exception as exc:
+        logging.info(f"There was a {type(exc)} error with {exc} publishing the report!")

--- a/tests/integration-tests/conftest_utils.py
+++ b/tests/integration-tests/conftest_utils.py
@@ -1,0 +1,169 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, List
+
+import pluggy
+import pytest
+import yaml
+from conftest_markers import DIMENSIONS_MARKER_ARGS
+from filelock import FileLock
+from framework.metrics_publisher import Metric, MetricsPublisher
+from time_utils import microseconds
+from utils import dict_add_nested_key, dict_has_nested_key
+
+
+def add_properties_to_report(item: pytest.Item):
+    props = []
+
+    # Add properties for test dimensions, obtained from fixtures passed to tests
+    for dimension in DIMENSIONS_MARKER_ARGS:
+        value = item.funcargs.get(dimension)
+        if value:
+            props.append((dimension, value))
+
+    # Add property for feature tested, obtained from filename containing the test
+    props.append(("feature", extract_tested_component_from_filename(item)))
+
+    for dimension_value_pair in props:
+        if dimension_value_pair not in item.user_properties:
+            item.user_properties.append(dimension_value_pair)
+
+
+def update_failed_tests_config(item: pytest.Item):
+    out_dir = Path(item.config.getoption("output_dir"))
+    if not str(out_dir).endswith(".out"):
+        # Navigate to the parent dir in case of parallel run so that we can access the shared parent dir
+        out_dir = out_dir.parent
+
+    out_file = out_dir / "failed_tests_config.yaml"
+    logging.info("Updating failed tests config file %s", out_file)
+    # We need to acquire a lock first to prevent concurrent edits to this file
+    with FileLock(str(out_file) + ".lock"):
+        failed_tests = {"test-suites": {}}
+        if out_file.is_file():
+            with open(str(out_file), encoding="utf-8") as f:
+                failed_tests = yaml.safe_load(f)
+
+        # item.node.nodeid example:
+        # 'dcv/test_dcv.py::test_dcv_configuration[eu-west-1-c5.xlarge-centos7-slurm-8443-0.0.0.0/0-/shared]'
+        feature, test_id = item.nodeid.split("/", 1)
+        test_id = test_id.split("[", 1)[0]
+        dimensions = {}
+        for dimension in DIMENSIONS_MARKER_ARGS:
+            value = item.callspec.params.get(dimension)
+            if value:
+                dimensions[dimension + "s"] = [value]
+
+        if not dict_has_nested_key(failed_tests, ("test-suites", feature, test_id)):
+            dict_add_nested_key(failed_tests, [], ("test-suites", feature, test_id, "dimensions"))
+        if dimensions not in failed_tests["test-suites"][feature][test_id]["dimensions"]:
+            failed_tests["test-suites"][feature][test_id]["dimensions"].append(dimensions)
+            with open(out_file, "w", encoding="utf-8") as f:
+                yaml.dump(failed_tests, f)
+
+
+def extract_tested_component_from_filename(item: pytest.Item):
+    """Extract portion of test item's filename identifying the component it tests."""
+    test_location = os.path.splitext(os.path.basename(item.location[0]))[0]
+    return re.sub(r"test_|_test", "", test_location)
+
+
+def add_filename_markers(items: List[pytest.Item], config: pytest.Config):
+    """Add a marker based on the name of the file where the test case is defined."""
+    for item in items:
+        marker = extract_tested_component_from_filename(item)
+        # This dynamically registers markers in pytest so that warning for the usage of undefined markers are not
+        # displayed
+        config.addinivalue_line("markers", marker)
+        item.add_marker(marker)
+
+
+def runtest_hook_start_end_time(item: pytest.Item, when: str):
+    """Generator function to store start and end times for test phases."""
+    logging.info(f"Starting {when} for test {item.name}")
+    item.user_properties.append((f"start_time_{when}", datetime.now(timezone.utc)))
+    # execute all other hooks to obtain the call object
+    outcome: pluggy.Result = yield
+    item.user_properties.append((f"end_time_{when}", datetime.now(timezone.utc)))
+    call_list: List[pytest.CallInfo] = outcome.get_result()
+    logging.info(f"{when} list {call_list}")
+
+
+def publish_test_metrics(when: str, item: pytest.Item, rep: pytest.TestReport):
+    """
+    Publish test metrics specific to a given test execution.
+
+    Dimensions - feature, test name, region, os, instance type
+    Execution times - for each phase and total
+    Test Result - Pass/Fail
+    """
+    pub = MetricsPublisher(get_user_prop(item, "region"))
+    dimensions = [
+        {"Name": dimension, "Value": get_user_prop(item, dimension)}
+        for dimension in ["feature", "os", "instance", "region"]
+    ]
+    dimensions.append({"Name": "test_name", "Value": item.location[2]})
+    # Create a list of metrics
+    logging.info("create metrics")
+    metrics = create_phase_metrics(when, item, rep, dimensions)
+    logging.info("publish metrics")
+    pub.publish_metrics_to_cloudwatch("ParallelCluster/IntegrationTests", metrics)
+
+
+def get_user_prop(item: pytest.Item, prop: str) -> Any:
+    """From a list of tuples, get the desired user property."""
+    logging.info(f"getting user prop {prop}")
+    for user_prop in item.user_properties:
+        logging.info(f"checking prop {user_prop}")
+        if user_prop[0] == prop:
+            logging.info(f"returning {user_prop[1]}")
+            return user_prop[1]
+
+
+def create_phase_metrics(when: str, item: pytest.Item, rep: pytest.TestReport, dimensions: List[dict[str, str]]):
+    metrics = [
+        Metric(f"{when}_result", int(rep.passed), "None", dimensions),
+        Metric(
+            f"{when}_time",
+            int(
+                microseconds(
+                    (
+                        get_user_prop(item, f"end_time_{when}") - get_user_prop(item, f"start_time_{when}")
+                    ).total_seconds()
+                )
+            ),
+            "Microseconds",
+            dimensions,
+        ),
+    ]
+    if when == "teardown":
+        metrics.append(
+            Metric(
+                "total_time",
+                int(
+                    microseconds(
+                        (
+                            get_user_prop(item, "end_time_teardown") - get_user_prop(item, "start_time_setup")
+                        ).total_seconds()
+                    )
+                ),
+                "Microseconds",
+                dimensions,
+            )
+        )
+    return metrics

--- a/tests/integration-tests/framework/metrics_publisher.py
+++ b/tests/integration-tests/framework/metrics_publisher.py
@@ -52,9 +52,14 @@ class MetricsPublisher:
     def publish_metrics_to_cloudwatch(self, namespace: str, metrics: List[Metric]):
         """Pushes a list of metrics to cloudwatch using a single namespace."""
         try:
+            logging.info(
+                f"publishing metrics to cloudwatch {[metric.generate_metric_data_entry() for metric in metrics]}"
+            )
             self.client.put_metric_data(
                 Namespace=namespace,
                 MetricData=[metric.generate_metric_data_entry() for metric in metrics],
             )
         except botocore.exceptions.ParamValidationError:
             logging.error("Invalid params for metric")
+        except Exception as exc:
+            logging.error(f"A {type(exc)} occurred with {exc}")

--- a/tests/integration-tests/time_utils.py
+++ b/tests/integration-tests/time_utils.py
@@ -19,3 +19,8 @@ def minutes(min):
 def seconds(sec):
     """Convert seconds to milliseconds"""
     return sec * 1000
+
+
+def microseconds(sec: float):
+    """Convert seconds to microseconds."""
+    return sec * 1000000


### PR DESCRIPTION
…ase result metrics and timing metrics

Also refactors the conftest functions that are related to runtest hooks into a separate module for clarity and to reduce the content in the conftest file

### Tests
* Ran integ tests locally and verified the metrics are available in cloudwatch.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
