### PR TITLE
[Test] Fix 'test_custom_image'

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -44,7 +44,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
                       [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
                       [--no-delete] [--retain-ad-stack] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
-                      [--bucket-name BUCKET_NAME] [--proxy-stack PROXY_STACK_NAME]
+                      [--bucket-name BUCKET_NAME] [--proxy-stack PROXY_STACK_NAME] [--build-image-roles-stack BUILD_IMAGE_ROLES_STACK_NAME] [--api-stack API_STACK_NAME]
 
 Run integration tests suite.
 
@@ -178,6 +178,10 @@ Debugging/Development options:
                         Name of an existing bucket. (default: None)
   --proxy-stack
                         Name of an existing proxy stack. (default: None)
+  --build-image-roles-stack
+                        Name of CFN stack providing the build image permissions. (default: None)
+  --api-stack
+                        Name of CFN stack providing the ParallelCluster API infrastructure. (default: None)
 ```
 
 Here is an example of tests submission:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -214,6 +214,14 @@ def pytest_addoption(parser):
         "--proxy-stack",
         help="Name of CFN stack providing a Proxy environment.",
     )
+    parser.addoption(
+        "--build-image-roles-stack",
+        help="Name of CFN stack providing the build image permissions.",
+    )
+    parser.addoption(
+        "--api-stack",
+        help="Name of CFN stack providing the ParallelCluster API infrastructure.",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -414,38 +422,44 @@ def api_server_factory(
     api_servers = {}
 
     def _api_server_factory(server_region):
-        api_stack_name = generate_stack_name("integ-tests-api", request.config.getoption("stackname_suffix"))
-
-        params = [
-            {"ParameterKey": "EnableIamAdminAccess", "ParameterValue": "true"},
-            {"ParameterKey": "CreateApiUserRole", "ParameterValue": "false"},
-        ]
-        if api_definition_s3_uri:
-            params.append({"ParameterKey": "ApiDefinitionS3Uri", "ParameterValue": api_definition_s3_uri})
-        if policies_uri:
-            params.append({"ParameterKey": "PoliciesTemplateUri", "ParameterValue": policies_uri})
-        if resource_bucket:
-            params.append({"ParameterKey": "CustomBucket", "ParameterValue": resource_bucket})
-
-        template = (
-            api_infrastructure_s3_uri
-            or f"https://{resource_bucket}.s3.{server_region}.amazonaws.com"
-            f"{'.cn' if server_region.startswith('cn') else ''}"
-            f"/parallelcluster/{get_installed_parallelcluster_version()}/api/parallelcluster-api.yaml"
-        )
-        if server_region not in api_servers:
-            logging.info(f"Creating API Server stack: {api_stack_name} in {server_region} with template {template}")
-            stack = CfnStack(
-                name=api_stack_name,
-                region=server_region,
-                parameters=params,
-                capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
-                template=template,
-            )
-            cfn_stacks_factory.create_stack(stack)
-            api_servers[server_region] = stack
+        option = "api_stack"
+        if request.config.getoption(option):
+            api_stack_name = request.config.getoption(option)
+            logging.info(f"Using existing ParallelCluster API stack in {server_region}: {api_stack_name}")
+            api_servers[server_region] = CfnStack(name=api_stack_name, region=server_region, template=None)
         else:
-            logging.info(f"Found cached API Server stack: {api_stack_name} in {server_region}")
+            api_stack_name = generate_stack_name("integ-tests-api", request.config.getoption("stackname_suffix"))
+
+            params = [
+                {"ParameterKey": "EnableIamAdminAccess", "ParameterValue": "true"},
+                {"ParameterKey": "CreateApiUserRole", "ParameterValue": "false"},
+            ]
+            if api_definition_s3_uri:
+                params.append({"ParameterKey": "ApiDefinitionS3Uri", "ParameterValue": api_definition_s3_uri})
+            if policies_uri:
+                params.append({"ParameterKey": "PoliciesTemplateUri", "ParameterValue": policies_uri})
+            if resource_bucket:
+                params.append({"ParameterKey": "CustomBucket", "ParameterValue": resource_bucket})
+
+            template = (
+                api_infrastructure_s3_uri
+                or f"https://{resource_bucket}.s3.{server_region}.amazonaws.com"
+                f"{'.cn' if server_region.startswith('cn') else ''}"
+                f"/parallelcluster/{get_installed_parallelcluster_version()}/api/parallelcluster-api.yaml"
+            )
+            if server_region not in api_servers:
+                logging.info(f"Creating API Server stack: {api_stack_name} in {server_region} with template {template}")
+                stack = CfnStack(
+                    name=api_stack_name,
+                    region=server_region,
+                    parameters=params,
+                    capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+                    template=template,
+                )
+                cfn_stacks_factory.create_stack(stack)
+                api_servers[server_region] = stack
+            else:
+                logging.info(f"Found cached API Server stack: {api_stack_name} in {server_region}")
 
         return api_servers[server_region]
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -70,6 +70,7 @@ TEST_DEFAULTS = {
     "api_uri": None,
     "cluster": None,
     "policies_uri": None,
+    "api_stack": None,
     "api_definition_s3_uri": None,
     "api_infrastructure_s3_uri": None,
     "no_delete": False,
@@ -99,6 +100,7 @@ TEST_DEFAULTS = {
     "retain_ad_stack": False,
     "global_build_number": 0,
     "proxy_stack": None,
+    "build_image_roles_stack": None,
 }
 
 
@@ -461,6 +463,16 @@ def _init_argparser():
         help="Name of CFN stack providing a Proxy environment.",
         default=TEST_DEFAULTS.get("proxy_stack"),
     )
+    debug_group.add_argument(
+        "--build-image-roles-stack",
+        help="Name of CFN stack providing build image permissions.",
+        default=TEST_DEFAULTS.get("build_image_roles_stack"),
+    )
+    debug_group.add_argument(
+        "--api-stack",
+        help="Name of CFN stack providing the ParallelCluster API infrastructure.",
+        default=TEST_DEFAULTS.get("api_stack"),
+    )
 
     return parser
 
@@ -684,6 +696,12 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.proxy_stack:
         pytest_args.extend(["--proxy-stack", args.proxy_stack])
+
+    if args.build_image_roles_stack:
+        pytest_args.extend(["--build-image-roles-stack", args.build_image_roles_stack])
+
+    if args.api_stack:
+        pytest_args.extend(["--api-stack", args.api_stack])
 
 
 def _set_validate_instance_type_args(args, pytest_args):

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
@@ -1,4 +1,6 @@
 Build:
+  Iam:
+    CleanupLambdaRole: {{ cleanup_lambda_role }}
   InstanceType: {{ instance }}
   ParentImage: {{ parent_image }}
   UpdateOsPackages:


### PR DESCRIPTION
### Description of changes
Fix 'test_custom_image' by setting the CleanupLambdaRole to prevent stack deletion failures caused by known cloudFormation issue. This is the mitigation suggested to our users https://github.com/aws/aws-parallelcluster/wiki/(3.0.0%E2%80%903.10.1)-Build-image-CloudFormation-stacks-fail-to-delete-after-images-are-successfully-built.

Also added two new test runner options to consume existing PCAPI stack and build-image roles stack.

### Tests
* SUCCEEDED test_custom_image

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
