### PR TITLE
[Test] Add FSxLustre integration tests for us-iso-east-1.

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -451,6 +451,49 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+    # FSxLustre is supported only in us-iso-east-1
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_fsx_lustre_dra:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_file_cache:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_multiple_fsx:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_multi_az_fsx:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_fsx_lustre_configuration_options:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_fsx_lustre.py::test_fsx_lustre_backup:
+      dimensions:
+        - regions: ["us-iso-east-1"]
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
   tags:
     test_tag_propagation.py::test_tag_propagation:
       dimensions:


### PR DESCRIPTION
### Description of changes
Add FSxLustre integration tests for us-iso-east-1.
The list of tests has been taken from the develop config.

### Tests
* None: the config will be used directly in us-iso-east-1.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
