### PR TITLE
[slurmdbd] Disable Slurmdbd service by default and add a CFN parameter to enable it and enable CloudWatch logs

### DIFF
--- a/cloudformation/external-slurmdbd/external-slurmdbd.json
+++ b/cloudformation/external-slurmdbd/external-slurmdbd.json
@@ -507,7 +507,7 @@
            {
             "Ref": "AWS::StackName"
            },
-           "\", \"node_type\": \"ExternalSlurmDbd\"}}"
+           "\", \"node_type\": \"ExternalSlurmDbd\", \"cw_logging_enabled\": \"true\"}}"
           ]
          ]
         },

--- a/cloudformation/external-slurmdbd/external-slurmdbd.json
+++ b/cloudformation/external-slurmdbd/external-slurmdbd.json
@@ -33,6 +33,15 @@
    "Default": "",
    "Description": "URL of the custom Chef Cookbook."
   },
+  "EnableSlurmdbdSystemService": {
+   "Type": "String",
+   "Default": "false",
+   "AllowedValues": [
+    "true",
+    "false"
+   ],
+   "Description": "[Warning] It is not recommended to enable this if the Database was created by a different version of SlurmDBD. If the database contains a large number of entries, the SlurmDBD daemon may require tens of minutes to update the database and be unresponsive during this time interval. Before upgrading SlurmDBD it is strongly recommended to make a backup of the database.See Slurm documentation for details: https://slurm.schedmd.com/quickstart_admin.html#upgrade"
+  },
   "SlurmdbdPort": {
    "Type": "Number",
    "Default": 6819,
@@ -507,7 +516,11 @@
            {
             "Ref": "AWS::StackName"
            },
-           "\", \"node_type\": \"ExternalSlurmDbd\", \"cw_logging_enabled\": \"true\"}}"
+           "\", \"node_type\": \"ExternalSlurmDbd\", \"cw_logging_enabled\": \"true\", \"slurmdbd_service_enabled\": \"",
+           {
+            "Ref": "EnableSlurmdbdSystemService"
+           },
+           "\"}}"
           ]
          ]
         },

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -67,6 +67,18 @@ class ExternalSlurmdbdStack(Stack):
         self.custom_cookbook_url_param = CfnParameter(
             self, "CustomCookbookUrl", type="String", description="URL of the custom Chef Cookbook.", default=""
         )
+        self.enable_slurm_dbd_system_service = CfnParameter(
+            self,
+            "EnableSlurmdbdSystemService",
+            type="String",
+            allowed_values=["true", "false"],
+            description="[Warning] It is not recommended to enable this if the database was created by a different "
+            "version of SlurmDBD. If the database contains a large number of entries, the SlurmDBD daemon may require "
+            "tens of minutes to update the database and be unresponsive during this time interval. "
+            "Before upgrading SlurmDBD it is strongly recommended to make a backup of the database."
+            "See Slurm documentation for details: https://slurm.schedmd.com/quickstart_admin.html#upgrade",
+            default="false",
+        )
 
         # create management security group with SSH access from SSH client SG
         self._ssh_server_sg, self._ssh_client_sg = self._add_management_security_groups()
@@ -124,6 +136,7 @@ class ExternalSlurmdbdStack(Stack):
                 "stack_name": Aws.STACK_NAME,
                 "node_type": "ExternalSlurmDbd",
                 "cw_logging_enabled": "true",
+                "slurmdbd_service_enabled": self.enable_slurm_dbd_system_service.value_as_string,
             },
         }
 

--- a/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
+++ b/cloudformation/external-slurmdbd/external_slurmdbd/external_slurmdbd_stack.py
@@ -123,6 +123,7 @@ class ExternalSlurmdbdStack(Stack):
                 "log_group_name": self._log_group.log_group_name,
                 "stack_name": Aws.STACK_NAME,
                 "node_type": "ExternalSlurmDbd",
+                "cw_logging_enabled": "true",
             },
         }
 

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -207,6 +207,7 @@ def slurm_dbd(request, database, region, os, vpc_stack_for_database, munge_key):
                 {"ParameterKey": "SubnetId", "ParameterValue": subnet_id},
                 {"ParameterKey": "SlurmdbdPort", "ParameterValue": "6819"},
                 {"ParameterKey": "VPCId", "ParameterValue": vpc_id},
+                {"ParameterKey": "EnableSlurmdbdSystemService", "ParameterValue": "true"},
             ]
             custom_cookbook_url = request.config.getoption("custom_chef_cookbook")
             if custom_cookbook_url:


### PR DESCRIPTION
### Description of changes
See commits descriptions for details

### Tests
`test_slurm_accounting_external_dbd` has passed

### References
* Cookbook PR https://github.com/aws/aws-parallelcluster-cookbook/pull/2717

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
