### PR TITLE
[Integ-tests] Don't check FSx in dynamic file system update test when FSx is not supported

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1187,13 +1187,17 @@ def test_dynamic_file_systems_update(
     scheduler_commands.assert_job_state(queue1_job_id, "RUNNING")
 
     # Check that the mounted storage is visible on all cluster nodes right after the update.
-    all_mount_dirs_update_1 = [
-        existing_efs_mount_dir,
-        existing_fsx_lustre_mount_dir,
-        existing_fsx_ontap_mount_dir,
-        existing_fsx_open_zfs_mount_dir,
-        existing_file_cache_mount_dir,
-    ]
+    all_mount_dirs_update_1 = (
+        [existing_efs_mount_dir]
+        + [
+            existing_fsx_lustre_mount_dir,
+            existing_fsx_ontap_mount_dir,
+            existing_fsx_open_zfs_mount_dir,
+            existing_file_cache_mount_dir,
+        ]
+        if fsx_supported
+        else []
+    )
     _test_shared_storages_mount_on_headnode(
         remote_command_executor,
         cluster,
@@ -1353,26 +1357,36 @@ def test_dynamic_file_systems_update(
         file_cache_path,
     )
 
-    all_mount_dirs_update_2 = [
-        new_ebs_mount_dir,
-        new_raid_mount_dir,
-        new_efs_mount_dir,
-        new_lustre_mount_dir,
-        existing_ebs_mount_dir,
-        existing_efs_mount_dir,
-        existing_fsx_lustre_mount_dir,
-        existing_fsx_ontap_mount_dir,
-        existing_fsx_open_zfs_mount_dir,
-        existing_file_cache_mount_dir,
-    ]
+    all_mount_dirs_update_2 = (
+        [
+            new_ebs_mount_dir,
+            new_raid_mount_dir,
+            new_efs_mount_dir,
+            new_lustre_mount_dir,
+            existing_ebs_mount_dir,
+            existing_efs_mount_dir,
+        ]
+        + [
+            existing_fsx_lustre_mount_dir,
+            existing_fsx_ontap_mount_dir,
+            existing_fsx_open_zfs_mount_dir,
+            existing_file_cache_mount_dir,
+        ]
+        if fsx_supported
+        else []
+    )
 
-    mount_dirs_requiring_replacement = [
-        new_ebs_mount_dir,
-        new_raid_mount_dir,
-        new_efs_mount_dir,
-        new_lustre_mount_dir,
-        existing_ebs_mount_dir,
-    ]
+    mount_dirs_requiring_replacement = (
+        [
+            new_ebs_mount_dir,
+            new_raid_mount_dir,
+            new_efs_mount_dir,
+            existing_ebs_mount_dir,
+        ]
+        + [new_lustre_mount_dir]
+        if fsx_supported
+        else []
+    )
 
     logging.info("Checking that previously mounted storage is visible on all compute nodes")
     for mount_dir in all_mount_dirs_update_1:


### PR DESCRIPTION
The logic has been done in other checks of the same test

### References
The previous fix was incomprehensive https://github.com/aws/aws-parallelcluster/pull/6191

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
