### PR TITLE
Add dummy global build number for release tests to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 **CHANGES**
 - Upgrade Slurm to 23.11.7 (from 23.11.4).
 
+**BUG FIXES**
+- Fix issue with `SharedStorageType: Efs` not bootstrapping on ARM instances.
+
 3.9.1
 ------
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -93,6 +93,7 @@ TEST_DEFAULTS = {
     "force_run_instances": False,
     "force_elastic_ip": False,
     "retain_ad_stack": False,
+    "global_build_number": 0,
 }
 
 
@@ -423,6 +424,11 @@ def _init_argparser():
         action="store_true",
         help="Retain AD stack and corresponding VPC stack.",
         default=TEST_DEFAULTS.get("retain_ad_stack"),
+    )
+    parser.add_argument(
+        "--global-build-number",
+        help="The build number passed from the testing pipelines",
+        default=TEST_DEFAULTS.get("global_build_number"),
     )
 
     return parser


### PR DESCRIPTION
Add missed bug fix to 3.9.2 changelog entry

### Tests
* Tested with the test_runner locally providing the global build number on the cli

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
