### PR TITLE
[Linters] Pin setuptools to <70.0.0 as in cli/setup.py to prevent false positive violations on packaging module.

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -133,6 +133,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
+    setuptools<70.0.0
     pyflakes
     pylint
 commands =

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -16,6 +16,7 @@ usedevelop =
 allowlist_externals =
     bash
 deps =
+    setuptools<70.0.0
     -rtests/requirements.txt
 extras =
     awslambda
@@ -146,6 +147,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
+    setuptools<70.0.0
     pyflakes
     pylint
 commands =


### PR DESCRIPTION
### Description of changes
In PyLint setup, pin setuptools to <70.0.0 as in cli/setup.py to prevent false positive violations on packaging module.
This change fixes PyLint errors bloicking PRs (see examplehttps://github.com/aws/aws-parallelcluster/actions/runs/9649751742/job/26623514412)

### Tests
* PR checks

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
