### PR TITLE
[Isolated] Adding DeleteConflictException Exception

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -857,13 +857,13 @@ Resources:
             alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
             return ''.join(random.choice(alnum) for _ in range(16))
 
-          def delete_certificate(certificate_arn):
+          def delete_certificate(domain_name, certificate_arn):
             logger.info(f"Deleting iam certificate {certificate_arn}...")
             max_attempts = 10
             sleep_time = 60
             for attempt in range(1, max_attempts+1):
               try:
-                iam.delete_server_certificate(CertificateArn=certificate_arn)
+                iam.delete_server_certificate(ServerCertificateName=domain_name)
                 break
               except iam.exceptions.DeleteConflictException as e:
                 logger.info(f"(Attempt {attempt}/{max_attempts}) Cannot delete IAM certificate because it is in use. Retrying in {sleep_time} seconds...")
@@ -886,7 +886,8 @@ Resources:
             try:
               if event['RequestType'] == 'Delete':
                 certificate_arn = event['ResourceProperties']['DomainCertificateArn']
-                delete_certificate(certificate_arn)
+                domain_name = event['ResourceProperties']['DomainName']
+                delete_certificate(domain_name, certificate_arn)
             except Exception as e:
               response_status = cfnresponse.FAILED
               reason = str(e)
@@ -898,6 +899,7 @@ Resources:
       - DomainCertificateSetup
     Properties:
       ServiceToken: !GetAtt CleanupLambda.Arn
+      DomainName: !Ref DomainName
       DomainCertificateArn: !GetAtt DomainCertificateSetup.DomainCertificateArn
 
   DomainCertificateSecretReadPolicy:

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -865,7 +865,7 @@ Resources:
               try:
                 iam.delete_server_certificate(CertificateArn=certificate_arn)
                 break
-              except iam.exceptions.ResourceInUseException as e:
+              except iam.exceptions.DeleteConflictException as e:
                 logger.info(f"(Attempt {attempt}/{max_attempts}) Cannot delete IAM certificate because it is in use. Retrying in {sleep_time} seconds...")
                 if attempt == max_attempts:
                   raise Exception(f"Cannot delete certificate {certificate_arn}: {e}")


### PR DESCRIPTION
### Description of changes
* ResourceInUse is not an Execption which exists in IAM. So replacing it with `DeleteConflictException`

### Tests
* `test_ad_integration`

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
