### PR TITLE
[Validators] Add validator to prevent the use of Placement Groups with Capacity Blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Add new configuration section `Scheduling/SlurmSettings/ExternalSlurmdbd` to connect the cluster to an external Slurmdbd.
 - Add support for Amazon Linux 2023.
 - Add support for `price-capacity-optimized` as an `AllocationStrategy`.
+- Add validator to prevent the use of Placement Groups with Capacity Blocks.
 
 **BUG FIXES**
 - Fix DRA configuration to make `AutoExportPolicy` and `AutoImportPolicy` optional.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -146,6 +146,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeValidator,
     KeyPairValidator,
     PlacementGroupCapacityReservationValidator,
+    PlacementGroupCapacityTypeValidator,
     PlacementGroupNamingValidator,
 )
 from pcluster.validators.efs_validators import EfsMountOptionsValidator
@@ -3026,6 +3027,11 @@ class SlurmClusterConfig(BaseClusterConfig):
                     efa_enabled=compute_resource.efa.enabled,
                     os=self.image.os,
                     architecture=self.head_node.architecture,
+                )
+                self._register_validator(
+                    PlacementGroupCapacityTypeValidator,
+                    capacity_type=queue.capacity_type,
+                    placement_group_enabled=queue.is_placement_group_enabled_for_compute_resource(compute_resource),
                 )
                 # The validation below has to be in cluster config class instead of queue class
                 # to make sure the subnet APIs are cached by previous validations.

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -585,6 +585,20 @@ class CapacityReservationResourceGroupValidator(Validator):
             )
 
 
+class PlacementGroupCapacityTypeValidator(Validator):
+    """Validate the placement group is compatible with the capacity type."""
+
+    def _validate(self, capacity_type: str, placement_group_enabled: bool):
+        if capacity_type == CapacityType.CAPACITY_BLOCK and placement_group_enabled:
+            self._add_failure(
+                "When using a capacity block reservation, a placement group constraint should not be set "
+                "as insufficient capacity errors may occur due to placement constraints outside of the "
+                "reservation even if the capacity reservation has remaining capacity. "
+                "Please remove the placement group for the compute resource.",
+                FailureLevel.WARNING,
+            )
+
+
 class PlacementGroupCapacityReservationValidator(Validator):
     """Validate the placement group is compatible with the capacity reservation target."""
 

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -37,6 +37,7 @@ from pcluster.config.cluster_config import (
     SlurmSettings,
     Tag,
 )
+from pcluster.validators.ec2_validators import PlacementGroupCapacityTypeValidator
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 
 mock_compute_resources = [
@@ -381,7 +382,14 @@ class TestBaseClusterConfig:
             ),
         )
         cluster_config._register_validators()
-        assert_that(cluster_config._validators).is_not_empty()
+        actual_validators = cluster_config._validators
+        assert_that(actual_validators).is_not_empty()
+        assert_that(actual_validators).contains(
+            (
+                PlacementGroupCapacityTypeValidator().__class__,
+                {"capacity_type": CapacityType.ONDEMAND, "placement_group_enabled": False},
+            )
+        )
 
     def test_instances_in_slurm_queue(self):
         queue = SlurmQueue(


### PR DESCRIPTION
### Description of changes
Add validator to prevent the use of Placement Groups with Capacity Blocks.

### Tests
* Unit tests
* Manually verified that the validator fails with error level only when CapacityType is CAPACITY_BLOCK and a PlacementGroup section is specified for the compute resource.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
