### PR TITLE
Output bootstrap errors in scaling test

### DIFF
--- a/tests/integration-tests/tests/common/scaling/get_bootstrap_errors.sh
+++ b/tests/integration-tests/tests/common/scaling/get_bootstrap_errors.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+set -ex
+
+CLUSTERMGTD_LOG="/var/log/parallelcluster/clustermgtd"
+touch "bootstrap_errors.txt"
+
+# Find a log message like:
+# ... WARNING - Node bootstrap error: Node queue-0-dy-compute-resource-0-1690(192.168.90.197) ...
+# and get the IP address
+sudo cat ${CLUSTERMGTD_LOG} | grep -i "Node bootstrap error" | awk -F"[()]" '{print $2}' | while read -r ip_address ; do
+  if ! grep -q "${ip_address}" "bootstrap_errors.txt"; then
+    echo "${ip_address}" >> "bootstrap_errors.txt"
+  fi
+done

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -11,6 +11,7 @@
 import datetime
 import json
 import logging
+import os
 import pathlib
 import time
 
@@ -62,6 +63,58 @@ def retry_if_scaling_target_not_reached(
         or (use_ec2_limit and max(ec2_capacity_time_series) == 0)
         or (use_compute_nodes_limit and max(compute_nodes_time_series) == 0)
     )
+
+
+def _check_no_node_log_exists_for_ip_address(path, ip_address):
+    for file_name in os.listdir(path):
+        if file_name.startswith(ip_address):
+            return False
+    return True
+
+
+def _sort_instances_by_launch_time(describe_instances_page_iterator):
+    instances = []
+    for page in describe_instances_page_iterator:
+        for reservation in page["Reservations"]:
+            for instance in reservation["Instances"]:
+                instances.append(instance)
+    instances.sort(key=lambda inst: inst["LaunchTime"])
+    return instances
+
+
+def get_bootstrap_errors(remote_command_executor: RemoteCommandExecutor, cluster_name, output_dir, region):
+    logging.info("Checking for bootstrap errors...")
+    remote_command_executor.run_remote_script(script_file=str(SCALING_COMMON_DATADIR / "get_bootstrap_errors.sh"))
+    ip_addresses_with_bootstrap_errors = remote_command_executor.run_remote_command(
+        command="cat $HOME/bootstrap_errors.txt"
+    ).stdout
+
+    path = os.path.join(output_dir, "bootstrap_errors")
+    os.makedirs(path, exist_ok=True)
+
+    client = boto3.client("ec2", region_name=region)
+    for ip_address in ip_addresses_with_bootstrap_errors.splitlines():
+        # Since the same cluster is re-used for multiple scale up tests, the script may find the same bootstrap error
+        # multiple times and then get the wrong instance logs since the IP address would be attached to a new instance.
+        # Therefore, only write the compute node logs for the IP address if the file doesn't exist yet.
+        if _check_no_node_log_exists_for_ip_address(path, ip_address):
+            try:
+                logging.warning(f"Compute node with IP {ip_address} had bootstrap errors. Getting instance id...")
+                # Get the latest launched instance with the IP address since the most recent one should have the error
+                paginator = client.get_paginator("describe_instances")
+                instance_id = _sort_instances_by_launch_time(
+                    paginator.paginate(Filters=[{"Name": "private-ip-address", "Values": [ip_address]}])
+                )[-1]["InstanceId"]
+                logging.warning(f"Instance {instance_id} had bootstrap errors. Check the test outputs for details.")
+                compute_node_log = client.get_console_output(InstanceId=instance_id, Latest=True)["Output"]
+                with open(os.path.join(path, f"{ip_address}-{cluster_name}-{instance_id}-{region}-log.txt"), "w") as f:
+                    f.write(compute_node_log)
+            except IndexError:
+                # If the instance with the IP address can't be found, continue to get any other bootstrap errors
+                logging.warning("Couldn't find instance with IP %s but could have a bootstrap error.", ip_address)
+            except Exception:
+                logging.error("Error when retrieving the compute node logs for instance with ip address %s", ip_address)
+                raise
 
 
 def get_scaling_metrics(


### PR DESCRIPTION
### Description of changes
* Adding a check for every scale up for any bootstrap errors in clustermgtd. If there are (very unlikely with the latest versions), get the latest console logs for that associated instance because it's possible that the bootstrap error would happen before the CWAgent has been configured (and thus no logs in Cloudwatch yet to check). The logs are visible in the test outputs in Jenkins
* There are some nuances with getting the IP address and then the associated instance id because we reuse the same cluster for multiple scale ups (and thus the info from previous scale ups will stay in clustermgtd when we query it for the bootstrap errors)
  * The node bootstrap error message in the clustermgtd gives the IP address, not the instance id. So then we need to handle getting the correct instance id from the IP address.
  * In the code, the bootstrap error code is ran for each scale up and the bootstrap error console logs are recorded for that IP address. Then if those logs are there, there will be no further checks on that IP address for future scale ups
    * This is to avoid getting the logs of an instance that doesn't have a bootstrap error (since the IP address will be flagged for every scale-up). The problem this poses would be if in one scale-up there is a bootstrap error with that IP address and then in a following scale-up there is another error with the same IP address so those console logs wouldn't be recorded, but this would be very rare.
  * The code gets the logs of the latest launched instance if there are multiple instances associated with the same IP address. 
    * This is to avoid getting the logs of an instance with the same IP address from a previous scale-up, but assumes that the latest launched instance is the one with the bootstrap error.
  * Since it is very rare to get a bootstrap error in the first place, these nuances should not matter much

### Tests
* Ran the test with a few P3 instances with v3.8.0 in order to get the known issue of the gdrcopy bootstrap failure. Logs are in the test artifacts in Jenkins
* Ran the test regularly and worked fine (but there were no bootstrap failures)

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
