### PR TITLE
[Isolated] Using IAM instead of ACM

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -436,7 +436,7 @@ Resources:
                 echo "Registering user: $username"
                 echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain="${DirectoryDomain}" --display-name="$username" "$username"
               done
-              
+
               echo "Creating domain certificate..."
               PRIVATE_KEY="${DirectoryDomain}.key"
               CERTIFICATE="${DirectoryDomain}.crt"
@@ -705,9 +705,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - acm:ImportCertificate
-                  - acm:AddTagsToCertificate
-                Resource: !Sub arn:${AWS::Partition}:acm:${AWS::Region}:${AWS::AccountId}:certificate/*
+                  - iam:UploadServerCertificate
+                  - iam:TagServerCertificate
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:server-certificate/*
                 Condition:
                   StringEquals:
                     aws:RequestTag/StackId: !Sub ${AWS::StackId}
@@ -721,7 +721,7 @@ Resources:
   DomainCertificateSetupLambda:
     Type: AWS::Lambda::Function
     Properties:
-      Description: !Sub "${AWS::StackName}: custom resource handler to import the domain certificate into ACM."
+      Description: !Sub "${AWS::StackName}: custom resource handler to import the domain certificate into IAM."
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt DomainCertificateSetupLambdaRole.Arn
@@ -739,21 +739,24 @@ Resources:
           import string
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)
-          acm = boto3.client("acm")
+          iam = boto3.client("iam")
           sm = boto3.client("secretsmanager")
 
           def create_physical_resource_id():
               alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
               return ''.join(random.choice(alnum) for _ in range(16))
 
-          def import_certificate(certificate_secret_arn, private_key_secret_arn, tags):
+          def import_certificate(certificate_secret_arn, private_key_secret_arn, domain_name, tags):
             logger.info('Reading secrets from Secrets Manager...')
             domain_certificate = sm.get_secret_value(SecretId=certificate_secret_arn)["SecretString"]
             domain_private_key = sm.get_secret_value(SecretId=private_key_secret_arn)["SecretString"]
-            logger.info('Importing certificate into ACM...')
-            certificate_arn = acm.import_certificate(
-              Certificate=domain_certificate, PrivateKey=domain_private_key, Tags=tags
-            )["CertificateArn"]
+            logger.info('Importing certificate into IAM...')
+
+            certificate_arn = iam.upload_server_certificate(
+              ServerCertificateName=domain_name,
+              CertificateBody=domain_certificate,
+              PrivateKey=domain_private_key, Tags=tags
+            )["ServerCertificateMetadata"]["Arn"]
             return certificate_arn
 
           def handler(event, context):
@@ -774,9 +777,10 @@ Resources:
 
               try:
                 if event['RequestType'] == 'Create':
-                  certificate_arn = import_certificate(certificate_secret_arn, private_key_secret_arn, tags)
+                  certificate_arn = import_certificate(certificate_secret_arn, private_key_secret_arn, domain_name, tags)
+                  time.sleep(60)
                   response_data['DomainCertificateArn'] = certificate_arn
-                  response_data['Message'] = f"Resource creation successful! ACM certificate imported: {certificate_arn}"
+                  response_data['Message'] = f"Resource creation successful! IAM certificate imported: {certificate_arn}"
               except Exception as e:
                 response_status = cfnresponse.FAILED
                 reason = str(e)
@@ -823,7 +827,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - acm:DeleteCertificate
+                  - iam:DeleteServerCertificate
                 Resource: !GetAtt DomainCertificateSetup.DomainCertificateArn
 
   CleanupLambda:
@@ -847,22 +851,22 @@ Resources:
           import string
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)
-          acm = boto3.client("acm")
+          iam = boto3.client("iam")
 
           def create_physical_resource_id():
             alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
             return ''.join(random.choice(alnum) for _ in range(16))
 
           def delete_certificate(certificate_arn):
-            logger.info(f"Deleting ACM certificate {certificate_arn}...")
+            logger.info(f"Deleting iam certificate {certificate_arn}...")
             max_attempts = 10
             sleep_time = 60
             for attempt in range(1, max_attempts+1):
               try:
-                acm.delete_certificate(CertificateArn=certificate_arn)
+                iam.delete_server_certificate(CertificateArn=certificate_arn)
                 break
-              except acm.exceptions.ResourceInUseException as e:
-                logger.info(f"(Attempt {attempt}/{max_attempts}) Cannot delete ACM certificate because it is in use. Retrying in {sleep_time} seconds...")
+              except iam.exceptions.ResourceInUseException as e:
+                logger.info(f"(Attempt {attempt}/{max_attempts}) Cannot delete IAM certificate because it is in use. Retrying in {sleep_time} seconds...")
                 if attempt == max_attempts:
                   raise Exception(f"Cannot delete certificate {certificate_arn}: {e}")
                 else:


### PR DESCRIPTION
### Description of changes
* Using IAM instead of ACM for all the regions

### Tests
[ONGOING]
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  ad_integration:
    test_ad_integration.py::test_ad_integration:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "centos7" ]
          schedulers: [ "slurm" ]

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
