### PR TITLE
[Develop] Fix cluster deletion failure when placement groups are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 **BUG FIXES**
 - Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.
 - Fix sporadic cluster creation failures with managed FSx for Lustre.
+- Fix cluster deletion failure when placement group is enabled.
 
 3.10.1
 ------

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
@@ -117,10 +117,31 @@ def _terminate_cluster_nodes(event):
                         logger.error("Failed when terminating instances with error %s", e)
                         completed_successfully = False
                         continue
-        logger.info("Compute fleet clean-up: COMPLETED. Instances are either in shutting-down or terminated state")
+            logger.info("Sleeping for 10 seconds to allow all instances to initiate shut-down")
+            time.sleep(10)
+
+        while _has_shuttingdown_instances(stack_name):
+            logger.info("Waiting for all nodes to shut-down...")
+            time.sleep(10)
+
+        # Sleep for 30 more seconds to give PlacementGroups the time to update
+        time.sleep(30)
+
+        logger.info("Compute fleet clean-up: COMPLETED")
     except Exception as e:
         logger.error("Failed when terminating instances with error %s", e)
         raise
+
+
+def _has_shuttingdown_instances(stack_name):
+    ec2 = boto3.client("ec2", config=boto3_config)
+    filters = [
+        {"Name": "tag:parallelcluster:cluster-name", "Values": [stack_name]},
+        {"Name": "instance-state-name", "Values": ["shutting-down"]},
+    ]
+
+    result = ec2.describe_instances(Filters=filters)
+    return len(result.get("Reservations", [])) > 0
 
 
 def _describe_instance_ids_iterator(stack_name, instance_state=("pending", "running", "stopping", "stopped")):


### PR DESCRIPTION
### Description of changes
* Add back the logic of waiting for nodes shut-down and placement group update.
* Prevents Lambda function from timing out if instance termination exceeds 15 minutes.
* Original: The cluster will fail to delete when PlacementGroups are enabled
* After Revert: The cluster have potential deletion fail risk when customers are using `trn1` and `trn1n` instance type. (These instance types' termination time exceeded 15 minutes, caused lambda function timeout error before. But now in the test they are good.)
* Now: The cluster only have potential deletion fail risk when PlacementGroups are enabled and customers are using `trn1` and `trn1n` instance type at the same time. Customers can simply re-run the deletion after 5 minutes to delete.
* Note: It's important to note that instances in a shutting-down state are not recoverable and are not billed during this period.

### References
* This PR can address https://github.com/aws/aws-parallelcluster/issues/6329
* This https://github.com/aws/aws-parallelcluster/pull/6169 PR caused if we enable placement group, the cluster deletion will fail. Fail message:
`The placement group 'test1-ComputeFleetQueuesNestedStackQueuesNestedStackResource4C142E85-KWDIYNRLWKYM-PlacementGroupBb4e614a3a68fa43-JTRVLZ06WEVN' is in use and may not be deleted. (Service: Ec2, Status Code: 400, Request ID: 8602aa29-8b27-4541-ab98-d378ec4ce8e4)`
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html

### Tests
* Locally tests passed. Even using `trn1`, the deletion succeed. seems like not in all situation the shutting-down time of `trn1` and `trn1n` instance type exceeds 15 minutes. 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
