### PR TITLE
Pin setuptools version to be less than 70.0.0

### DIFF
--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -22,7 +22,7 @@ def readme():
 
 VERSION = "1.3.0"
 REQUIRES = [
-    "setuptools",
+    "setuptools<70.0.0",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
 ]

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -23,7 +23,7 @@ def readme():
 VERSION = "3.9.1"
 CDK_VERSION = "1.164"
 REQUIRES = [
-    "setuptools",
+    "setuptools<70.0.0",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
     "PyYAML>=5.3.1,!=5.4",


### PR DESCRIPTION
The [setuptools 70.0.0](https://pypi.org/project/setuptools/#history) release broke unit tests with Python 3.12. For example: https://github.com/aws/aws-parallelcluster/actions/runs/9196405216/job/25294425565?pr=6250)

The same failure has been encountered by others. For example, https://github.com/vllm-project/vllm/issues/4961

### References
* Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6251

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
