### PR TITLE
Add verify_pmix parameter to test_mpi

### DIFF
--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -27,6 +27,7 @@ def _test_mpi(
     stack_name=None,
     scaledown_idletime=None,
     verify_scaling=False,
+    verify_pmix=False,
     partition=None,
     num_computes=None,
 ):
@@ -36,11 +37,12 @@ def _test_mpi(
     compile_mpi_ring(mpi_module, remote_command_executor)
 
     # Verifies PMIx worked
-    mpi_list_output = remote_command_executor.run_remote_command("srun 2>&1 --mpi=list").stdout
-    assert_that(mpi_list_output).matches(r"\s+pmix($|\s+)")
+    if verify_pmix:
+        mpi_list_output = remote_command_executor.run_remote_command("srun 2>&1 --mpi=list").stdout
+        assert_that(mpi_list_output).matches(r"\s+pmix($|\s+)")
 
-    interactive_command = f"module load {mpi_module} && srun --mpi=pmix -N {num_computes} ring"
-    remote_command_executor.run_remote_command(interactive_command)
+        interactive_command = f"module load {mpi_module} && srun --mpi=pmix -N {num_computes} ring"
+        remote_command_executor.run_remote_command(interactive_command)
 
     if partition:
         # submit script using additional files

--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -40,6 +40,7 @@ def test_mpi(scheduler, region, instance, pcluster_config_reader, clusters_facto
         scaledown_idletime,
         verify_scaling=False,
         num_computes=max_queue_size,
+        verify_pmix=True,
     )
 
     # This verifies that scaling worked


### PR DESCRIPTION
### Description of changes
* Add verify_pmix parameter to test_mpi so that num_computes is not a required parameter if `verify_pmix = false`

### Tests
* Ran test on personal jenkins:
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  scaling:
    test_mpi.py::test_mpi:  
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
```

### References
* Patch for: https://github.com/aws/aws-parallelcluster/pull/6184

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
