### PR TITLE
Test internal efs on arm and x86

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -688,7 +688,7 @@ test-suites:
     test_internal_efs.py::test_internal_efs:
       dimensions:
         - regions: [ "us-west-2" ]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          instances: {{ common.INSTANCES_DEFAULT }}
           oss: [ "ubuntu2204" ]
           schedulers: [ "slurm" ]
     test_shared_home.py::test_shared_home:

--- a/tests/integration-tests/tests/storage/test_internal_efs.py
+++ b/tests/integration-tests/tests/storage/test_internal_efs.py
@@ -23,11 +23,14 @@ from tests.storage.storage_common import (
 
 @pytest.mark.usefixtures("os", "scheduler", "instance")
 def test_internal_efs(
-    region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory
+    region, scheduler, pcluster_config_reader, architecture, clusters_factory, vpc_stack, scheduler_commands_factory
 ):
     """Verify the internal shared storage fs is available when set to Efs"""
-    compute_shared_dirs = ["/opt/parallelcluster/shared", "/opt/slurm", "/opt/intel", "/home"]
-    login_shared_dirs = ["/opt/parallelcluster/shared_login_nodes", "/opt/slurm", "/opt/intel", "/home"]
+    compute_shared_dirs = ["/opt/parallelcluster/shared", "/opt/slurm", "/home"]
+    login_shared_dirs = ["/opt/parallelcluster/shared_login_nodes", "/opt/slurm", "/home"]
+    if architecture == "x86_64":
+        compute_shared_dirs.append("/opt/intel")
+        login_shared_dirs.append("/opt/intel")
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)


### PR DESCRIPTION

### Tests
* Ran updated integration tests, `test_internal_efs`, on both x86 and arm instance types.  The integ test now includes both and arm and an intel instance type

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
