### PR TITLE
Print warning to stdout

### DIFF
--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -64,10 +64,11 @@ def _dcv_connect(args):
 
         try:
             url = _retry(_retrieve_dcv_session_url, func_args=[cmd, args.cluster_name, head_node_ip], attempts=4)
-            url_message = f"Please use the following one-time URL in your browser within 30 seconds:\n{url}"
+            url_message = f"Please use the following one-time URL in your browser within 30 seconds:"
 
             if args.show_url:
-                print(url_message)
+                print(url_message, file=sys.stderr)
+                print(f"{url}")
                 return
 
             try:

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -73,8 +73,10 @@ def _test_dcv_configuration(
         # remove ssh key from jenkins user known hosts file
         remove_keys_from_known_hosts(cluster.head_node_ip, host_keys_file, env=env)
 
-    assert_that(result.stdout).matches(
+    assert_that(result.stderr).matches(
         r"Please use the following one-time URL in your browser within 30 seconds:\n"
+    )
+    assert_that(result.stdout).matches(
         r"https:\/\/(\b(?:\d{1,3}\.){3}\d{1,3}\b):" + str(dcv_port) + r"\?authToken=(.*)"
     )
     if access_from == "0.0.0.0/0":


### PR DESCRIPTION
### Description of changes
* This enables the use of `pcluster dcv-connect -n <cluster> | pbcopy` to copy the url directly into macOS paste buffer.
