### PR TITLE
[Dependencies] Upgrade setuptools to >= 70.0.0

### DIFF
--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -22,7 +22,7 @@ def readme():
 
 VERSION = "1.4.0"
 REQUIRES = [
-    "setuptools<70.0.0",
+    "setuptools>=70.0.0",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
 ]

--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -133,7 +133,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
-    setuptools<70.0.0
+    setuptools>=70.0.0
     pyflakes
     pylint
 commands =

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -23,7 +23,7 @@ def readme():
 VERSION = "3.11.0"
 CDK_VERSION = "1.164"
 REQUIRES = [
-    "setuptools<70.0.0",
+    "setuptools>=70.0.0",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
     "PyYAML>=5.3.1,!=5.4",

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -16,7 +16,7 @@ usedevelop =
 allowlist_externals =
     bash
 deps =
-    setuptools<70.0.0
+    setuptools>=70.0.0
     -rtests/requirements.txt
 extras =
     awslambda
@@ -147,7 +147,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
-    setuptools<70.0.0
+    setuptools>=70.0.0,<71.0.0
     pyflakes
     pylint
 commands =

--- a/cloudformation/external-slurmdbd/requirements.txt
+++ b/cloudformation/external-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
-setuptools<70.0.0
+setuptools>=70.0.0
 aws-cdk-lib~=2.105
 constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
### Description of changes
Upgrade setuptools from 69.5.1 to to >= 70.0.0 to mitigate the below vulns:
1. https://github.com/aws/aws-parallelcluster/security/dependabot/12
2. https://github.com/aws/aws-parallelcluster/security/dependabot/11
3. https://github.com/aws/aws-parallelcluster/security/dependabot/10

### Tests
PR checks

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
