### PR TITLE
Fix code linter for AWSBatch CLI code

### DIFF
--- a/awsbatch-cli/src/awsbatch/awsbhosts.py
+++ b/awsbatch-cli/src/awsbatch/awsbhosts.py
@@ -185,7 +185,6 @@ class AWSBhostsCommand:
             )
         except KeyError as e:
             fail("Error building Host item. Key (%s) not found." % e)
-            return None
 
     @staticmethod
     def __get_instance_attribute(attributes, attribute_name):

--- a/awsbatch-cli/src/awsbatch/awsbqueues.py
+++ b/awsbatch-cli/src/awsbatch/awsbqueues.py
@@ -127,7 +127,6 @@ class AWSBqueuesCommand:
             )
         except KeyError as e:
             fail("Error building Queue item. Key (%s) not found." % e)
-            return None
 
 
 def main():


### PR DESCRIPTION
This code was introduced by https://github.com/aws/aws-parallelcluster/pull/5703. Newer version of linters start to produce errors (e.g. https://github.com/aws/aws-parallelcluster/actions/runs/9879177934/job/27284833751?pr=6342)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
