### PR TITLE
Fix bug to allow alarms to be disabled when cw dashboard is enabled

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -317,6 +317,8 @@ class ClusterCdkStack:
         # Alarms
         if self.config.are_alarms_enabled:
             self._add_head_node_alarms()
+        else:
+            self.head_node_alarms = []
 
         # CloudWatch Dashboard
         if self.config.is_cw_dashboard_enabled:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
@@ -122,3 +122,5 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: true
+  Alarms:
+    Enabled: false


### PR DESCRIPTION
### Description of changes
* Fixes bug where is cloudwatch dashboard in enabled, but alarms are disabled you get the following error:
`{
  "message": "'ClusterCdkStack' object has no attribute 'head_node_alarms'"
}`

Allows for the following monitoring cluster configuration:

```
Monitoring:
  Dashboards:
    CloudWatch:
      Enabled: true
  Alarms:
    Enabled: false
```

### Tests
* Ran unit tests locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
