### PR TITLE
[Integ-tests] Use right permission to operate on log files

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -67,7 +67,8 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False,
         log_files = []
 
     for log_file in log_files:
-        log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+        log_file_user = remote_command_executor.get_user_to_operate_on_file(log_file)
+        log = remote_command_executor.run_remote_command(f"sudo -u {log_file_user} cat {log_file}", hide=True).stdout
         log = "\n".join(
             [line for line in log.splitlines() if not any(pattern in line for pattern in patterns_to_ignore)]
         )
@@ -80,7 +81,8 @@ def assert_no_msg_in_logs(remote_command_executor: RemoteCommandExecutor, log_fi
     __tracebackhide__ = True
     log = ""
     for log_file in log_files:
-        log += remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+        log_file_user = remote_command_executor.get_user_to_operate_on_file(log_file)
+        log += remote_command_executor.run_remote_command(f"sudo -u {log_file_user} cat {log_file}", hide=True).stdout
     for message in log_msg:
         assert_that(log).does_not_contain(message)
 
@@ -88,7 +90,8 @@ def assert_no_msg_in_logs(remote_command_executor: RemoteCommandExecutor, log_fi
 def assert_msg_in_log(remote_command_executor: RemoteCommandExecutor, log_file: str, message: str):
     """Assert message is in log_file."""
     __tracebackhide__ = True
-    log = remote_command_executor.run_remote_command(f"sudo cat {log_file}", hide=True).stdout
+    log_file_user = remote_command_executor.get_user_to_operate_on_file(log_file)
+    log = remote_command_executor.run_remote_command(f"sudo -u {log_file_user} cat {log_file}", hide=True).stdout
     assert_that(log).contains(message)
 
 
@@ -98,7 +101,8 @@ def assert_lines_in_logs(remote_command_executor: RemoteCommandExecutor, log_fil
 
     log = ""
     for log_file in log_files:
-        log += remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+        log_file_user = remote_command_executor.get_user_to_operate_on_file(log_file)
+        log += remote_command_executor.run_remote_command(f"sudo -u {log_file_user} cat {log_file}", hide=True).stdout
     for message in expected_errors:
         assert_that(log).matches(message)
 


### PR DESCRIPTION
In many of the operating systems ParallelCluster supported, `root` user could bypass any files permissions. However, with RHEL9 and Rocky9, `root` user could not bypass files permissions by default. Therefore, this commit improves integration tests to operate on files with the owner users of the files

This method started from https://github.com/aws/aws-parallelcluster/commit/3e85cf6759eb0cd19b066da99cd81ef21c07f6ae


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
