### PR TITLE
[Integ-tests] Use default factory for data classes

### DIFF
--- a/tests/integration-tests/framework/metadata_table_manager.py
+++ b/tests/integration-tests/framework/metadata_table_manager.py
@@ -8,7 +8,7 @@
 
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 import boto3
@@ -35,9 +35,9 @@ class TestMetadata:
     os: str = ""
     feature: str = ""
     instance_type: str = ""
-    setup_metadata: PhaseMetadata = PhaseMetadata(name="setup")
-    call_metadata: PhaseMetadata = PhaseMetadata(name="call")
-    teardown_metadata: PhaseMetadata = PhaseMetadata(name="teardown")
+    setup_metadata: PhaseMetadata = field(default_factory=lambda: PhaseMetadata(name="setup"))
+    call_metadata: PhaseMetadata = field(default_factory=lambda: PhaseMetadata(name="call"))
+    teardown_metadata: PhaseMetadata = field(default_factory=lambda: PhaseMetadata(name="teardown"))
     cli_commit: str = ""
     cookbook_commit: str = ""
     node_commit: str = ""


### PR DESCRIPTION
Integration tests with Python 3.11 produced the following error:
```
ValueError: mutable default <class 'framework.metadata_table_manager.PhaseMetadata'> for field setup_metadata is not allowed: use default_factory
```

This commit is also tested with Python 3.9

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
