### PR TITLE
[BuildImage] Fix AWS URL suffix to retrieve gems.tgz from S3 from ParallelCluster component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ CHANGELOG
 
 - Add support for custom actions on login nodes.
 
+3.10.1
+------
+
+**BUG FIXES**
+- Fix image build failure in China regions.
+
 3.10.0
 ------
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -221,7 +221,7 @@ phases:
                 ln -sf ${!CA_CERTS_FILE} /opt/cinc/embedded/ssl/certs/cacert.pem
               fi
               
-              curl --retry 3 -L -o gems.tgz https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/archives/dependencies/ruby/gems.tgz
+              curl --retry 3 -L -o gems.tgz https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/archives/dependencies/ruby/gems.tgz
               tar -xf gems.tgz
               
               cd vendor/cache


### PR DESCRIPTION
### Description of changes
Fix AWS URL suffix to retrieve gems.tgz from S3 from ParallelCluster component.
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6330


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
