### PR TITLE
Use a single extend to add the global build number, extend expects a …

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -587,8 +587,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
         pytest_args.extend(["--scaling-test-config", args.scaling_test_config])
 
     if args.global_build_number:
-        pytest_args.append("--global-build-number")
-        pytest_args.extend(args.global_build_number)
+        pytest_args.extend(["--global-build-number", args.global_build_number])
 
     _set_custom_packages_args(args, pytest_args)
     _set_ami_args(args, pytest_args)


### PR DESCRIPTION
…list, so a string will be converted into a list of chars

### Tests
* Ran tests with multi-digit build numbers to confirm

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
