### PR TITLE
[Test] Unblock the use of FSxLustre in tests when executed in us-iso-east-1 and disable File Cache tests for US isolated regions

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -464,12 +464,6 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-    test_fsx_lustre.py::test_file_cache:
-      dimensions:
-        - regions: ["us-iso-east-1"]
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
     test_fsx_lustre.py::test_multiple_fsx:
       dimensions:
         - regions: ["us-iso-east-1"]

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -34,11 +34,11 @@ SharedStorage:
   - MountDir: efs
     Name: {{ efs_name }}
     StorageType: Efs
-  {% if "us-iso" not in region and scheduler != "awsbatch" %}
+  {% if "us-isob" not in region and scheduler != "awsbatch" %}
   - MountDir: fsx
     Name: {{ fsx_name }}
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200
-      DeploymentType: SCRATCH_2
+      DeploymentType: PERSISTENT_1
   {% endif %}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -34,11 +34,11 @@ SharedStorage:
   - MountDir: efs
     Name: {{ efs_name }}
     StorageType: Efs
-  {% if "us-iso" not in region and scheduler != "awsbatch" %}
+  {% if "us-isob" not in region and scheduler != "awsbatch" %}
   - MountDir: fsx
     Name: {{ fsx_name }}
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200
-      DeploymentType: SCRATCH_2
+      DeploymentType: PERSISTENT_1
   {% endif %}

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -164,7 +164,7 @@ SharedStorage:
     EfsSettings: # New section
       ThroughputMode: provisioned
       ProvisionedThroughput: 1024
-{% if "-iso" not in region %}
+{% if "us-isob" not in region %}
   - MountDir: fsx
     Name: fsx
     StorageType: FsxLustre

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -103,7 +103,7 @@ SharedStorage:
       Raid:
         Type: 0
         NumberOfVolumes: 2
-{% if "-iso" not in region %}
+{% if "us-isob" not in region %}
   - MountDir: fsx
     Name: fsx
     StorageType: FsxLustre


### PR DESCRIPTION
### Description of changes
1. Unblock the use of FSxLustre in the following tests when executed in us-iso-east-1: test_overwrite_sg, test_update_slurm
. We keep it blocked for us-isob-* regions because FSx is not yet available there.
1. Disable File Cache tests for US isolated regions.

### Tests
Will be tested in US isolated regions (no impact on commercial execution).

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
