### PR TITLE
[Test] Fix the AWS domain used for FSx resources.

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -227,16 +227,22 @@ def get_installed_parallelcluster_base_version():
     return pkg_resources.packaging.version.parse(get_installed_parallelcluster_version()).base_version
 
 
+CLASSIC_AWS_DOMAIN = "amazonaws.com"
+CHINA_AWS_DOMAIN = "amazonaws.com.cn"
+US_ISO_AWS_DOMAIN = "c2s.ic.gov"
+US_ISOB_AWS_DOMAIN = "sc2s.sgov.gov"
+
+
 def get_aws_domain(region: str):
     """Get AWS domain for the given region."""
     if region.startswith("cn-"):
-        return "amazonaws.com.cn"
+        return CHINA_AWS_DOMAIN
     elif region.startswith("us-iso-"):
-        return "c2s.ic.gov"
+        return US_ISO_AWS_DOMAIN
     elif region.startswith("us-isob-"):
-        return "sc2s.sgov.gov"
+        return US_ISOB_AWS_DOMAIN
     else:
-        return "amazonaws.com"
+        return CLASSIC_AWS_DOMAIN
 
 
 def get_sts_endpoint(region):

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -33,7 +33,7 @@ from troposphere.iam import InstanceProfile, Policy, Role
 from utils import generate_stack_name, random_alphanumeric, retrieve_cfn_outputs
 
 from tests.common.schedulers_common import SlurmCommands
-from tests.common.utils import get_aws_domain, retrieve_latest_ami
+from tests.common.utils import CLASSIC_AWS_DOMAIN, get_aws_domain, retrieve_latest_ami
 
 
 def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head_node: bool = True):
@@ -675,9 +675,18 @@ def assert_fsx_lustre_correctly_mounted(
             mount_name=mount_name,
             mount_dir=mount_dir,
             mount_options=mount_options,
-            aws_domain_regex=re.escape(get_aws_domain(region)),
+            aws_domain_regex=re.escape(get_aws_domain_for_fsx(region)),
         ),
     )
+
+
+def get_aws_domain_for_fsx(region):
+    # Return the AWS domain for FSx resources.
+    # Notice that China and GovCloud use the Commercial domain.
+    if "us-iso" in region:
+        return get_aws_domain(region)
+    else:
+        return CLASSIC_AWS_DOMAIN
 
 
 def get_mount_name(fsx_fs_id, region):


### PR DESCRIPTION
### Description of changes
Fix the AWS domain used for FSx resources.

### Tests
* ONGOING test_multiple_fsx (in cn-north-1 and us-east-1): OUTCOME

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
