### PR TITLE
Add permissions to Github workflows to bump version

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   create-pull-requests:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/bump_version_awsbatch_cli.yml
+++ b/.github/workflows/bump_version_awsbatch_cli.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   create-pull-requests:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
On personal repos, Github workflows have write permission by default. However, on team account repos, Github workflows do not have write permission. Therefore, this commit grant permission to the workflow.

See details of Github workflow permissions https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
