### PR TITLE
[Test] In FSxLustre tests use only deployment types that are supported also in US ISO regions.

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -33,7 +33,7 @@ from troposphere.iam import InstanceProfile, Policy, Role
 from utils import generate_stack_name, random_alphanumeric, retrieve_cfn_outputs
 
 from tests.common.schedulers_common import SlurmCommands
-from tests.common.utils import retrieve_latest_ami
+from tests.common.utils import get_aws_domain, retrieve_latest_ami
 
 
 def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head_node: bool = True):
@@ -669,9 +669,13 @@ def assert_fsx_lustre_correctly_mounted(
     # example output: "192.168.46.168@tcp:/cg7k7bmv 1.7T /fsx_mount_dir"
     check_fstab_file(
         remote_command_executor,
-        r"{fsx_id}\.fsx\.[a-z1-9\-]+\.amazonaws\.com@tcp:/{mount_name}"
+        r"{fsx_id}\.fsx\.[a-z1-9\-]+\.{aws_domain_regex}@tcp:/{mount_name}"
         r" {mount_dir} lustre {mount_options} 0 0".format(
-            fsx_id=fsx_id, mount_name=mount_name, mount_dir=mount_dir, mount_options=mount_options
+            fsx_id=fsx_id,
+            mount_name=mount_name,
+            mount_dir=mount_dir,
+            mount_options=mount_options,
+            aws_domain_regex=re.escape(get_aws_domain(region)),
         ),
     )
 

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -24,6 +24,7 @@ from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import minutes, seconds
 from troposphere.fsx import LustreConfiguration
+from utils import is_fsx_lustre_deployment_type_supported
 
 from tests.storage.storage_common import (
     assert_fsx_lustre_correctly_mounted,
@@ -79,6 +80,11 @@ def test_fsx_lustre_configuration_options(
     storage_capacity,
     imported_file_chunk_size,
 ):
+    if not is_fsx_lustre_deployment_type_supported(region, deployment_type):
+        pytest.skip(
+            f"Skipping the test because the deployment type {deployment_type} is not supported in region {region}"
+        )
+
     mount_dir = "/fsx_mount_dir"
     bucket_name = None
     if deployment_type != "PERSISTENT_2":

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -43,8 +43,5 @@ SharedStorage:
       StorageCapacity: {{ storage_capacity }}
       ImportPath: s3://{{ bucket_name }}
       ExportPath: s3://{{ bucket_name }}/export_dir
-      # SCRATCH_1 not available in China/GovCloud regions
-      {% if region.startswith(("cn-", "us-gov-")) %}
       DeploymentType: PERSISTENT_1
       PerUnitStorageThroughput: 200
-      {% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
@@ -34,8 +34,8 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: {{ storage_capacity }}
-      DeploymentType: PERSISTENT_2
-      PerUnitStorageThroughput: 125
+      DeploymentType: PERSISTENT_1
+      PerUnitStorageThroughput: 200
       DataRepositoryAssociations:
         - Name: dra
           BatchImportMetaDataOnCreate: True

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.yaml
@@ -34,8 +34,8 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: {{ storage_capacity }}
-      DeploymentType: PERSISTENT_2
-      PerUnitStorageThroughput: 125
+      DeploymentType: PERSISTENT_1
+      PerUnitStorageThroughput: 200
       DataRepositoryAssociations:
         - Name: dra
           BatchImportMetaDataOnCreate: True

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -814,6 +814,10 @@ def is_filecache_supported(region: str):
     return "us-iso" not in region
 
 
+def is_fsx_lustre_deployment_type_supported(region: str, deployment_type: str):
+    return False if "us-iso-" in region and deployment_type in ["SCRATCH_1", "PERSISTENT_2"] else True
+
+
 def is_directory_supported(region: str, directory_type: str):
     return False if "us-iso" in region and directory_type == "SimpleAD" else True
 


### PR DESCRIPTION
### Description of changes
In FSxLustre tests use only deployment types that are supported also in US ISO regions.
Also adapted the fstab check for the US ISO domain.

### Tests
* FSxL tests in Commercial succeeded
* ONGOING FSXL tests in US ISO

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
