### PR TITLE
[Tags] Prevent duplicate tags in root volume of the head node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Consider Compute fleet clean-up completed during cluster deletion when instances are either in shutting-down or terminated state.
   This is to avoid cluster deletion failure for instance types with longer termination cycles.
 - Allow cloudwatch dashboard to be enabled and alarms to be disabled in the `Monitoring` section of the cluster config.
+- Fix a bug causing duplicated tags in the head node launch template.
 
 **CHANGES**
 - Upgrade Cinc Client to version to 18.4.12 from 18.2.7.

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -87,6 +87,7 @@ from pcluster.templates.cdk_builder_utils import (
     apply_permissions_boundary,
     convert_deletion_policy,
     create_hash_suffix,
+    dict_to_cfn_tags,
     get_cloud_watch_logs_policy_statement,
     get_cloud_watch_logs_retention_days,
     get_common_user_data_env,
@@ -1240,7 +1241,12 @@ class ClusterCdkStack:
                 tag_specifications=[
                     ec2.CfnLaunchTemplate.TagSpecificationProperty(
                         resource_type="volume",
-                        tags=get_default_volume_tags(self._stack_name, "HeadNode") + get_custom_tags(self.config),
+                        tags=dict_to_cfn_tags(
+                            {
+                                **get_default_volume_tags(self._stack_name, "HeadNode", raw_dict=True),
+                                **get_custom_tags(self.config, raw_dict=True),
+                            }
+                        ),
                     ),
                 ],
             ),


### PR DESCRIPTION
### Description of changes
Prevent duplicated tags in the head node launch template.

*Why there were duplicates?*
Because get_custom_tags() returns custom tags and a subset of default tags.
The long term fix would be to fix get_custom_tags() but since it is extensively used, this would imply a refactoring with a low ROI at the moment.

### Tests
* Create a cluster with this change and verified that the tag parallelcluster:cluster-name is not duplicated in the head node root volume (it used to be before this change).

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
