### PR TITLE
[Test] Fix 'test_create_wrong_pcluster_version' by using 3.10.0 as wrong version.

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -58,7 +58,7 @@ def test_create_wrong_pcluster_version(
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
-    wrong_version = "3.6.1"
+    wrong_version = "3.10.0"
     logging.info("Asserting wrong_version is different from current_version")
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.


### PR DESCRIPTION
### Description of changes
Fix 'test_create_wrong_pcluster_version' by using 3.10.0 as wrong version. 

This is required because, starting with Pcluster 3.10.0, the failure for whatever AMI < 3.10.0 would be HeadNodeBootstrapFailure rather than AmiVersionMismatch.

### Tests
* ONGOING test_create_wrong_pcluster_version

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
