### PR TITLE
[external SlurmDBD] Add a validator, improve bucket name management

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -197,6 +197,7 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
+    ExternalSlurmdbdRequiresCustomMungeKey,
     ExternalSlurmdbdTrafficNotEncrypted,
     ExternalSlurmdbdVsDatabaseIncompatibility,
     SlurmNodePrioritiesWarningValidator,
@@ -2786,6 +2787,11 @@ class SlurmSettings(Resource):
             ExternalSlurmdbdVsDatabaseIncompatibility,
             database=self.database,
             external_slurmdbd=self.external_slurmdbd,
+        )
+        self._register_validator(
+            ExternalSlurmdbdRequiresCustomMungeKey,
+            external_slurmdbd=self.external_slurmdbd,
+            munge_key_secret_arn=self.munge_key_secret_arn,
         )
         self._register_validator(
             ExternalSlurmdbdTrafficNotEncrypted,

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -199,6 +199,17 @@ class ExternalSlurmdbdVsDatabaseIncompatibility(Validator):
             )
 
 
+class ExternalSlurmdbdRequiresCustomMungeKey(Validator):
+    """External Slurmdbd requires custom munge key."""
+
+    def _validate(self, external_slurmdbd, munge_key_secret_arn):
+        if (external_slurmdbd is not None) and (munge_key_secret_arn is None):
+            self._add_failure(
+                "When ExternalSlurmdbd is defined, MungeKeySecretArn is required.",
+                FailureLevel.ERROR,
+            )
+
+
 class ExternalSlurmdbdTrafficNotEncrypted(Validator):
     """Inform users about unencrypted connections."""
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -89,6 +89,7 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
+    ExternalSlurmdbdRequiresCustomMungeKey,
     ExternalSlurmdbdTrafficNotEncrypted,
     ExternalSlurmdbdVsDatabaseIncompatibility,
     SlurmNodePrioritiesWarningValidator,
@@ -378,6 +379,20 @@ def test_custom_slurm_settings_include_file_only_validator(
 )
 def test_external_slurmdbd_vs_database_incompatibility_validator(database, external_slurmdbd, expected_message):
     actual_failures = ExternalSlurmdbdVsDatabaseIncompatibility().execute(database, external_slurmdbd)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "external_slurmdbd, munge_key_secret_arn, expected_message",
+    [
+        pytest.param(None, None, None),
+        pytest.param(None, "arn", None),
+        pytest.param("external_slurmdbd", "arn", None),
+        pytest.param("external_slurmdbd", None, "When ExternalSlurmdbd is defined, MungeKeySecretArn is required."),
+    ],
+)
+def test_external_slurmdbd_requires_munge_key_validator(external_slurmdbd, munge_key_secret_arn, expected_message):
+    actual_failures = ExternalSlurmdbdRequiresCustomMungeKey().execute(external_slurmdbd, munge_key_secret_arn)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cloudformation/external-slurmdbd/external-slurmdbd.json
+++ b/cloudformation/external-slurmdbd/external-slurmdbd.json
@@ -222,24 +222,6 @@
   "ExternalSlurmdbdS3Bucket": {
    "Type": "AWS::S3::Bucket",
    "Properties": {
-    "BucketName": {
-     "Fn::Join": [
-      "",
-      [
-       {
-        "Ref": "AWS::StackName"
-       },
-       "-",
-       {
-        "Ref": "AWS::AccountId"
-       },
-       "-",
-       {
-        "Ref": "AWS::Region"
-       }
-      ]
-     ]
-    },
     "PublicAccessBlockConfiguration": {
      "BlockPublicAcls": true,
      "BlockPublicPolicy": true,
@@ -511,15 +493,7 @@
            },
            "\", \"slurmdbd_conf_bucket\": \"",
            {
-            "Ref": "AWS::StackName"
-           },
-           "-",
-           {
-            "Ref": "AWS::AccountId"
-           },
-           "-",
-           {
-            "Ref": "AWS::Region"
+            "Ref": "ExternalSlurmdbdS3Bucket"
            },
            "\", \"cluster\": {\"region\": \"",
            {
@@ -608,22 +582,7 @@
   "SlurmdbdConfigS3BucketName": {
    "Description": "S3 Bucket where a copy of the slurmdbd configuration files can be stored and re-used when re-provisioning the slurmdbd instance",
    "Value": {
-    "Fn::Join": [
-     "",
-     [
-      {
-       "Ref": "AWS::StackName"
-      },
-      "-",
-      {
-       "Ref": "AWS::AccountId"
-      },
-      "-",
-      {
-       "Ref": "AWS::Region"
-      }
-     ]
-    ]
+    "Ref": "ExternalSlurmdbdS3Bucket"
    }
   }
  }

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -117,7 +117,7 @@ class ExternalSlurmdbdStack(Stack):
             "dbms_database_name": self.dbms_database_name.value_as_string,
             "dbms_password_secret_arn": self.dbms_password_secret_arn.value_as_string,
             "munge_key_secret_arn": self.munge_key_secret_arn.value_as_string,
-            "slurmdbd_conf_bucket": self.s3_bucket.bucket_name,
+            "slurmdbd_conf_bucket": self.s3_bucket.ref,
             "cluster": {
                 "region": self.region,
                 "log_group_name": self._log_group.log_group_name,
@@ -419,7 +419,6 @@ class ExternalSlurmdbdStack(Stack):
         return s3.CfnBucket(
             self,
             id="ExternalSlurmdbdS3Bucket",
-            bucket_name=Aws.STACK_NAME + "-" + Aws.ACCOUNT_ID + "-" + Aws.REGION,
             public_access_block_configuration=s3.CfnBucket.PublicAccessBlockConfigurationProperty(
                 block_public_acls=True,
                 block_public_policy=True,
@@ -486,5 +485,5 @@ class ExternalSlurmdbdStack(Stack):
             "SlurmdbdConfigS3BucketName",
             description="S3 Bucket where a copy of the slurmdbd configuration files can be stored and re-used when "
             "re-provisioning the slurmdbd instance",
-            value=self.s3_bucket.bucket_name,
+            value=self.s3_bucket.ref,
         )


### PR DESCRIPTION
### Description
See commits descriptions for details

### Tests
The follow test has been passed
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting_external_dbd:
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
