### PR TITLE
Move LT bootstrap log under /dev/ttyS0 instead of /dev/console

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -49,7 +49,7 @@ repo_upgrade: none
 datasource_list: [ Ec2, None ]
 
 output:
-  all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
+  all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
   - path: /tmp/bootstrap.sh
     permissions: '0744'

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -46,7 +46,7 @@ repo_upgrade: none
 datasource_list: [ Ec2, None ]
 
 output:
-  all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
+  all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
   - path: /tmp/bootstrap.sh
     permissions: '0744'


### PR DESCRIPTION
RedHat 9 does not report logs in the console when they are logged under /dev/console. While it does when they are sent to /dev/ttyS0. Also the other OS work with this new configuration

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
