### PR TITLE
Run log_rotation integ test on Amazon Linux 2

### DIFF
--- a/awsbatch-cli/src/awsbatch/awsbstat.py
+++ b/awsbatch-cli/src/awsbatch/awsbstat.py
@@ -296,7 +296,7 @@ class AWSBstatCommand:
             fail("Error listing jobs from AWS Batch. job_ids or job_queue must be defined")
 
         sort_keys_function = self.__sort_by_status_startedat_jobid() if not job_ids else self.__sort_by_key(job_ids)
-        if details_required:
+        if details_required:  # pylint: disable=E0606
             self.output.show(sort_keys_function=sort_keys_function)
         else:
             self.output.show_table(

--- a/awsbatch-cli/src/awsbatch/awsbsub.py
+++ b/awsbatch-cli/src/awsbatch/awsbsub.py
@@ -245,7 +245,7 @@ def _upload_and_get_command(boto3_factory, args, job_s3_folder, job_name, config
         command = [args.command] + args.arguments
     else:
         fail("Unexpected error. Command cannot be empty.")
-    log.info("Command: %s" % shell_join(command))
+    log.info("Command: %s" % shell_join(command))  # pylint: disable=E0606
     return command
 
 

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -117,7 +117,10 @@ def _retrieve_dcv_session_url(ssh_cmd, cluster_name, head_node_ip):
             raise DCVConnectionError(e.output)
 
     return "https://{IP}:{PORT}?authToken={TOKEN}#{SESSION_ID}".format(
-        IP=head_node_ip, PORT=dcv_server_port, TOKEN=dcv_session_token, SESSION_ID=dcv_session_id
+        IP=head_node_ip,
+        PORT=dcv_server_port,  # pylint: disable=E0606
+        TOKEN=dcv_session_token,  # pylint: disable=E0606
+        SESSION_ID=dcv_session_id,  # pylint: disable=E0606
     )
 
 

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -92,7 +92,11 @@ class PasswordSecretArnValidator(Validator):
                 resource_type = resource.split("/")[0]
             if service == "secretsmanager" and resource == "secret":
                 AWSApi.instance().secretsmanager.describe_secret(password_secret_arn)
-            elif service == "ssm" and resource_type == "parameter" and region == "us-isob-east-1":
+            elif (
+                service == "ssm"
+                and resource_type == "parameter"  # pylint: disable=E0606
+                and region == "us-isob-east-1"
+            ):
                 parameter_name = resource.split("/")[1]
                 AWSApi.instance().ssm.get_parameter(parameter_name)
             else:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -148,7 +148,7 @@ test-suites:
       dimensions:
         - regions: ["il-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   monitoring:
     test_monitoring.py::test_monitoring:


### PR DESCRIPTION
### Description of changes
* Ubuntu started shipping a default logrotate configuration for cloud-init log files, which clashes with the one coming from ParallelCluster.
* Run this test on Amazon Linux 2 until the issue is fixed on the cookbook.

### Tests
* Trivial change. To be tested directly in the integration tests.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
