### PR TITLE
[integ-tests] Skip custom image test

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -192,11 +192,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
-    test_api.py::test_custom_image:
-      dimensions:
-        - regions: ["sa-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+# Skip because of https://github.com/aws/aws-parallelcluster/issues/5914
+#    test_api.py::test_custom_image:
+#      dimensions:
+#        - regions: ["sa-east-1"]
+#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#          oss: ["alinux2"]
     test_api.py::test_official_images:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
temporarily skip custom image test for released 3.9.0, until issue https://github.com/aws/aws-parallelcluster/issues/5914 get fixed

### References
* Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6167

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
