### PR TITLE
Fix sporadic cluster creation failure with ParallelCluster managed FSx Lustre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.
+- Fix sporadic cluster creation failures with managed FSx for Lustre.
 
 3.10.1
 ------

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -960,53 +960,7 @@ class ClusterCdkStack:
             if isinstance(shared_fsx, ExistingFileCache):
                 mount_name = shared_fsx.file_cache_mount_name
         else:
-            # Drive cache type must be set for HDD (Either "NONE" or "READ"), and must not be set for SDD (None).
-            drive_cache_type = None
-            if shared_fsx.fsx_storage_type == "HDD":
-                if shared_fsx.drive_cache_type:
-                    drive_cache_type = shared_fsx.drive_cache_type
-                else:
-                    drive_cache_type = "NONE"
-            file_system_security_group, security_group_rules = self._add_storage_security_group(id, shared_fsx)
-            fsx_resource = fsx.CfnFileSystem(
-                self.stack,
-                id,
-                storage_capacity=shared_fsx.storage_capacity,
-                lustre_configuration=fsx.CfnFileSystem.LustreConfigurationProperty(
-                    deployment_type=shared_fsx.deployment_type,
-                    data_compression_type=shared_fsx.data_compression_type,
-                    imported_file_chunk_size=shared_fsx.imported_file_chunk_size,
-                    export_path=shared_fsx.export_path,
-                    import_path=shared_fsx.import_path,
-                    weekly_maintenance_start_time=shared_fsx.weekly_maintenance_start_time,
-                    automatic_backup_retention_days=shared_fsx.automatic_backup_retention_days,
-                    copy_tags_to_backups=shared_fsx.copy_tags_to_backups,
-                    daily_automatic_backup_start_time=shared_fsx.daily_automatic_backup_start_time,
-                    per_unit_storage_throughput=shared_fsx.per_unit_storage_throughput,
-                    auto_import_policy=shared_fsx.auto_import_policy,
-                    drive_cache_type=drive_cache_type,
-                ),
-                backup_id=shared_fsx.backup_id,
-                kms_key_id=shared_fsx.kms_key_id,
-                file_system_type=LUSTRE,
-                storage_type=shared_fsx.fsx_storage_type,
-                subnet_ids=self.config.compute_subnet_ids[0:1],
-                security_group_ids=[file_system_security_group.ref],
-                file_system_type_version=shared_fsx.file_system_type_version,
-                tags=[CfnTag(key="Name", value=shared_fsx.name)],
-            )
-            for rule in security_group_rules:
-                fsx_resource.add_depends_on(rule)
-            fsx_resource.cfn_options.deletion_policy = fsx_resource.cfn_options.update_replace_policy = (
-                convert_deletion_policy(shared_fsx.deletion_policy)
-            )
-
-            fsx_id = fsx_resource.ref
-
-            self._add_dra(fsx_id, shared_fsx)
-
-            # Get MountName for new filesystem. DNSName cannot be retrieved from CFN and will be generated in cookbook
-            mount_name = fsx_resource.attr_lustre_mount_name
+            fsx_id, mount_name = self._add_managed_fsx(fsx_id, id, mount_name, shared_fsx)
 
         self.shared_storage_attributes[shared_fsx.shared_storage_type]["DNSNames"].append(dns_name)
         self.shared_storage_attributes[shared_fsx.shared_storage_type]["MountNames"].append(mount_name)
@@ -1018,6 +972,53 @@ class ClusterCdkStack:
         )
 
         return fsx_id
+
+    def _add_managed_fsx(self, fsx_id, id, mount_name, shared_fsx):
+        # Drive cache type must be set for HDD (Either "NONE" or "READ"), and must not be set for SDD (None).
+        drive_cache_type = None
+        if shared_fsx.fsx_storage_type == "HDD":
+            if shared_fsx.drive_cache_type:
+                drive_cache_type = shared_fsx.drive_cache_type
+            else:
+                drive_cache_type = "NONE"
+        file_system_security_group, security_group_rules = self._add_storage_security_group(id, shared_fsx)
+        fsx_resource = fsx.CfnFileSystem(
+            self.stack,
+            id,
+            storage_capacity=shared_fsx.storage_capacity,
+            lustre_configuration=fsx.CfnFileSystem.LustreConfigurationProperty(
+                deployment_type=shared_fsx.deployment_type,
+                data_compression_type=shared_fsx.data_compression_type,
+                imported_file_chunk_size=shared_fsx.imported_file_chunk_size,
+                export_path=shared_fsx.export_path,
+                import_path=shared_fsx.import_path,
+                weekly_maintenance_start_time=shared_fsx.weekly_maintenance_start_time,
+                automatic_backup_retention_days=shared_fsx.automatic_backup_retention_days,
+                copy_tags_to_backups=shared_fsx.copy_tags_to_backups,
+                daily_automatic_backup_start_time=shared_fsx.daily_automatic_backup_start_time,
+                per_unit_storage_throughput=shared_fsx.per_unit_storage_throughput,
+                auto_import_policy=shared_fsx.auto_import_policy,
+                drive_cache_type=drive_cache_type,
+            ),
+            backup_id=shared_fsx.backup_id,
+            kms_key_id=shared_fsx.kms_key_id,
+            file_system_type=LUSTRE,
+            storage_type=shared_fsx.fsx_storage_type,
+            subnet_ids=self.config.compute_subnet_ids[0:1],
+            security_group_ids=[file_system_security_group.ref],
+            file_system_type_version=shared_fsx.file_system_type_version,
+            tags=[CfnTag(key="Name", value=shared_fsx.name)],
+        )
+        for rule in security_group_rules:
+            fsx_resource.add_depends_on(rule)
+        fsx_resource.cfn_options.deletion_policy = fsx_resource.cfn_options.update_replace_policy = (
+            convert_deletion_policy(shared_fsx.deletion_policy)
+        )
+        fsx_id = fsx_resource.ref
+        self._add_dra(fsx_id, shared_fsx)
+        # Get MountName for new filesystem. DNSName cannot be retrieved from CFN and will be generated in cookbook
+        mount_name = fsx_resource.attr_lustre_mount_name
+        return fsx_id, mount_name
 
     def _add_dra(self, fsx_id: str, shared_fsx: BaseSharedFsx):
         """Add Cfn Data Repository Association Resources."""


### PR DESCRIPTION
### Description of changes
The issue: https://github.com/aws/aws-parallelcluster/issues/6181
This is done by adding "dependsOn"s to ensure Lustre file system is created after security group rules.
Reviewing changes by commits is easier

### Tests
Following tests are passed:
```
{%- import 'common.jinja2' as common with context -%}
{{- common.OSS_COMMERCIAL_ARM.append("centos7") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
---
test-suites:
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_fsx_lustre_dra:
      dimensions:
        - regions: [ "eu-west-2" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2023" ]
          schedulers: [ "slurm" ]
    test_fsx_lustre.py::test_file_cache:
      dimensions:
        - regions: [ "eu-north-1" ]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: [ "alinux2023" ]
          schedulers: [ "slurm" ]
    # The checks performed in test_multiple_fsx is the same as test_fsx_lustre.
    # We should consider this when assigning dimensions to each test.
    test_fsx_lustre.py::test_multiple_fsx:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_multi_az_fsx:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_fsx_lustre_configuration_options:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_fsx_lustre_backup:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
```

### References
The issue: https://github.com/aws/aws-parallelcluster/issues/6181

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
