### PR TITLE
[Test] DFSM: add draining as a valid state for compute nodes marked for draining as part of an update.

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1329,10 +1329,10 @@ def test_dynamic_file_systems_update(
     logging.info("Checking the status of compute nodes in queue2")
     # All compute nodes in queue2 are expected to be in idle or drained
     # because they have not jobs running, hence we expect them to have been replaced (idle)
-    # or under replacement (drained).
+    # or under replacement (drained, draining).
     queue2_nodes = scheduler_commands.get_compute_nodes("queue2")
     assert_compute_node_states(
-        scheduler_commands, queue2_nodes, expected_states=["idle", "drained", "idle%", "drained*"]
+        scheduler_commands, queue2_nodes, expected_states=["idle", "drained", "idle%", "drained*", "draining"]
     )
 
     logging.info("Checking that shared storage is visible on the head node")


### PR DESCRIPTION
### Description of changes
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6204

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
