### PR TITLE
Change instance types to support arm architecture

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
@@ -18,10 +18,10 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: t3.xlarge
+            - InstanceType: {{ instance }}
         - Name: compute-resource-1
           Instances:
-            - InstanceType: m5.xlarge
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
@@ -29,10 +29,10 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: t3.xlarge
+            - InstanceType: {{ instance }}
         - Name: ice-cr-multiple
           Instances:
-            - InstanceType: m5.xlarge
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
* Change instance types to support arm architecture for test_job_level_scaling

### Tests
* Ran integration test on personal Jenkins with the following config:
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  scaling:
    test_scaling.py::test_job_level_scaling:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: ["slurm"]
```

### References
* Patch for: https://github.com/aws/aws-parallelcluster/pull/6205

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
