### PR TITLE
[Integ-tests] Fix CloudWatch test failed because of change for external Slurm dbd

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -103,8 +103,18 @@ class CloudWatchLoggingClusterState:
         self.scheduler_commands = get_scheduler_commands(
             scheduler=self.scheduler, remote_command_executor=self.remote_command_executor
         )
-        self._relevant_logs = {HEAD_NODE_ROLE_NAME: [], COMPUTE_NODE_ROLE_NAME: [], LOGIN_NODE_ROLE_NAME: []}
-        self._cluster_log_state = {HEAD_NODE_ROLE_NAME: {}, COMPUTE_NODE_ROLE_NAME: {}, LOGIN_NODE_ROLE_NAME: []}
+        self._relevant_logs = {
+            HEAD_NODE_ROLE_NAME: [],
+            COMPUTE_NODE_ROLE_NAME: [],
+            LOGIN_NODE_ROLE_NAME: [],
+            EXTERNAL_SLURM_DBD_ROLE_NAME: [],
+        }
+        self._cluster_log_state = {
+            HEAD_NODE_ROLE_NAME: {},
+            COMPUTE_NODE_ROLE_NAME: {},
+            LOGIN_NODE_ROLE_NAME: [],
+            EXTERNAL_SLURM_DBD_ROLE_NAME: [],
+        }
         self._set_cluster_log_state()
 
     @property


### PR DESCRIPTION
### Tests
* `test_cloudwatch_logging` has passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
