### PR TITLE
[Develop] Add an end2end test to validate the proxy use case

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -120,6 +120,11 @@ Resources:
         - CidrIp: !GetAtt PrivateSubnet.CidrBlock
           Description: Allow all inbound traffic from private subnet
           IpProtocol: -1
+        - CidrIp: 0.0.0.0/0
+          Description: Allow SSH access from anywhere
+          IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           Description: Allow all outbound traffic

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -11,6 +11,11 @@ Parameters:
     Type: String
     Default: 10.0.0.0/16
 
+  SSHCidr:
+    Description: CIDR to allow SSH traffic from
+    Type: String
+    Default: 0.0.0.0/0
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -18,6 +23,7 @@ Metadata:
           default: Networking
         Parameters:
           - VpcCidr
+          - SSHCidr
       - Label:
           default: Permissions
         Parameters:
@@ -120,8 +126,8 @@ Resources:
         - CidrIp: !GetAtt PrivateSubnet.CidrBlock
           Description: Allow all inbound traffic from private subnet
           IpProtocol: -1
-        - CidrIp: 0.0.0.0/0
-          Description: Allow SSH access from anywhere
+        - CidrIp: !Ref SSHCidr
+          Description: Allow SSH access from specified CIDR
           IpProtocol: tcp
           FromPort: 22
           ToPort: 22

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -44,7 +44,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
                       [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
                       [--no-delete] [--retain-ad-stack] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
-                      [--bucket-name BUCKET_NAME]
+                      [--bucket-name BUCKET_NAME] [--proxy-stack PROXY_STACK_NAME]
 
 Run integration tests suite.
 
@@ -176,6 +176,8 @@ Debugging/Development options:
                         Name of an existing external shared storage stack. (default: None)
   --bucket-name
                         Name of an existing bucket. (default: None)
+  --proxy-stack
+                        Name of an existing proxy stack. (default: None)
 ```
 
 Here is an example of tests submission:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -795,3 +795,10 @@ test-suites:
           regions: [ "us-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
+  proxy:
+    test_proxy.py::test_proxy:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu2004"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -215,6 +215,7 @@ def pytest_addoption(parser):
         help="Name of CFN stack providing a Proxy stack to be used for testing Proxy feature.",
     )
 
+
 def pytest_generate_tests(metafunc):
     """Generate (multiple) parametrized calls to a test function."""
     if metafunc.config.getoption("tests_config", None):

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -212,7 +212,7 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--proxy-stack",
-        help="Name of CFN stack providing a Proxy stack to be used for testing Proxy feature.",
+        help="Name of CFN stack providing a Proxy environment.",
     )
 
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -210,7 +210,10 @@ def pytest_addoption(parser):
         help="The build number passed from the testing pipelines",
         default=0,
     )
-
+    parser.addoption(
+        "--proxy-stack",
+        help="Name of CFN stack providing a Proxy stack to be used for testing Proxy feature.",
+    )
 
 def pytest_generate_tests(metafunc):
     """Generate (multiple) parametrized calls to a test function."""

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -98,6 +98,7 @@ TEST_DEFAULTS = {
     "force_elastic_ip": False,
     "retain_ad_stack": False,
     "global_build_number": 0,
+    "proxy_stack": None,
 }
 
 
@@ -455,6 +456,11 @@ def _init_argparser():
         help="Retain AD stack and corresponding VPC stack.",
         default=TEST_DEFAULTS.get("retain_ad_stack"),
     )
+    debug_group.add_argument(
+        "--proxy-stack",
+        help="Name of CFN stack providing a Proxy stack to be used for testing Proxy feature.",
+        default=TEST_DEFAULTS.get("proxy_stack"),
+    )
 
     return parser
 
@@ -675,6 +681,9 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.retain_ad_stack:
         pytest_args.append("--retain-ad-stack")
+
+    if args.proxy_stack:
+        pytest_args.extend(["--proxy-stack", args.proxy_stack])
 
 
 def _set_validate_instance_type_args(args, pytest_args):

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -458,7 +458,7 @@ def _init_argparser():
     )
     debug_group.add_argument(
         "--proxy-stack",
-        help="Name of CFN stack providing a Proxy stack to be used for testing Proxy feature.",
+        help="Name of CFN stack providing a Proxy environment.",
         default=TEST_DEFAULTS.get("proxy_stack"),
     )
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import pytest
+from cfn_stacks_factory import CfnStack
+from remote_command_executor import RemoteCommandExecutor
+from utils import generate_stack_name
+
+from tests.common.assertions import assert_no_errors_in_logs
+
+
+@pytest.fixture(scope="class")
+def proxy_stack(region, request, cfn_stacks_factory):
+    """
+    Set up and tear down a CloudFormation stack to deploy a proxy environment.
+
+    The stack is created from a CloudFormation template that sets up the necessary
+    networking, instances, and security groups for a proxy environment. The proxy
+    address and subnet are retrieved from the stack outputs and used in the cluster
+    configuration.
+    """
+    proxy_stack_template_path = "../../cloudformation/proxy/proxy.yaml"
+    with open(proxy_stack_template_path) as proxy_stack_template:
+        stack_name = generate_stack_name("integ-tests-proxy", request.config.getoption("stackname_suffix"))
+        stack_parameters = [
+            {"ParameterKey": "Keypair", "ParameterValue": request.config.getoption("key_name")},
+            {"ParameterKey": "VpcCidr", "ParameterValue": "10.0.0.0/16"},
+        ]
+        capabilities = ["CAPABILITY_IAM"]
+        tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]
+
+        proxy_stack = CfnStack(
+            name=stack_name,
+            region=region,
+            template=proxy_stack_template.read(),
+            parameters=stack_parameters,
+            capabilities=capabilities,
+            tags=tags,
+        )
+
+    cfn_stacks_factory.create_stack(proxy_stack)
+    yield proxy_stack
+
+    if not request.config.getoption("no_delete"):
+        cfn_stacks_factory.delete_stack(proxy_stack.name, region)
+
+
+@pytest.mark.usefixtures("os", "instance")
+def test_proxy(scheduler, pcluster_config_reader, clusters_factory, proxy_stack, scheduler_commands_factory):
+    """
+    Test the creation and functionality of a ParallelCluster using a proxy environment.
+
+    The test performs the following steps:
+    1. Deploy a proxy environment using a CloudFormation stack.
+    2. Create a ParallelCluster that uses the deployed proxy.
+    3. Submit a sleep job to the cluster and verify it completes successfully.
+    """
+    proxy_address = proxy_stack.cfn_outputs["ProxyAddress"]
+    subnet_with_proxy = proxy_stack.cfn_outputs["PrivateSubnet"]
+
+    cluster_config = pcluster_config_reader(proxy_address=proxy_address, subnet_with_proxy=subnet_with_proxy)
+    cluster = clusters_factory(cluster_config)
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    job_id = scheduler_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={"command": "sleep 5", "nodes": 2}
+    )
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -9,16 +9,20 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import logging
+
 import boto3
 import pytest
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
 from remote_command_executor import RemoteCommandExecutor
-from utils import generate_stack_name, get_username_for_os
+from utils import generate_stack_name
+
+from tests.common.schedulers_common import SlurmCommands
 
 
 @pytest.fixture(scope="class")
-def proxy_stack(region, request, cfn_stacks_factory):
+def proxy_stack_factory(region, request, cfn_stacks_factory):
     """
     Set up and tear down a CloudFormation stack to deploy a proxy environment.
 
@@ -29,28 +33,37 @@ def proxy_stack(region, request, cfn_stacks_factory):
     """
     proxy_stack_template_path = "../../cloudformation/proxy/proxy.yaml"
     with open(proxy_stack_template_path) as proxy_stack_template:
-        stack_name = generate_stack_name("integ-tests-proxy", request.config.getoption("stackname_suffix"))
-        stack_parameters = [
-            {"ParameterKey": "Keypair", "ParameterValue": request.config.getoption("key_name")},
-            {"ParameterKey": "VpcCidr", "ParameterValue": "10.0.0.0/16"},
-        ]
-        capabilities = ["CAPABILITY_IAM"]
-        tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]
+        if request.config.getoption("proxy_stack"):
+            logging.info("Using proxy stack {0} in region {1}".format(request.config.getoption("proxy_stack"), region))
+            proxy_stack = CfnStack(
+                name=request.config.getoption("proxy_stack"),
+                region=region,
+                template=proxy_stack_template.read(),
+            )
+        else:
+            stack_name = generate_stack_name("integ-tests-proxy", request.config.getoption("stackname_suffix"))
+            stack_parameters = [
+                {"ParameterKey": "Keypair", "ParameterValue": request.config.getoption("key_name")},
+                {"ParameterKey": "VpcCidr", "ParameterValue": "10.0.0.0/16"},
+                {"ParameterKey": "SSHCidr", "ParameterValue": "0.0.0.0/0"},
+            ]
+            capabilities = ["CAPABILITY_IAM"]
+            tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]
+            proxy_stack = CfnStack(
+                name=stack_name,
+                region=region,
+                template=proxy_stack_template.read(),
+                parameters=stack_parameters,
+                capabilities=capabilities,
+                tags=tags,
+            )
 
-        proxy_stack = CfnStack(
-            name=stack_name,
-            region=region,
-            template=proxy_stack_template.read(),
-            parameters=stack_parameters,
-            capabilities=capabilities,
-            tags=tags,
-        )
+            cfn_stacks_factory.create_stack(proxy_stack)
 
-    cfn_stacks_factory.create_stack(proxy_stack)
-    yield proxy_stack
+        yield proxy_stack
 
-    if not request.config.getoption("no_delete"):
-        cfn_stacks_factory.delete_stack(proxy_stack.name, region)
+        if not request.config.getoption("no_delete") and not request.config.getoption("proxy_stack"):
+            cfn_stacks_factory.delete_stack(proxy_stack.name, region)
 
 
 def get_instance_public_ip(instance_id, region):
@@ -61,34 +74,43 @@ def get_instance_public_ip(instance_id, region):
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
-def test_proxy(pcluster_config_reader, clusters_factory, proxy_stack, scheduler_commands_factory):
+def test_proxy(pcluster_config_reader, clusters_factory, proxy_stack_factory, scheduler_commands_factory):
     """
-    Test the creation and functionality of a ParallelCluster using a proxy environment.
+    Test the creation and functionality of a Cluster using a proxy environment.
 
     The test performs the following steps:
     1. Deploy a proxy environment using a CloudFormation stack.
     2. Create a ParallelCluster that uses the deployed proxy.
     3. Submit a sleep job to the cluster and verify it completes successfully.
+    4. Check Internet access by trying to access google.com
     """
-    proxy_address = proxy_stack.cfn_outputs["ProxyAddress"]
-    subnet_with_proxy = proxy_stack.cfn_outputs["PrivateSubnet"]
-    proxy_instance_id = proxy_stack.cfn_resources.get("Proxy")
+    proxy_address = proxy_stack_factory.cfn_outputs["ProxyAddress"]
+    subnet_with_proxy = proxy_stack_factory.cfn_outputs["PrivateSubnet"]
+    proxy_instance_id = proxy_stack_factory.cfn_resources.get("Proxy")
     assert_that(proxy_instance_id).is_not_none().described_as("Proxy instance ID should not be None")
-    proxy_public_ip = get_instance_public_ip(proxy_instance_id, proxy_stack.region)
+    proxy_public_ip = get_instance_public_ip(proxy_instance_id, proxy_stack_factory.region)
     assert_that(proxy_public_ip).is_not_none().described_as("Proxy public IP should not be None")
 
     cluster_config = pcluster_config_reader(proxy_address=proxy_address, subnet_with_proxy=subnet_with_proxy)
     cluster = clusters_factory(cluster_config)
 
-    username = get_username_for_os(cluster.os)
-
-    bastion = f"{username}@{proxy_public_ip}"
+    bastion = f"ubuntu@{proxy_public_ip}"
 
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion)
-    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    slurm_commands = SlurmCommands(remote_command_executor)
 
-    job_id = scheduler_commands.submit_command_and_assert_job_accepted(
-        submit_command_args={"command": "sleep 5", "nodes": 2}
+    _check_internet_access(remote_command_executor)
+
+    job_id = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={"command": "srun sleep 1", "nodes": 1}
     )
-    scheduler_commands.wait_job_completed(job_id)
-    scheduler_commands.assert_job_succeeded(job_id)
+    slurm_commands.wait_job_completed(job_id)
+    slurm_commands.assert_job_succeeded(job_id)
+
+
+def _check_internet_access(remote_command_executor):
+    logging.info("Checking cluster has Internet access by trying to access google.com")
+    internet_result = remote_command_executor.run_remote_command(
+        "curl --connect-timeout 10 -I https://google.com", raise_on_error=False
+    )
+    assert_that(internet_result.failed).is_false()

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -14,8 +14,6 @@ from cfn_stacks_factory import CfnStack
 from remote_command_executor import RemoteCommandExecutor
 from utils import generate_stack_name
 
-from tests.common.assertions import assert_no_errors_in_logs
-
 
 @pytest.fixture(scope="class")
 def proxy_stack(region, request, cfn_stacks_factory):

--- a/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
+++ b/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
@@ -1,0 +1,26 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Networking:
+    SubnetId: {{ subnet_with_proxy }}
+    Proxy:
+      HttpProxyAddress: {{ proxy_address }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue
+      ComputeResources:
+        - Name: compute1
+          Instances:
+            - InstanceType: t2.medium
+          MinCount: 1
+          MaxCount: 5
+      Networking:
+        SubnetIds:
+          - {{ subnet_with_proxy }}
+        AssignPublicIp: false
+        Proxy:
+          HttpProxyAddress: {{ proxy_address }}

--- a/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
+++ b/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
@@ -8,6 +8,9 @@ HeadNode:
     SubnetId: {{ subnet_with_proxy }}
     Proxy:
       HttpProxyAddress: {{ proxy_address }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -24,3 +27,6 @@ Scheduling:
         AssignPublicIp: false
         Proxy:
           HttpProxyAddress: {{ proxy_address }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status


### PR DESCRIPTION
### Description of changes
* Added a new integration test to validate the proxy use case.
* Use [cloudformation/proxy/proxy.yaml](https://github.com/aws/aws-parallelcluster/blob/develop/cloudformation/proxy/proxy.yaml) to deploy the proxy environment.
  * The proxy environment includes necessary networking, instances, and security groups.
* The test performs the following steps:
  1. Deploy the proxy environment using the CloudFormation stack.
  2. Create a ParallelCluster using the proxy environment.
  3. Connect to HeadNode through bastion.
  4. Check internet access by trying to access google.com
  5. Submit a sleep job to the cluster and verify its successful completion.

### Tests
* Locally test can pass successfully now. 

### References
* Proxy CloudFormation template (see https://github.com/aws/aws-parallelcluster/blob/develop/cloudformation/proxy/proxy.yaml)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
