### PR TITLE
Add git commit refs to test metadata table

### DIFF
--- a/tests/integration-tests/conftest_utils.py
+++ b/tests/integration-tests/conftest_utils.py
@@ -180,6 +180,9 @@ def publish_test_metadata(item: pytest.Item, rep: pytest.TestReport):
             os=get_user_prop(item, "os"),
             feature=get_user_prop(item, "feature"),
             instance_type=get_user_prop(item, "instance"),
+            cli_commit=item.config.getoption("--pcluster-git-ref"),
+            cookbook_commit=item.config.getoption("--cookbook-git-ref"),
+            node_commit=item.config.getoption("--node-git-ref"),
             setup_metadata=PhaseMetadata(
                 rep.when,
                 status=rep.outcome,


### PR DESCRIPTION
### Description of changes
* Add cli, node, and cookbook git commit refs from integration tests to test metadata table

### Tests
* Ran dummy test on Jenkins and checked that refs were uploaded to the dynamodb table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
