### PR TITLE
[Test] Make test_raid_performance ignore not impactful mdadm warning surfaced in rocky8

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -196,7 +196,13 @@ def test_raid_correctly_configured(remote_command_executor, raid_type, volume_si
     mdadm_conf = remote_command_executor.run_remote_command(
         "sudo cat /etc/mdadm.conf || sudo cat /etc/mdadm/mdadm.conf"
     ).stdout
-    assert_that(mdadm_conf).contains(expected_entry)
+    # We remove from the mdadm scan output all the warning messages that are considered not problematic.
+    sanitized_expected_entry = re.sub(
+        r"mdadm: Value .* cannot be set as name\. Reason: Not POSIX compatible\. Value ignored\.\n?",
+        "",
+        expected_entry,
+    )
+    assert_that(mdadm_conf).contains(sanitized_expected_entry)
 
 
 def test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size):

--- a/tests/integration-tests/tests/storage/test_raid.py
+++ b/tests/integration-tests/tests/storage/test_raid.py
@@ -29,9 +29,9 @@ def test_raid_performance_mode(pcluster_config_reader, clusters_factory, schedul
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     mount_dir = "/raid_dir"
-    test_raid_correctly_configured(remote_command_executor, raid_type="0", volume_size=75, raid_devices=5)
     test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size=74)
     _test_raid_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+    test_raid_correctly_configured(remote_command_executor, raid_type="0", volume_size=75, raid_devices=5)
 
 
 @pytest.mark.usefixtures("region", "os", "instance")


### PR DESCRIPTION
### Description of changes
Make test_raid_performance ignore not impactful mdadm warning surfaced in rocky8.

Commits cherry-picked from integ-tests-3.9.3 (https://github.com/aws/aws-parallelcluster/pull/6297)

### Tests
Tested in original PR

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
