### PR TITLE
[integ-tests] Fix integration tests in opt-in regions

### DIFF
--- a/tests/integration-tests/framework/credential_providers.py
+++ b/tests/integration-tests/framework/credential_providers.py
@@ -105,7 +105,13 @@ def _retrieve_sts_credential(region, credential_arn, sts, credential_external_id
     if credential_external_id:
         assume_role_kwargs["ExternalId"] = credential_external_id
 
-    assumed_role_object = sts.assume_role(**assume_role_kwargs)
+    try:
+        assumed_role_object = sts.assume_role(**assume_role_kwargs)
+    except Exception:
+        # Roles assumed by role chaining have 1-hour session limit.
+        # This exception handling block retries with default session duration.
+        assume_role_kwargs.pop("DurationSeconds", None)
+        assumed_role_object = sts.assume_role(**assume_role_kwargs)
     aws_credentials = assumed_role_object["Credentials"]
 
     return aws_credentials


### PR DESCRIPTION
After https://github.com/aws/aws-parallelcluster/commit/fc7d9baaba8683bbac7fb49be56ea1ce3fee27eb, integration tests in opt-in regions started to fail, because role chaining is used when assume roles in opt-in regions. Adding a retry blcok allows long-running tests to finish in default regions and tests shorter than 1 hour in opt-in regions.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
