### PR TITLE
[Test] Allow custom OSes in test config for isolated regions.

### DIFF
--- a/awsbatch-cli/src/awsbatch/awsbstat.py
+++ b/awsbatch-cli/src/awsbatch/awsbstat.py
@@ -296,7 +296,7 @@ class AWSBstatCommand:
             fail("Error listing jobs from AWS Batch. job_ids or job_queue must be defined")
 
         sort_keys_function = self.__sort_by_status_startedat_jobid() if not job_ids else self.__sort_by_key(job_ids)
-        if details_required:
+        if details_required:  # pylint: disable=E0606
             self.output.show(sort_keys_function=sort_keys_function)
         else:
             self.output.show_table(

--- a/awsbatch-cli/src/awsbatch/awsbsub.py
+++ b/awsbatch-cli/src/awsbatch/awsbsub.py
@@ -245,7 +245,7 @@ def _upload_and_get_command(boto3_factory, args, job_s3_folder, job_name, config
         command = [args.command] + args.arguments
     else:
         fail("Unexpected error. Command cannot be empty.")
-    log.info("Command: %s" % shell_join(command))
+    log.info("Command: %s" % shell_join(command))  # pylint: disable=E0606
     return command
 
 

--- a/cli/src/pcluster/aws/common.py
+++ b/cli/src/pcluster/aws/common.py
@@ -155,7 +155,7 @@ class Boto3Client:
         """
         paginator = self._client.get_paginator(method.__name__)
         for page in paginator.paginate(**kwargs).result_key_iters():
-            for result in page:
+            for result in page:  # pylint: disable=R1737
                 yield result
 
 

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -117,7 +117,10 @@ def _retrieve_dcv_session_url(ssh_cmd, cluster_name, head_node_ip):
             raise DCVConnectionError(e.output)
 
     return "https://{IP}:{PORT}?authToken={TOKEN}#{SESSION_ID}".format(
-        IP=head_node_ip, PORT=dcv_server_port, TOKEN=dcv_session_token, SESSION_ID=dcv_session_id
+        IP=head_node_ip,
+        PORT=dcv_server_port,  # pylint: disable=E0606
+        TOKEN=dcv_session_token,  # pylint: disable=E0606
+        SESSION_ID=dcv_session_id,  # pylint: disable=E0606
     )
 
 

--- a/cli/src/pcluster/cli/model.py
+++ b/cli/src/pcluster/cli/model.py
@@ -88,7 +88,7 @@ def _resolve_body(spec, operation):
 
 def package_spec():
     """Load the OpenAPI specification from the package."""
-    with pkg_resources.open_text(openapi, "openapi.yaml") as spec_file:
+    with pkg_resources.open_text(openapi, "openapi.yaml") as spec_file:  # pylint: disable=W4902
         return yaml_load(spec_file.read())
 
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2276,7 +2276,7 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
             for instance_type in self.instance_types[1:]:
                 instance_type_info = self.instance_type_info_map[instance_type]
                 max_nics = instance_type_info.max_network_interface_count()
-                if max_nics < least_max_nics:
+                if max_nics < least_max_nics:  # pylint: disable=R1730
                     least_max_nics = max_nics
         return least_max_nics
 

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -92,7 +92,11 @@ class PasswordSecretArnValidator(Validator):
                 resource_type = resource.split("/")[0]
             if service == "secretsmanager" and resource == "secret":
                 AWSApi.instance().secretsmanager.describe_secret(password_secret_arn)
-            elif service == "ssm" and resource_type == "parameter" and region == "us-isob-east-1":
+            elif (
+                service == "ssm"
+                and resource_type == "parameter"  # pylint: disable=E0606
+                and region == "us-isob-east-1"
+            ):
                 parameter_name = resource.split("/")[1]
                 AWSApi.instance().ssm.get_parameter(parameter_name)
             else:

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -5,7 +5,11 @@
 {%- set REGIONS = ["us-isob-east-1","us-iso-east-1"] -%}
 {% endif %}
 {%- set INSTANCES = ["c5.xlarge"] -%}
+{% if OSS  %}
+{%- set OSS = [ OSS ] -%}
+{% else %}
 {%- set OSS = ["alinux2"] -%}
+{% endif %}
 {%- set SCHEDULERS = ["slurm"] -%}
 ---
 test-suites:


### PR DESCRIPTION
### Description of changes
Allow custom OSes in test config for isolated regions.
This change is required to unblock RHEL8 testing in US isolated regions.
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6244


Also disabled some pylint rules because linter would block the PR otherwise ands we do not want to invest in code style in a release branch of an old release.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
