### PR TITLE
[Test] Reduce test_monitoring to only running one test in develop

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -141,13 +141,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
-  monitoring:
-    test_monitoring.py::test_monitoring:
-      dimensions:
-        - regions: ["ap-northeast-2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["rocky9"]
   networking:
     test_cluster_networking.py::test_existing_eip:
       dimensions:

--- a/tests/integration-tests/tests/monitoring/test_monitoring.py
+++ b/tests/integration-tests/tests/monitoring/test_monitoring.py
@@ -26,7 +26,7 @@ from time_utils import minutes
 @pytest.mark.usefixtures("instance", "os", "scheduler")
 @pytest.mark.parametrize(
     "dashboard_enabled, cw_log_enabled, alarms_enabled",
-    [(True, True, True), (True, False, True), (False, False, False)],
+    [(True, True, True)],
 )
 def test_monitoring(
     dashboard_enabled,


### PR DESCRIPTION
### Description of changes
* Reduce test_monitoring to only running one test in develop
* Modify unit test to cover all the different cases when validating the content of the CFN template

### Tests
* Ran unit test locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
