### PR TITLE
Add the global_build_number parameter to the test runs

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -205,6 +205,11 @@ def pytest_addoption(parser):
         help="Force the usage of Elastic IP for Multi network interface EC2 instances.",
         action="store_true",
     )
+    parser.addoption(
+        "--global-build-number",
+        help="The build number passed from the testing pipelines",
+        default=0,
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integration-tests/conftest_runtest_hooks.py
+++ b/tests/integration-tests/conftest_runtest_hooks.py
@@ -44,8 +44,6 @@ def pytest_runtest_logfinish(nodeid: str, location: Tuple[str, Optional[int], st
 def pytest_runtest_logreport(report: pytest.TestReport):
     logging.info(f"Starting log report for test {report.nodeid}")
     # Set the approximate start time for the test
-    logging.info(f"Report keys {list(report.keywords)}")
-    logging.info(f"Report props {list(report.user_properties)}")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -91,7 +89,6 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
         except Exception as e:
             logging.error("Failed when generating config for failed tests: %s", e, exc_info=True)
     # Set the approximate start time for the test
-    logging.info(f"Report keys {list(item.keywords)}")
     try:
         publish_test_metrics(item, rep)
         publish_test_metadata(item, rep)

--- a/tests/integration-tests/conftest_utils.py
+++ b/tests/integration-tests/conftest_utils.py
@@ -180,6 +180,7 @@ def publish_test_metadata(item: pytest.Item, rep: pytest.TestReport):
             os=get_user_prop(item, "os"),
             feature=get_user_prop(item, "feature"),
             instance_type=get_user_prop(item, "instance"),
+            global_build_number=item.config.getoption("--global-build-number"),
             setup_metadata=PhaseMetadata(
                 rep.when,
                 status=rep.outcome,

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -97,6 +97,7 @@ TEST_DEFAULTS = {
     "force_run_instances": False,
     "force_elastic_ip": False,
     "retain_ad_stack": False,
+    "global_build_number": 0,
 }
 
 
@@ -143,6 +144,11 @@ def _init_argparser():
         "--tests-root-dir",
         help="Root dir where integration tests are defined",
         default=TEST_DEFAULTS.get("tests_root_dir"),
+    )
+    parser.add_argument(
+        "--global-build-number",
+        help="The build number passed from the testing pipelines",
+        default=TEST_DEFAULTS.get("global_build_number"),
     )
 
     dimensions_group = parser.add_argument_group("Test dimensions")
@@ -579,6 +585,10 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
 
     if args.scaling_test_config:
         pytest_args.extend(["--scaling-test-config", args.scaling_test_config])
+
+    if args.global_build_number:
+        pytest_args.append("--global-build-number")
+        pytest_args.extend(args.global_build_number)
 
     _set_custom_packages_args(args, pytest_args)
     _set_ami_args(args, pytest_args)


### PR DESCRIPTION

### Tests
* Ran local integration tests to see the global build number passed from the cli

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
