### PR TITLE
[integ-tests] Fix test_create_wrong_pcluster_version

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -58,7 +58,7 @@ def test_create_wrong_pcluster_version(
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
-    wrong_version = "3.6.1"
+    wrong_version = "3.10.0"
     logging.info("Asserting wrong_version is different from current_version")
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.


### PR DESCRIPTION
The failure was not signaled to CloudFormation via cfn-signal with version 3.6.1 because of this change https://github.com/aws/aws-parallelcluster/commit/aeb87fc9a7c453d18b470aa97abfa1e93b321979. In particular, for whatever version<3.10.0 the envar $CFN_BOOTSTRAP_VIRTUALENV_PATH is not set and so the cfn-signal command is not resolved.

Therefore, we change the version to 3.10.0 vs 3.11.0 to make ``$CFN_BOOTSTRAP_VIRTUALENV_PATH` setup consistent.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
