### PR TITLE
[Draft][Develop] Fix test_porxy integ test

### DIFF
--- a/tests/integration-tests/configs/tmp_test.yaml
+++ b/tests/integration-tests/configs/tmp_test.yaml
@@ -1,0 +1,13 @@
+{%- import 'common.jinja2' as common with context -%}
+{{- common.OSS_COMMERCIAL_ARM.append("centos7") or "" -}}
+{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
+{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
+---
+test-suites:
+  proxy:
+    test_proxy.py::test_proxy:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu2004"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -69,6 +69,7 @@ class RemoteCommandExecutor:
             "host": node_ip,
             "user": username,
             "forward_agent": False,
+            "connect_timeout": 360,
             "connect_kwargs": {
                 "key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key],
                 "look_for_keys": False,
@@ -81,11 +82,13 @@ class RemoteCommandExecutor:
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
-            connection_kwargs["connect_kwargs"]["banner_timeout"] = 360
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 600
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
+                logging.info(f"set timeout to {connection_timeout}")
             if connection_allow_agent:
                 connection_kwargs["connect_kwargs"]["allow_agent"] = connection_allow_agent
+                logging.info(f"set allow_agent to {connection_allow_agent}")
         logging.info(
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -37,6 +37,7 @@ class RemoteCommandExecutor:
         alternate_ssh_key=None,
         use_login_node=False,
         connection_timeout=None,
+        connection_allow_agent=None,
     ):
         """
         Initiate SSH connection
@@ -83,6 +84,8 @@ class RemoteCommandExecutor:
             connection_kwargs["connect_kwargs"]["banner_timeout"] = 360
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
+            if connection_allow_agent:
+                connection_kwargs["connect_kwargs"]["allow_agent"] = connection_allow_agent
         logging.info(
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -80,7 +80,7 @@ class RemoteCommandExecutor:
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
-            connection_kwargs["connect_kwargs"]["banner_timeout"] = 200
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 360
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
         logging.info(

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -69,7 +69,6 @@ class RemoteCommandExecutor:
             "host": node_ip,
             "user": username,
             "forward_agent": False,
-            "connect_timeout": 360,
             "connect_kwargs": {
                 "key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key],
                 "look_for_keys": False,

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -29,7 +29,14 @@ class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
     def __init__(
-        self, cluster, compute_node_ip=None, username=None, bastion=None, alternate_ssh_key=None, use_login_node=False
+        self,
+        cluster,
+        compute_node_ip=None,
+        username=None,
+        bastion=None,
+        alternate_ssh_key=None,
+        use_login_node=False,
+        connection_timeout=None,
     ):
         """
         Initiate SSH connection
@@ -74,6 +81,8 @@ class RemoteCommandExecutor:
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
             connection_kwargs["connect_kwargs"]["banner_timeout"] = 60
+            if connection_timeout:
+                connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
         logging.info(
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -37,7 +37,6 @@ class RemoteCommandExecutor:
         alternate_ssh_key=None,
         use_login_node=False,
         connection_timeout=None,
-        custom_env=None,
     ):
         """
         Initiate SSH connection
@@ -81,7 +80,6 @@ class RemoteCommandExecutor:
                 f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname",
                 timeout=30,
                 shell=True,
-                env=custom_env if custom_env else None,
             )
             logging.info(f"Command output: {ssh_command_result}")
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -37,7 +37,7 @@ class RemoteCommandExecutor:
         alternate_ssh_key=None,
         use_login_node=False,
         connection_timeout=None,
-        connection_allow_agent=None,
+        custom_env=None,
     ):
         """
         Initiate SSH connection
@@ -77,17 +77,17 @@ class RemoteCommandExecutor:
         if bastion:
             # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
             run_command(
-                f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname", timeout=30, shell=True
+                f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname",
+                timeout=30,
+                shell=True,
+                env=custom_env if custom_env else None,
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
-            connection_kwargs["connect_kwargs"]["banner_timeout"] = 600
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 300
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
                 logging.info(f"set timeout to {connection_timeout}")
-            if connection_allow_agent:
-                connection_kwargs["connect_kwargs"]["allow_agent"] = connection_allow_agent
-                logging.info(f"set allow_agent to {connection_allow_agent}")
         logging.info(
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -84,7 +84,7 @@ class RemoteCommandExecutor:
             logging.info(f"Command output: {ssh_command_result}")
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
-            connection_kwargs["connect_kwargs"]["banner_timeout"] = 300
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 1800
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
                 logging.info(f"set timeout to {connection_timeout}")

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -80,7 +80,7 @@ class RemoteCommandExecutor:
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
-            connection_kwargs["connect_kwargs"]["banner_timeout"] = 60
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 200
             if connection_timeout:
                 connection_kwargs["connect_kwargs"]["timeout"] = connection_timeout
         logging.info(

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -69,6 +69,7 @@ class RemoteCommandExecutor:
             "host": node_ip,
             "user": username,
             "forward_agent": False,
+            "inline_ssh_env": True,
             "connect_kwargs": {
                 "key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key],
                 "look_for_keys": False,
@@ -76,12 +77,13 @@ class RemoteCommandExecutor:
         }
         if bastion:
             # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
-            run_command(
+            ssh_command_result = run_command(
                 f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname",
                 timeout=30,
                 shell=True,
                 env=custom_env if custom_env else None,
             )
+            logging.info(f"Command output: {ssh_command_result}")
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
             connection_kwargs["connect_kwargs"]["banner_timeout"] = 300

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -16,7 +16,7 @@ import pytest
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
 from remote_command_executor import RemoteCommandExecutor
-from utils import generate_stack_name
+from utils import generate_stack_name, run_command
 
 from tests.common.schedulers_common import SlurmCommands
 
@@ -95,8 +95,8 @@ def test_proxy(pcluster_config_reader, clusters_factory, proxy_stack_factory, sc
     cluster = clusters_factory(cluster_config)
 
     bastion = f"ubuntu@{proxy_public_ip}"
-
-    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
+    run_command(f"eval ssh-agent && ssh-add {cluster.ssh_key}", timeout=60, shell=True)
+    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=200)
     slurm_commands = SlurmCommands(remote_command_executor)
 
     _check_internet_access(remote_command_executor)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -63,14 +63,8 @@ def proxy_stack_factory(region, request, cfn_stacks_factory):
 
         yield proxy_stack
 
-        # Add finalizer to ensure proxy stack is deleted after cluster stacks
-        request.addfinalizer(lambda: delete_proxy_stack(proxy_stack, region, request, cfn_stacks_factory))
-
-
-def delete_proxy_stack(proxy_stack, region, request, cfn_stacks_factory):
-    if not request.config.getoption("no_delete") and not request.config.getoption("proxy_stack"):
-        logging.info(f"Deleting proxy stack {proxy_stack.name} in region {region}")
-        cfn_stacks_factory.delete_stack(proxy_stack.name, region)
+        if not request.config.getoption("no_delete") and not request.config.getoption("proxy_stack"):
+            cfn_stacks_factory.delete_stack(proxy_stack.name, region)
 
 
 def get_instance_public_ip(instance_id, region):
@@ -81,7 +75,7 @@ def get_instance_public_ip(instance_id, region):
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
-def test_proxy(pcluster_config_reader, clusters_factory, proxy_stack_factory, scheduler_commands_factory):
+def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_factory, clusters_factory):
     """
     Test the creation and functionality of a Cluster using a proxy environment.
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -96,7 +96,7 @@ def test_proxy(pcluster_config_reader, clusters_factory, proxy_stack_factory, sc
 
     bastion = f"ubuntu@{proxy_public_ip}"
 
-    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion)
+    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
     slurm_commands = SlurmCommands(remote_command_executor)
 
     _check_internet_access(remote_command_executor)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -131,7 +131,7 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
     env_prefix = " && ".join([f"export {key}={value}" for key, value in env_vars.items()])
 
     headnode_instance_ip = cluster.head_node_ip
-    ssh_gateway_result = run_command(f"ssh -W {headnode_instance_ip}:22 -A {bastion}", shell=True, raise_on_error=False)
+    ssh_gateway_result = run_command(f"ssh -W {headnode_instance_ip}:22 -A {bastion} -vvv", shell=True, raise_on_error=False)
     logging.info(f"SSH command output: {ssh_gateway_result}")
 
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -10,15 +10,13 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
-import os
-from time import sleep
 
 import boto3
 import pytest
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
 from remote_command_executor import RemoteCommandExecutor
-from utils import generate_stack_name, run_command
+from utils import generate_stack_name
 
 from tests.common.schedulers_common import SlurmCommands
 
@@ -103,7 +101,7 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_f
     )
     slurm_commands = SlurmCommands(remote_command_executor)
 
-    _check_internet_access(remote_command_executor)
+    # _check_internet_access(remote_command_executor)
 
     job_id = slurm_commands.submit_command_and_assert_job_accepted(
         submit_command_args={"command": "srun sleep 1", "nodes": 1}

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -97,19 +97,6 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_f
 
     bastion = f"ubuntu@{proxy_public_ip}"
 
-    # Start the SSH agent and add SSH key
-    agent_result = run_command("eval `ssh-agent -s`", shell=True)
-    logging.info(f"SSH agent started with output: {agent_result.stdout}")
-
-    # Set environment variables
-    for line in agent_result.stdout.splitlines():
-        if "SSH_AUTH_SOCK" in line or "SSH_AGENT_PID" in line:
-            key, value = line.replace(";", "").split("=")
-            os.environ[key.strip()] = value.strip()
-
-    add_key_result = run_command(f"ssh-add {cluster.ssh_key}", shell=True, env=os.environ)
-    logging.info(f"SSH key add result: {add_key_result.stdout}")
-
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=200)
     slurm_commands = SlurmCommands(remote_command_executor)
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -131,6 +131,14 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
     env_prefix = " && ".join([f"export {key}={value}" for key, value in env_vars.items()])
 
     headnode_instance_ip = cluster.head_node_ip
+
+    ssh_command_result = run_command(
+        f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname",
+        timeout=30,
+        shell=True,
+    )
+    logging.info(f"Command output: {ssh_command_result}")
+
     ssh_gateway_result = run_command(f"ssh -W {headnode_instance_ip}:22 -A {bastion} -vvv", shell=True, raise_on_error=False)
     logging.info(f"SSH command output: {ssh_gateway_result}")
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -98,13 +98,6 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_f
 
     bastion = f"ubuntu@{proxy_public_ip}"
 
-    # Start the SSH agent and add SSH key
-    agent_result = run_command("eval `ssh-agent -s`", shell=True)
-    logging.info(f"SSH agent started with output: {agent_result.stdout}")
-    sleep(5)
-    add_key_result = run_command(f"ssh-add {cluster.ssh_key}", shell=True)
-    logging.info(f"SSH key add result: {add_key_result.stdout}")
-
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
     slurm_commands = SlurmCommands(remote_command_executor)
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
+from time import sleep
 
 import boto3
 import pytest
@@ -97,7 +98,14 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_f
 
     bastion = f"ubuntu@{proxy_public_ip}"
 
-    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=200)
+    # Start the SSH agent and add SSH key
+    agent_result = run_command("eval `ssh-agent -s`", shell=True)
+    logging.info(f"SSH agent started with output: {agent_result.stdout}")
+    sleep(5)
+    add_key_result = run_command(f"ssh-add {cluster.ssh_key}", shell=True)
+    logging.info(f"SSH key add result: {add_key_result.stdout}")
+
+    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
     slurm_commands = SlurmCommands(remote_command_executor)
 
     _check_internet_access(remote_command_executor)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -104,7 +104,11 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
 
     # Add the SSH key using the ssh-add command, passing the environment variables
     ssh_add_result = run_command(f'ssh-add {request.config.getoption("key_path")}', shell=True, env=os.environ.copy())
-    logging.info(f"SSH key add result: {ssh_add_result.stdout}")
+    logging.info(f"SSH key add result: {ssh_add_result.stderr}")
+
+    # Confirm that the key has been added
+    added_keys = run_command("ssh-add -l", shell=True, env=os.environ.copy())
+    logging.info(f"SSH keys added: {added_keys.stdout}")
 
     proxy_address = proxy_stack_factory.cfn_outputs["ProxyAddress"]
     subnet_with_proxy = proxy_stack_factory.cfn_outputs["PrivateSubnet"]
@@ -119,7 +123,7 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
     bastion = f"ubuntu@{proxy_public_ip}"
 
     remote_command_executor = RemoteCommandExecutor(
-        cluster=cluster, bastion=bastion, connection_timeout=300, connection_allow_agent=False
+        cluster=cluster, bastion=bastion, connection_timeout=300, custom_env=os.environ.copy()
     )
     slurm_commands = SlurmCommands(remote_command_executor)
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -98,7 +98,9 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, scheduler_commands_f
 
     bastion = f"ubuntu@{proxy_public_ip}"
 
-    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
+    remote_command_executor = RemoteCommandExecutor(
+        cluster=cluster, bastion=bastion, connection_timeout=300, connection_allow_agent=False
+    )
     slurm_commands = SlurmCommands(remote_command_executor)
 
     _check_internet_access(remote_command_executor)

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -130,6 +130,10 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
     }
     env_prefix = " && ".join([f"export {key}={value}" for key, value in env_vars.items()])
 
+    headnode_instance_ip = cluster.head_node_ip
+    ssh_gateway_result = run_command(f"ssh -W {headnode_instance_ip}:22 -A {bastion}", shell=True, raise_on_error=False)
+    logging.info(f"SSH command output: {ssh_gateway_result}")
+
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
     # slurm_commands = SlurmCommands(remote_command_executor)
 

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -130,9 +130,7 @@ def test_proxy(pcluster_config_reader, request, proxy_stack_factory, scheduler_c
     }
     env_prefix = " && ".join([f"export {key}={value}" for key, value in env_vars.items()])
 
-    remote_command_executor = RemoteCommandExecutor(
-        cluster=cluster, bastion=bastion, connection_timeout=300
-    )
+    remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion, connection_timeout=300)
     # slurm_commands = SlurmCommands(remote_command_executor)
 
     _check_internet_access(remote_command_executor, env_prefix)

--- a/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
+++ b/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
@@ -4,6 +4,7 @@ HeadNode:
   InstanceType: {{ instance }}
   Ssh:
     KeyName: {{ key_name }}
+    AllowedIps: 0.0.0.0/0
   Networking:
     SubnetId: {{ subnet_with_proxy }}
     Proxy:

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -187,6 +187,9 @@ def run_command(
         command = shlex.split(command)
     log_command = command if isinstance(command, str) else " ".join(str(arg) for arg in command)
     logging.info("Executing command: {}".format(log_command))
+
+    env = env if env is not None else os.environ.copy()
+
     try:
         result = subprocess.run(
             command,


### PR DESCRIPTION
### Description of changes
* test_porxy integ test can not pass on Jenkin but can pass on local machine, suspect is because of SSH settings on Jenkins docker
* Increase connection_timeout to fix paramiko: no existing session issue
* Fix Proxy Stack deletion failed issue
* For Paramiko : Error reading SSH protocol banner issue, tried below options:
  * Increase banner_timeout
  * Run `ssh-agent -s` and set the env variables, run `ssh-add <private-key>`
    * Modify `run_command` function, if env is not set, use os.environ
  * Enable `inline_ssh_env` for RemoteCommandExecutor, and add `env_prefix` before the commands
  * For now, this issue hasn't been fixed, once done will remove [Draft] label

### Tests
* test_porxy integ test can not pass on Jenkins
* test_porxy integ test can pass on local machine

### References
* https://github.com/aws/aws-parallelcluster/pull/6268

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
