### PR TITLE
[Test] In test_custom_image, set the CleanupLambdaRole to prevent stack deletion failures caused by known cloudFormation issue.

### DIFF
--- a/tests/integration-tests/tests/common/permissions.py
+++ b/tests/integration-tests/tests/common/permissions.py
@@ -1,0 +1,9 @@
+def create_image_roles(create_roles_stack):
+    # Create build image roles
+    image_roles_stack = create_roles_stack(
+        stack_prefix="integ-tests-iam-image-roles", roles_file="image-roles.cfn.yaml"
+    )
+    lambda_cleanup_role = image_roles_stack.cfn_outputs["BuildImageLambdaCleanupRole"]
+    instance_profile = image_roles_stack.cfn_outputs["BuildImageInstanceProfile"]
+    # instance_role = image_roles_stack.cfn_outputs["BuildImageInstanceRole"]
+    return instance_profile, lambda_cleanup_role

--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -45,6 +45,7 @@ from troposphere.template_generator import TemplateGenerator
 from utils import generate_stack_name
 
 from tests.common.assertions import wait_for_num_instances_in_cluster
+from tests.common.permissions import create_image_roles
 from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
 
 LOGGER = logging.getLogger(__name__)
@@ -520,10 +521,15 @@ def test_official_images(region, api_client):
 
 
 @pytest.mark.usefixtures("instance")
-def test_custom_image(region, api_client, build_image, os, request, pcluster_config_reader):
+def test_custom_image(region, api_client, build_image, os, request, pcluster_config_reader, create_roles_stack):
     base_ami = retrieve_latest_ami(region, os)
+    _, cleanup_lambda_role = create_image_roles(create_roles_stack)
 
-    config_file = pcluster_config_reader(config_file="image.config.yaml", parent_image=base_ami)
+    config_file = pcluster_config_reader(
+        config_file="image.config.yaml",
+        parent_image=base_ami,
+        cleanup_lambda_role=cleanup_lambda_role,
+    )
     with open(config_file, encoding="utf-8") as config_file:
         config = config_file.read()
 

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
@@ -1,4 +1,6 @@
 Build:
+  Iam:
+    CleanupLambdaRole: {{ cleanup_lambda_role }}
   InstanceType: {{ instance }}
   ParentImage: {{ parent_image }}
   UpdateOsPackages:


### PR DESCRIPTION
### Description of changes
In test_custom_image, set the CleanupLambdaRole to prevent stack deletion failures caused by known cloudFormation issue.

### Tests
* **ONGOING** Executed integ test: test_custom_image

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
