### PR TITLE
[Test] Add ec2:DeleteTags to the pcluster user role

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -362,6 +362,7 @@ Resources:
               - ec2:CreateSecurityGroup
               - ec2:CreateSnapshot
               - ec2:CreateTags
+              - ec2:DeleteTags
               - ec2:CreateVolume
               - ec2:DeleteLaunchTemplate
               - ec2:DeleteNetworkInterface

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -303,6 +303,7 @@ Resources:
               - ec2:CreateSecurityGroup
               - ec2:CreateSnapshot
               - ec2:CreateTags
+              - ec2:DeleteTags
               - ec2:CreateVolume
               - ec2:DeleteLaunchTemplate
               - ec2:DeleteNetworkInterface


### PR DESCRIPTION
### Description of changes
Add `ec2:DeleteTags` to the pcluster user role, required by the dynamic file systems updates.
The additional permissions is added to both the public cfn template of policies and to the role assumed by the test framework.

We started observing on Apr 6th that this additional permission started being required to update tags in the head node.
We are still investigating if this is an expected recent requirement from CFN and/or EC2.
In any case this change is required to unblock the DFSM test.

### Tests
* [ONGOING] DFSM integ test: still ongoing but already verified that adding the permissions is enough to unblock the update.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
