### PR TITLE
[PCAPI] Fix DescribeClusterResponse by replacing the field 'failureReason' with 'failures'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 - Allow ParallelCluster Custom Resource to suppress validators using `PclusterCluster/SuppressValidators`.
 - Removing `/etc/profile.d/pcluster.sh` so that it's not executed at every user login and
   `cfn_bootstrap_virtualenv` is not added in PATH environment variable.
+- Fix ParallelCluster API spec by replacing in `DescribeCluster` response the field `failureReason` with `failures`.
 
 **CHANGES**
 - CentOS 7 is no longer supported.

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -18,3 +18,6 @@ cdk.out
 build
 node_modules
 package.json
+
+# Generated code
+generated

--- a/cli/src/pcluster/api/models/__init__.py
+++ b/cli/src/pcluster/api/models/__init__.py
@@ -20,6 +20,7 @@ from pcluster.api.models.build_image_bad_request_exception_response_content impo
 from pcluster.api.models.build_image_request_content import BuildImageRequestContent
 from pcluster.api.models.build_image_response_content import BuildImageResponseContent
 from pcluster.api.models.change import Change
+from pcluster.api.models.cloud_formation_resource_status import CloudFormationResourceStatus
 from pcluster.api.models.cloud_formation_stack_status import CloudFormationStackStatus
 from pcluster.api.models.cluster_configuration_structure import ClusterConfigurationStructure
 from pcluster.api.models.cluster_info_summary import ClusterInfoSummary

--- a/cli/src/pcluster/api/models/describe_cluster_response_content.py
+++ b/cli/src/pcluster/api/models/describe_cluster_response_content.py
@@ -80,6 +80,7 @@ class DescribeClusterResponseContent(Model):
         :type scheduler: Scheduler
         :param login_nodes: The login_nodes of this DescribeClusterResponseContent.  # noqa: E501
         :type login_nodes: LoginNodesPool
+        :param failures: The failures of this DescribeClusterResponseContent.  # noqa: E501
         :type failures: List[Failure]
         """
         self.openapi_types = {
@@ -487,7 +488,7 @@ class DescribeClusterResponseContent(Model):
     def failures(self):
         """Gets the failures of this DescribeClusterResponseContent.
 
-        Failures reason and code when the stack is in CREATE_FAILED status.  # noqa: E501
+        Failures array containing failures reason and code when the stack is in CREATE_FAILED status.  # noqa: E501
 
         :return: The failures of this DescribeClusterResponseContent.
         :rtype: List[Failure]
@@ -498,7 +499,7 @@ class DescribeClusterResponseContent(Model):
     def failures(self, failures):
         """Sets the failures of this DescribeClusterResponseContent.
 
-        Failures reason and code when the stack is in CREATE_FAILED status.  # noqa: E501
+        Failures array containing failures reason and code when the stack is in CREATE_FAILED status.  # noqa: E501
 
         :param failures: The failures of this DescribeClusterResponseContent.
         :type failures: List[Failure]

--- a/cli/src/pcluster/api/models/failure.py
+++ b/cli/src/pcluster/api/models/failure.py
@@ -45,7 +45,7 @@ class Failure(Model):
     def failure_code(self):
         """Gets the failure_code of this Failure.
 
-        Failure code  # noqa: E501
+        Failure code when the cluster stack is in CREATE_FAILED status.  # noqa: E501
 
         :return: The failure_code of this Failure.
         :rtype: str
@@ -56,7 +56,7 @@ class Failure(Model):
     def failure_code(self, failure_code):
         """Sets the failure_code of this Failure.
 
-        Failure code  # noqa: E501
+        Failure code when the cluster stack is in CREATE_FAILED status.  # noqa: E501
 
         :param failure_code: The failure_code of this Failure.
         :type failure_code: str
@@ -68,7 +68,7 @@ class Failure(Model):
     def failure_reason(self):
         """Gets the failure_reason of this Failure.
 
-        Failure reason  # noqa: E501
+        Failure reason when the cluster stack is in CREATE_FAILED status.  # noqa: E501
 
         :return: The failure_reason of this Failure.
         :rtype: str
@@ -79,7 +79,7 @@ class Failure(Model):
     def failure_reason(self, failure_reason):
         """Sets the failure_reason of this Failure.
 
-        Failure reason  # noqa: E501
+        Failure reason when the cluster stack is in CREATE_FAILED status.  # noqa: E501
 
         :param failure_reason: The failure_reason of this Failure.
         :type failure_reason: str

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -2348,6 +2348,11 @@ components:
       type: object
     DescribeClusterResponseContent:
       example:
+        failures:
+        - failureCode: failureCode
+          failureReason: failureReason
+        - failureCode: failureCode
+          failureReason: failureReason
         creationTime: 2000-01-23T04:56:07.000+00:00
         loginNodes:
           unhealthyNodes: 6
@@ -2431,11 +2436,13 @@ components:
           $ref: '#/components/schemas/EC2Instance'
         loginNodes:
           $ref: '#/components/schemas/LoginNodesPool'
-        failureReason:
-          description: "Reason of the failure when the stack is in CREATE_FAILED,\
-            \ UPDATE_FAILED or DELETE_FAILED status."
-          title: failureReason
-          type: string
+        failures:
+          description: Failures array containing failures reason and code when the
+            stack is in CREATE_FAILED status.
+          items:
+            $ref: '#/components/schemas/Failure'
+          title: failures
+          type: array
       required:
       - cloudFormationStackStatus
       - cloudformationStackArn
@@ -2682,6 +2689,21 @@ components:
       - ERROR
       title: Ec2AmiState
       type: string
+    Failure:
+      example:
+        failureCode: failureCode
+        failureReason: failureReason
+      properties:
+        failureCode:
+          description: Failure code when the cluster stack is in CREATE_FAILED status.
+          title: failureCode
+          type: string
+        failureReason:
+          description: Failure reason when the cluster stack is in CREATE_FAILED status.
+          title: failureReason
+          type: string
+      title: Failure
+      type: object
     GetClusterLogEventsResponseContent:
       example:
         nextToken: nextToken


### PR DESCRIPTION
### Description of changes
* Fix DescribeClusterResponse in PCAPI definition by replacing the field 'failureReason' with 'failures' and importing CloudFormationResourceStatus in modules init.
* Add to gitignore: api/generated folder of generated code.

Changes to PCAPI are generated following the standard procedure described in [development workflow](https://github.com/aws/aws-parallelcluster/blob/develop/api/README.md#development-workflow).

### Tests
* Successful api integ test `test_api.py::test_cluster_slurm`, `test_api.py::test_cluster_awsbatch`, `test_api.py::test_login_nodes`, `test_api.py::test_api_infrastructure_with_default_parameters`, `test_api.py::test_api_infrastructure_with_full_parameters`, `test_api.py::test_custom_image` (known failure on stack deletion unrelated to this change).

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
