### PR TITLE
Add EFS access point support (aws-parallelcluster#2337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **ENHANCEMENTS**
 
 - Add support for custom actions on login nodes.
+- Add new configuration `SharedStorage/EfsSettings/AccessPointId` to specify an optional EFS access point for a mount
 
 **BUG FIXES**
 - Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.

--- a/cli/src/pcluster/aws/efs.py
+++ b/cli/src/pcluster/aws/efs.py
@@ -80,3 +80,14 @@ class EfsClient(Boto3Client):
         :return: the mount_target_ids
         """
         return self._client.describe_file_systems(FileSystemId=efs_fs_id)
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def describe_access_point(self, access_point_id):
+        """
+        Describe access point attributes for the given EFS access point id.
+
+        :param efaccess_point_ids_ap_id: EFS access point Id
+        :return: the access_point details
+        """
+        return self._client.describe_access_points(AccessPointId=access_point_id)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -371,7 +371,7 @@ class SharedEfs(Resource):
         deletion_policy: str = None,
         encryption_in_transit: bool = None,
         iam_authorization: bool = None,
-        accesspoint_id: str = None,
+        access_point_id: str = None,
     ):
         super().__init__()
         self.mount_dir = Resource.init_param(mount_dir)
@@ -388,7 +388,7 @@ class SharedEfs(Resource):
         )
         self.encryption_in_transit = Resource.init_param(encryption_in_transit, default=False)
         self.iam_authorization = Resource.init_param(iam_authorization, default=False)
-        self.accesspoint_id = Resource.init_param(accesspoint_id)
+        self.access_point_id = Resource.init_param(access_point_id)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(SharedStorageNameValidator, name=self.name)
@@ -400,7 +400,7 @@ class SharedEfs(Resource):
             EfsMountOptionsValidator,
             encryption_in_transit=self.encryption_in_transit,
             iam_authorization=self.iam_authorization,
-            accesspoint_id=self.accesspoint_id,
+            access_point_id=self.access_point_id,
             name=self.name,
         )
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -371,6 +371,7 @@ class SharedEfs(Resource):
         deletion_policy: str = None,
         encryption_in_transit: bool = None,
         iam_authorization: bool = None,
+        accesspoint_id: str = None,
     ):
         super().__init__()
         self.mount_dir = Resource.init_param(mount_dir)
@@ -387,6 +388,7 @@ class SharedEfs(Resource):
         )
         self.encryption_in_transit = Resource.init_param(encryption_in_transit, default=False)
         self.iam_authorization = Resource.init_param(iam_authorization, default=False)
+        self.accesspoint_id = Resource.init_param(accesspoint_id)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(SharedStorageNameValidator, name=self.name)
@@ -398,6 +400,7 @@ class SharedEfs(Resource):
             EfsMountOptionsValidator,
             encryption_in_transit=self.encryption_in_transit,
             iam_authorization=self.iam_authorization,
+            accesspoint_id=self.accesspoint_id,
             name=self.name,
         )
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -321,6 +321,9 @@ class EfsSettingsSchema(BaseSchema):
     deletion_policy = fields.Str(
         validate=validate.OneOf(DELETION_POLICIES), metadata={"update_policy": UpdatePolicy.SUPPORTED}
     )
+    accesspoint_id = fields.Str(
+        validate=validate.Regexp(r"^fsap-[0-9a-z]{17}$"),
+    )
     encryption_in_transit = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     iam_authorization = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
@@ -331,7 +334,7 @@ class EfsSettingsSchema(BaseSchema):
         messages = []
         if data.get("file_system_id") is not None:
             for key in data:
-                if key is not None and key not in ["encryption_in_transit", "iam_authorization", "file_system_id"]:
+                if key is not None and key not in ["encryption_in_transit", "iam_authorization", "file_system_id", "accesspoint_id"]:
                     messages.append(EFS_MESSAGES["errors"]["ignored_param_with_efs_fs_id"].format(efs_param=key))
             if messages:
                 raise ValidationError(message=messages)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -321,8 +321,8 @@ class EfsSettingsSchema(BaseSchema):
     deletion_policy = fields.Str(
         validate=validate.OneOf(DELETION_POLICIES), metadata={"update_policy": UpdatePolicy.SUPPORTED}
     )
-    accesspoint_id = fields.Str(
-        validate=validate.Regexp(r"^fsap-[0-9a-z]{17}$"),
+    access_point_id = fields.Str(
+        validate=validate.Regexp(r"^fsap-[0-9a-z]{17}$"), metadata={"update_policy": UpdatePolicy.SUPPORTED}
     )
     encryption_in_transit = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     iam_authorization = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
@@ -334,7 +334,12 @@ class EfsSettingsSchema(BaseSchema):
         messages = []
         if data.get("file_system_id") is not None:
             for key in data:
-                if key is not None and key not in ["encryption_in_transit", "iam_authorization", "file_system_id", "accesspoint_id"]:
+                if key is not None and key not in [
+                    "encryption_in_transit",
+                    "iam_authorization",
+                    "file_system_id",
+                    "access_point_id"
+                ]:
                     messages.append(EFS_MESSAGES["errors"]["ignored_param_with_efs_fs_id"].format(efs_param=key))
             if messages:
                 raise ValidationError(message=messages)

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1109,7 +1109,7 @@ class ClusterCdkStack:
             shared_efs.encryption_in_transit
         )
         self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"].append(shared_efs.iam_authorization)
-        self.shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"].append(shared_efs.accesspoint_id)
+        self.shared_storage_attributes[SharedStorageType.EFS]["AccessPointIds"].append(shared_efs.access_point_id)
 
         return efs_id
 
@@ -1289,8 +1289,8 @@ class ClusterCdkStack:
                     "efs_iam_authorizations": to_comma_separated_string(
                         self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"], use_lower_case=True
                     ),
-                    "efs_accesspoint_ids": to_comma_separated_string(
-                        self.shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                    "efs_access_point_ids": to_comma_separated_string(
+                        self.shared_storage_attributes[SharedStorageType.EFS]["AccessPointIds"],
                         use_lower_case=True,
                     ),
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.FSX),

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1109,6 +1109,7 @@ class ClusterCdkStack:
             shared_efs.encryption_in_transit
         )
         self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"].append(shared_efs.iam_authorization)
+        self.shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"].append(shared_efs.accesspoint_id)
 
         return efs_id
 
@@ -1287,6 +1288,10 @@ class ClusterCdkStack:
                     ),
                     "efs_iam_authorizations": to_comma_separated_string(
                         self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"], use_lower_case=True
+                    ),
+                    "efs_accesspoint_ids": to_comma_separated_string(
+                        self.shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                        use_lower_case=True,
                     ),
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.FSX),
                     "fsx_mount_names": to_comma_separated_string(

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -235,8 +235,8 @@ class Pool(Construct):
                         self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
                         use_lower_case=True,
                     ),
-                    "efs_accesspoint_ids": to_comma_separated_string(
-                        self._shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                    "efs_access_point_ids": to_comma_separated_string(
+                        self._shared_storage_attributes[SharedStorageType.EFS]["AccessPointIds"],
                         use_lower_case=True,
                     ),
                     "enable_intel_hpc_platform": "true" if self._config.is_intel_hpc_platform_enabled else "false",

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -235,6 +235,10 @@ class Pool(Construct):
                         self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
                         use_lower_case=True,
                     ),
+                    "efs_accesspoint_ids": to_comma_separated_string(
+                        self._shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                        use_lower_case=True,
+                    ),
                     "enable_intel_hpc_platform": "true" if self._config.is_intel_hpc_platform_enabled else "false",
                     "ephemeral_dir": DEFAULT_EPHEMERAL_DIR,
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self._shared_storage_infos, SharedStorageType.FSX),

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -335,8 +335,8 @@ class QueuesStack(NestedStack):
                         self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
                         use_lower_case=True,
                     ),
-                    "efs_accesspoint_ids": to_comma_separated_string(
-                        self._shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                    "efs_access_point_ids": to_comma_separated_string(
+                        self._shared_storage_attributes[SharedStorageType.EFS]["AccessPointIds"],
                         use_lower_case=True,
                     ),
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self._shared_storage_infos, SharedStorageType.FSX),

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -335,6 +335,10 @@ class QueuesStack(NestedStack):
                         self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
                         use_lower_case=True,
                     ),
+                    "efs_accesspoint_ids": to_comma_separated_string(
+                        self._shared_storage_attributes[SharedStorageType.EFS]["AccesspointIds"],
+                        use_lower_case=True,
+                    ),
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self._shared_storage_infos, SharedStorageType.FSX),
                     "fsx_mount_names": to_comma_separated_string(
                         self._shared_storage_attributes[SharedStorageType.FSX]["MountNames"]

--- a/cli/src/pcluster/validators/efs_validators.py
+++ b/cli/src/pcluster/validators/efs_validators.py
@@ -18,7 +18,7 @@ class EfsMountOptionsValidator(Validator):
     IAM Authorization requires Encryption in Transit.
     """
 
-    def _validate(self, encryption_in_transit: bool, iam_authorization: bool, name: str):
+    def _validate(self, encryption_in_transit: bool, iam_authorization: bool, accesspoint_id: str, name: str):
         if iam_authorization and not encryption_in_transit:
             self._add_failure(
                 "EFS IAM authorization cannot be enabled when encryption in-transit is disabled. "

--- a/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
+++ b/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
@@ -296,7 +296,7 @@ class Pcluster3ConfigConverter(object):
                 ("efs_kms_key_id", "KmsKeyId"),
                 ("provisioned_throughput", "ProvisionedThroughput", "getint"),
                 ("throughput_mode", "ThroughputMode"),
-                ("accesspoint_id", "AccesspointId"),
+                ("access_point_id", "AccessPointId"),
             ]
             efs_section, efs_dict, _section_label = self.convert_storage_base(
                 "efs", efs_label.strip(), additional_items

--- a/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
+++ b/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
@@ -296,6 +296,7 @@ class Pcluster3ConfigConverter(object):
                 ("efs_kms_key_id", "KmsKeyId"),
                 ("provisioned_throughput", "ProvisionedThroughput", "getint"),
                 ("throughput_mode", "ThroughputMode"),
+                ("accesspoint_id", "AccesspointId"),
             ]
             efs_section, efs_dict, _section_label = self.convert_storage_base(
                 "efs", efs_label.strip(), additional_items

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
@@ -20,6 +20,7 @@
     "efs_fs_ids": "",
     "efs_iam_authorizations": "",
     "efs_shared_dirs": "",
+    "efs_access_point_ids": "",
     "enable_intel_hpc_platform": "false",
     "ephemeral_dir": "/scratch",
     "fsx_dns_names": "",

--- a/cli/tests/pcluster/templates/test_login_nodes_stack/test_login_nodes_dna_json/dna-1.json
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack/test_login_nodes_dna_json/dna-1.json
@@ -22,6 +22,7 @@
     "efs_fs_ids": "",
     "efs_iam_authorizations": "",
     "efs_shared_dirs": "",
+    "efs_access_point_ids": "",
     "enable_intel_hpc_platform": "false",
     "ephemeral_dir": "/scratch",
     "fsx_dns_names": "",

--- a/cli/tests/pcluster/templates/test_login_nodes_stack/test_login_nodes_dna_json/dna-2.json
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack/test_login_nodes_dna_json/dna-2.json
@@ -22,6 +22,7 @@
     "efs_fs_ids": "",
     "efs_iam_authorizations": "",
     "efs_shared_dirs": "",
+    "efs_access_point_ids": "",
     "enable_intel_hpc_platform": "false",
     "ephemeral_dir": "/scratch",
     "fsx_dns_names": "",

--- a/cli/tests/pcluster/templates/test_queues_stack/test_compute_nodes_dna_json/dna-1.json
+++ b/cli/tests/pcluster/templates/test_queues_stack/test_compute_nodes_dna_json/dna-1.json
@@ -20,6 +20,7 @@
     "efs_fs_ids": "",
     "efs_iam_authorizations": "",
     "efs_shared_dirs": "",
+    "efs_access_point_ids": "",
     "enable_efa": "NONE",
     "enable_efa_gdr": "NONE",
     "enable_intel_hpc_platform": "false",

--- a/cli/tests/pcluster/templates/test_queues_stack/test_compute_nodes_dna_json/dna-2.json
+++ b/cli/tests/pcluster/templates/test_queues_stack/test_compute_nodes_dna_json/dna-2.json
@@ -20,6 +20,7 @@
     "efs_fs_ids": "",
     "efs_iam_authorizations": "",
     "efs_shared_dirs": "",
+    "efs_access_point_ids": "",
     "enable_efa": "NONE",
     "enable_efa_gdr": "NONE",
     "enable_intel_hpc_platform": "false",


### PR DESCRIPTION
### Description of changes
Add support to specify EFS access points per issue aws/aws-parallelcluster#2337

### Tests
Tested mounting EFS with and without accesspoints from an aws-parallelcluster cluster.

**More tests to be done but opening a draft PR for discussion and early feedback**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
