### PR TITLE
[Test] Fix test_starccm so that it can be executed on AL2023.

### DIFF
--- a/tests/integration-tests/configs/starccm.yaml
+++ b/tests/integration-tests/configs/starccm.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "ubuntu2204", "ubuntu2004", "centos7", "rhel8", "rocky8"]
+          oss: ["alinux2", "alinux2023", "ubuntu2204", "ubuntu2004", "centos7", "rhel8", "rocky8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -22,6 +22,8 @@ BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {
 }
 PERF_TEST_DIFFERENCE_TOLERANCE = 3
 
+OSS_REQUIRING_EXTRA_DEPS = ["alinux2023", "rhel8", "rocky8"]
+
 
 def get_starccm_secrets(region_name):
     secrets_manager_client = boto3.client("secretsmanager", region_name=region_name)
@@ -67,7 +69,9 @@ def test_starccm(
     s3.upload_file(str(test_datadir / "dependencies.install.sh"), bucket_name, "scripts/dependencies.install.sh")
 
     cluster_config = pcluster_config_reader(
-        bucket_name=bucket_name, install_extra_deps=os in ["rhel8", "rocky8"], number_of_nodes=max(number_of_nodes)
+        bucket_name=bucket_name,
+        install_extra_deps=os in OSS_REQUIRING_EXTRA_DEPS,
+        number_of_nodes=max(number_of_nodes),
     )
     cluster = clusters_factory(cluster_config)
     logging.info("Cluster Created")

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -13,6 +13,7 @@ STARCCM_JOB_TIMEOUT = 600
 STARCCM_LICENCE_SECRET = "starccm-license-secret"
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {
+    "alinux2023": {8: 62.414, 16: 31.998, 32: 20.422},  # v3.10.0
     "alinux2": {8: 64.475, 16: 33.173, 32: 17.899},  # v3.1.3
     "ubuntu2204": {8: 75.502, 16: 36.353, 32: 19.688},  # v3.7.0
     "ubuntu2004": {8: 67.384, 16: 36.434, 32: 19.449},  # v3.1.3


### PR DESCRIPTION
### Description of changes
Fix test_starccm so that it can be executed on AL2023.
AL2023 required extra dependencies (libnsl) to be installed with custom action script.
Without this change the installation of libnsl was skipped.
Also set ther AL2023 baseline to the values observed on this first run.

### Tests
1. Executed test_starccm: detected perf improvement of ~3% w.r.t AL2 on 8, 16 nodes, but perf degrad on 32 nodes. This perf degradation makes the test fail, but the goal of the PR is to actually unblock the test execution not to address perf issues.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
