### PR TITLE
[Test] Fixes to integ tests: test_dynamic_file_systems_update_data_loss, test_log_rotation, test_raid_performance_mode

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -148,7 +148,7 @@ test-suites:
       dimensions:
         - regions: ["il-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   monitoring:
     test_monitoring.py::test_monitoring:

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -196,7 +196,13 @@ def test_raid_correctly_configured(remote_command_executor, raid_type, volume_si
     mdadm_conf = remote_command_executor.run_remote_command(
         "sudo cat /etc/mdadm.conf || sudo cat /etc/mdadm/mdadm.conf"
     ).stdout
-    assert_that(mdadm_conf).contains(expected_entry)
+    # We remove from the mdadm scan output all the warning messages that are considered not problematic.
+    sanitized_expected_entry = re.sub(
+        r"mdadm: Value .* cannot be set as name\. Reason: Not POSIX compatible\. Value ignored\.\n?",
+        "",
+        expected_entry,
+    )
+    assert_that(mdadm_conf).contains(sanitized_expected_entry)
 
 
 def test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size):

--- a/tests/integration-tests/tests/storage/test_raid.py
+++ b/tests/integration-tests/tests/storage/test_raid.py
@@ -29,9 +29,9 @@ def test_raid_performance_mode(pcluster_config_reader, clusters_factory, schedul
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     mount_dir = "/raid_dir"
-    test_raid_correctly_configured(remote_command_executor, raid_type="0", volume_size=75, raid_devices=5)
     test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size=74)
     _test_raid_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+    test_raid_correctly_configured(remote_command_executor, raid_type="0", volume_size=75, raid_devices=5)
 
 
 @pytest.mark.usefixtures("region", "os", "instance")

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -37,6 +37,7 @@ from utils import (
     is_fsx_lustre_supported,
     is_fsx_ontap_supported,
     is_fsx_openzfs_supported,
+    random_alphanumeric,
     retrieve_cfn_resources,
     wait_for_computefleet_changed,
 )


### PR DESCRIPTION
### Description of changes
Fixes to integ tests: 
1. test_dynamic_file_systems_update_data_loss: missing import statement due to missed cherry-pick from develop
2. test_log_rotation: cherry.-picked commit from integ-tests-3.9.2 to execute the test on al2 as we know there is a test issue in ubuntu, fixed in the next upcoming release, that was excluded for 3.9.3.
3. test_raid_performance_mode: adapted test code to ingore a mdadm warning surfaced in rocky8

### Tests
* Executed all the modified integ tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
