### PR TITLE
[Test] Add option 'bucket-name' to optionally reuse an existing bucket in tests.

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -44,6 +44,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
                       [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
                       [--no-delete] [--retain-ad-stack] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
+                      [--bucket-name BUCKET_NAME]
 
 Run integration tests suite.
 
@@ -173,6 +174,8 @@ Debugging/Development options:
                         Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
   --external-shared-storage-stack-name
                         Name of an existing external shared storage stack. (default: None)
+  --bucket-name
+                        Name of an existing bucket. (default: None)
 ```
 
 Here is an example of tests submission:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -192,6 +192,7 @@ def pytest_addoption(parser):
         help="ARN of the secret containing the munge key to be used for testing Slurm accounting feature.",
     )
     parser.addoption("--external-shared-storage-stack-name", help="Name of existing external shared storage stack.")
+    parser.addoption("--bucket-name", help="Name of existing bucket.")
     parser.addoption("--custom-security-groups-stack-name", help="Name of existing custom security groups stack.")
     parser.addoption(
         "--force-run-instances",
@@ -1004,10 +1005,15 @@ def s3_bucket_factory(request, region):
     created_buckets = []
 
     def _create_bucket():
-        bucket_name = "integ-tests-" + random_alphanumeric()
-        logging.info("Creating S3 bucket {0}".format(bucket_name))
-        create_s3_bucket(bucket_name, region)
-        created_buckets.append((bucket_name, region))
+        option = "bucket_name"
+        if request.config.getoption(option):
+            bucket_name = request.config.getoption(option)
+            logging.info("Using existing S3 bucket {0}".format(bucket_name))
+        else:
+            bucket_name = "integ-tests-" + random_alphanumeric()
+            logging.info("Creating S3 bucket {0}".format(bucket_name))
+            create_s3_bucket(bucket_name, region)
+            created_buckets.append((bucket_name, region))
         return bucket_name
 
     yield _create_bucket
@@ -1033,10 +1039,15 @@ def s3_bucket_factory_shared(request):
     created_buckets = []
 
     def _create_bucket(region):
-        bucket_name = "integ-tests-" + random_alphanumeric()
-        logging.info("Creating S3 bucket {0}".format(bucket_name))
-        create_s3_bucket(bucket_name, region)
-        created_buckets.append((bucket_name, region))
+        option = "bucket_name"
+        if request.config.getoption(option):
+            bucket_name = request.config.getoption(option)
+            logging.info("Using existing S3 bucket {0}".format(bucket_name))
+        else:
+            bucket_name = "integ-tests-" + random_alphanumeric()
+            logging.info("Creating S3 bucket {0}".format(bucket_name))
+            create_s3_bucket(bucket_name, region)
+            created_buckets.append((bucket_name, region))
         return bucket_name
 
     regions = request.config.getoption("regions") or get_all_regions(request.config.getoption("tests_config"))

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -89,6 +89,7 @@ TEST_DEFAULTS = {
     "slurm_dbd_stack_name": None,
     "munge_key_secret_arn": None,
     "external_shared_storage_stack_name": None,
+    "bucket_name": None,
     "custom_security_groups_stack_name": None,
     "cluster_custom_resource_service_token": None,
     "resource_bucket": None,
@@ -419,6 +420,11 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("external_shared_storage_stack_name"),
     )
     debug_group.add_argument(
+        "--bucket-name",
+        help="Name of existing bucket.",
+        default=TEST_DEFAULTS.get("bucket_name"),
+    )
+    debug_group.add_argument(
         "--custom-security-groups-stack-name",
         help="Name of existing custom security groups stack.",
         default=TEST_DEFAULTS.get("custom_security_groups_stack_name"),
@@ -654,6 +660,9 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.external_shared_storage_stack_name:
         pytest_args.extend(["--external-shared-storage-stack-name", args.external_shared_storage_stack_name])
+
+    if args.bucket_name:
+        pytest_args.extend(["--bucket-name", args.bucket_name])
 
     if args.retain_ad_stack:
         pytest_args.append("--retain-ad-stack")


### PR DESCRIPTION
### Description of changes
Add option 'bucket-name' to optionally reuse an existing bucket in tests.
This option is useful in those tests where we want to reuse an existing infrasdtructure that depends on a bucket created in previous run, .e.g DFSM integ test.

### Tests
* Used the option to make DFSM integ test reuse an existing bucket.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
