### PR TITLE
[Test] Adapt the check of logrotate status in 'test_log_rotation' to support all OSes.

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation.py
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation.py
@@ -266,12 +266,12 @@ def _test_logs_are_rotated(os, logs, remote_command_executor, before_log_rotatio
     # force log rotate without waiting for logs to reach certain size
     _run_command_on_node(remote_command_executor, "sudo logrotate -f /etc/logrotate.conf", compute_node_ip)
     # check if logs are rotated
-    if os in ["alinux2", "centos7"]:
+    if "ubuntu" in os:
+        result = _run_command_on_node(remote_command_executor, "cat /var/lib/logrotate/status", compute_node_ip)
+    else:
         result = _run_command_on_node(
             remote_command_executor, "cat /var/lib/logrotate/logrotate.status", compute_node_ip
         )
-    else:
-        result = _run_command_on_node(remote_command_executor, "cat /var/lib/logrotate/status", compute_node_ip)
     for log in logs:
         assert_that(result).contains(log.get("log_path"))
         if log.get("existence"):


### PR DESCRIPTION
### Description of changes
[Test] Adapt the check of logrotate status in 'test_log_rotation' to support all OSes.
The same change is already part of develop, we are backporting it here because we are working on supporting RHEL8 in US Isolated regions, so we must adapt the tests to cover RHEL8.

### Tests
* Tested `test:_log_rotation` succeeded with RHEL8

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
