### PR TITLE
Upgrade RDS DB cluster to 8.0.mysql_aurora.3.07.0

### DIFF
--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -268,7 +268,7 @@ Resources:
     Properties:
       DBClusterIdentifier: !Ref ClusterName
       Engine: "aurora-mysql"
-      EngineVersion: "8.0.mysql_aurora.3.03.0"
+      EngineVersion: "8.0"
       CopyTagsToSnapshot: true
       DBClusterParameterGroupName: !Ref AccountingClusterParameterGroup
       DBSubnetGroupName: !Ref AccountingClusterSubnetGroup


### PR DESCRIPTION
8.0.mysql_aurora.3.03.0 is reaching end of life on August 15, 2024. See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.30Updates.html

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
