### PR TITLE
[Validators] Make EfaPlacementGroupValidator not suggest to set a Placement Group when Capacity Blocks are used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 
 - Add support for custom actions on login nodes.
 
+**BUG FIXES**
+- Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.
+
 3.10.1
 ------
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2639,6 +2639,7 @@ class SlurmQueue(_CommonQueue):
                 ).enabled
                 is False,
                 multi_az_enabled=self.multi_az_enabled,
+                capacity_type=self.capacity_type,
             )
             self._register_validator(
                 ComputeResourceSizeValidator,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -373,8 +373,16 @@ class EfaPlacementGroupValidator(Validator):
     """Validate placement group if EFA is enabled."""
 
     def _validate(
-        self, efa_enabled: bool, placement_group_key: str, placement_group_disabled: bool, multi_az_enabled: bool
+        self,
+        efa_enabled: bool,
+        placement_group_key: str,
+        placement_group_disabled: bool,
+        multi_az_enabled: bool,
+        capacity_type: str,
     ):
+        # Capacity Blocks do not require the configuration of a Placement Group
+        if capacity_type == CapacityType.CAPACITY_BLOCK:
+            return
         # if multi_az is enabled suggestions about PlacementGroups will be suppressed
         if efa_enabled and placement_group_disabled and not multi_az_enabled:
             self._add_failure(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -736,37 +736,66 @@ def test_efa_validator(
 
 
 @pytest.mark.parametrize(
-    "efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, expected_message",
+    "efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, capacity_type, expected_message",
     [
         # Efa disabled
-        (False, "test", False, False, None),
-        (False, "test", True, False, None),
-        (False, None, False, False, None),
-        (False, None, True, False, None),
+        (False, "test", False, False, CapacityType.ONDEMAND, None),
+        (False, "test", True, False, CapacityType.ONDEMAND, None),
+        (False, None, False, False, CapacityType.ONDEMAND, None),
+        (False, None, True, False, CapacityType.ONDEMAND, None),
+        (False, "test", False, False, CapacityType.CAPACITY_BLOCK, None),
         # Efa enabled
         (
             True,
             None,
             False,
             False,
+            CapacityType.ONDEMAND,
             "The placement group for EFA-enabled compute resources must be explicit. "
             "You may see better performance using a placement group, "
             "but if you don't wish to use one please add "
             "'Enabled: false' to the compute resource's configuration section.",
         ),
-        (True, None, True, False, "You may see better performance using a placement group for the queue."),
-        (True, "test", False, False, None),
-        (True, "test", True, False, "You may see better performance using a placement group for the queue."),
+        (
+            True,
+            None,
+            True,
+            False,
+            CapacityType.ONDEMAND,
+            "You may see better performance using a placement group for the queue.",
+        ),
+        (True, "test", False, False, CapacityType.ONDEMAND, None),
+        (
+            True,
+            "test",
+            True,
+            False,
+            CapacityType.ONDEMAND,
+            "You may see better performance using a placement group for the queue.",
+        ),
+        (
+            True,
+            None,
+            False,
+            False,
+            CapacityType.CAPACITY_BLOCK,
+            None,
+        ),
         # EFA and MultiAZ enabled
-        (True, "test", False, True, None),
-        (True, "test", True, True, None),
+        (True, "test", False, True, CapacityType.ONDEMAND, None),
+        (True, "test", True, True, CapacityType.ONDEMAND, None),
+        (True, "test", True, True, CapacityType.CAPACITY_BLOCK, None),
     ],
 )
 def test_efa_placement_group_validator(
-    efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, expected_message
+    efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, capacity_type, expected_message
 ):
     actual_failures = EfaPlacementGroupValidator().execute(
-        efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled
+        efa_enabled,
+        placement_group_key,
+        placement_group_disabled,
+        multi_az_enabled,
+        capacity_type,
     )
 
     assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
### Description of changes
Make EfaPlacementGroupValidator not suggest to set a Placement Group when Capacity Blocks are used.

### Tests
* Manually tested that no warning is returned by the validator EfaPlacementGroupValidator when capacity blocks are used.
* Unit tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
