### PR TITLE
[Integ-tests] Don't check FSx in dynamic file system update test when not supported

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1203,12 +1203,16 @@ def test_dynamic_file_systems_update(
         ebs_mount_dirs=[],
         new_raid_mount_dir=[],
         efs_mount_dirs=[existing_efs_mount_dir],
-        fsx_mount_dirs=[
-            existing_fsx_lustre_mount_dir,
-            existing_fsx_open_zfs_mount_dir,
-            existing_fsx_ontap_mount_dir,
-            existing_file_cache_mount_dir,
-        ],
+        fsx_mount_dirs=(
+            [
+                existing_fsx_lustre_mount_dir,
+                existing_fsx_open_zfs_mount_dir,
+                existing_fsx_ontap_mount_dir,
+                existing_file_cache_mount_dir,
+            ]
+            if fsx_supported
+            else []
+        ),
         file_cache_path=file_cache_path,
     )
     for mount_dir in all_mount_dirs_update_1:


### PR DESCRIPTION
The logic has been done in other checks of the same test.


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
