### PR TITLE
[Test] Replace t2.micro with t3.small in test_update_slurm and test_scontrol_reboot 

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -829,7 +829,7 @@ def test_scontrol_reboot(
     )
     wait_for_compute_nodes_states(
         slurm_commands,
-        ["queue1-dy-t2micro-1", "queue1-dy-t2micro-2"],
+        ["queue1-dy-cr1-1", "queue1-dy-cr1-2"],
         "idle",
         stop_max_delay_secs=330,
     )
@@ -860,7 +860,7 @@ def test_scontrol_reboot(
     _test_scontrol_reboot_powerdown_reboot_requested_node(
         remote_command_executor,
         slurm_commands,
-        "queue1-st-t2micro-1",
+        "queue1-st-cr1-1",
     )
 
     # Clear clustermgtd logs produced in previous tests
@@ -870,7 +870,7 @@ def test_scontrol_reboot(
     _test_scontrol_reboot_powerdown_reboot_issued_node(
         remote_command_executor,
         slurm_commands,
-        "queue1-st-t2micro-2",
+        "queue1-st-cr1-2",
     )
 
 

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
@@ -14,8 +14,8 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:
-        - Name: t2micro
+        - Name: cr1
           Instances:
-            - InstanceType: t2.micro
+            - InstanceType: t3.small
           MinCount: 2
           MaxCount: 4

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -50,7 +50,7 @@ Scheduling:
           MaxCount: 2
         - Name: queue1-i2
           Instances:
-            - InstanceType: t2.micro
+            - InstanceType: t3.small
           MinCount: 1
       Networking:
         SubnetIds:


### PR DESCRIPTION
### Description of changes
Replace t2.micro with t3.small in test_update_slurm and test_scontrol_reboot.
Using t2.micro causes cluster creation failures in US ISO regions, whereas t3.small does not.

### Tests
* Validate in US ISO regions.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
