### PR TITLE
Bump awsbatch-cli version to 1.4.0

### DIFF
--- a/awsbatch-cli/CHANGELOG.md
+++ b/awsbatch-cli/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+1.4.0
+------
+
+**ENHANCEMENTS**
+
+- Add support for Amazon Linux 2023.
+
 1.3.0
 ------
 

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -20,7 +20,7 @@ def readme():
         return f.read()
 
 
-VERSION = "1.3.0"
+VERSION = "1.4.0"
 REQUIRES = [
     "setuptools<70.0.0",
     "boto3>=1.16.14",


### PR DESCRIPTION
This is required to release new awsbatch-cli supporting alinux 2023

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
