### PR TITLE
[LoginNodes] Improve login node security posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ CHANGELOG
 - Add support for custom actions on login nodes.
 - Allow DCV connection on login nodes.
 - Add support for ap-southeast-3 region.
+- Add security groups to login node network load balancer.
+- Add `AllowedIps` configuration for login nodes.
 
 **BUG FIXES**
 - Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.
 - Fix sporadic cluster creation failures with managed FSx for Lustre.
+- Fix issue with login nodes being marked unhealthy when restricting SSH access.
 - Fix `retrieve_supported_regions` so that it can get the correct S3 url.
-
 3.10.1
 ------
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -835,7 +835,7 @@ class LoginNodesSsh(_BaseSsh):
 
     def __init__(self, allowed_ips: str = None, **kwargs):
         super().__init__(**kwargs)
-        # If allowed IPs is not specified for the login node pool, will be aligned with the setting defined
+        # If AllowedIPs is not specified for the login node pool, then allowed_ips will default to the same settings
         # in the HeadNode to restrict SSH access from a specific CIDR or prefix-list.
         self.allowed_ips = Resource.init_param(allowed_ips)
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -833,13 +833,11 @@ class HeadNodeSsh(_BaseSsh):
 class LoginNodesSsh(_BaseSsh):
     """Represent the SSH configuration for LoginNodes."""
 
-    def __init__(self, allowed_ips=CIDR_ALL_IPS, **kwargs):
+    def __init__(self, allowed_ips: str = None, **kwargs):
         super().__init__(**kwargs)
-        # This is an internal parameter not yet exposed in the configuration
-        # By default is initalized to allow SSH from everywhere.
-        # Will be aligned to the setting defined in the HeadNode to allow restricting SSH access
-        # from a specific CIDR or prefix-list.
-        self.allowed_ips = allowed_ips
+        # If allowed IPs is not specified, will be aligned to the setting defined in the HeadNode
+        # to restrict SSH access from a specific CIDR or prefix-list.
+        self.allowed_ips = Resource.init_param(allowed_ips)
 
 
 class Dcv(Resource):
@@ -2903,12 +2901,10 @@ class SlurmClusterConfig(BaseClusterConfig):
                     pool.ssh.key_name = self.head_node.ssh.key_name
                 elif not pool.ssh:
                     pool.ssh = LoginNodesSsh(key_name=self.head_node.ssh.key_name)
-                # Forces the source allowed IP for the SSH connection to the one defined in the HeadNode
-                # This parameter is not yet exposed to customers through the config.
-                # We may want to change this once we block access to the HeadNode to regular users.
-                # This will only be set at creation time, if the cluster is updated and the HeadNode configuration
-                # changes, the cange will not be reflected into the LoginNode SecurityGroup
-                pool.ssh.allowed_ips = self.head_node.ssh.allowed_ips
+                # If the login node pool allowed IPs is not specified, forces the source allowed IP for the
+                # SSH connection to the one defined in the HeadNode
+                if not pool.ssh.allowed_ips:
+                    pool.ssh.allowed_ips = self.head_node.ssh.allowed_ips
 
         self.__image_dict = None
         # Cache capacity reservations information together to reduce number of boto3 calls.

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1409,6 +1409,14 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
         fields.Str(validate=get_field_validator("security_group_id")),
         metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
     )
+    load_balancer_additional_security_groups = fields.List(
+        fields.Str(validate=get_field_validator("security_group_id")),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+    load_balancer_security_groups = fields.List(
+        fields.Str(validate=get_field_validator("security_group_id")),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
 
     proxy = fields.Nested(LoginNodeProxySchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1409,14 +1409,6 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
         fields.Str(validate=get_field_validator("security_group_id")),
         metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
     )
-    load_balancer_additional_security_groups = fields.List(
-        fields.Str(validate=get_field_validator("security_group_id")),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
-    )
-    load_balancer_security_groups = fields.List(
-        fields.Str(validate=get_field_validator("security_group_id")),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
-    )
 
     proxy = fields.Nested(LoginNodeProxySchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1384,6 +1384,7 @@ class LoginNodesSshSchema(BaseSshSchema):
     """Represent the Ssh schema of LoginNodes."""
 
     key_name = fields.Str(metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    allowed_ips = fields.Str(validate=is_cidr_or_prefix_list, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -290,6 +290,22 @@ def get_login_nodes_security_groups_full(
     return login_nodes_security_groups
 
 
+def get_load_balancer_security_groups_full(
+    pool: LoginNodesPool,
+):
+    """
+    Return all of the user-defined security groups to be used for the login node pool Network Load Balancer.
+    """
+    load_balancer_security_groups = []
+
+    if pool.networking.load_balancer_security_groups:
+        load_balancer_security_groups.extend(pool.networking.load_balancer_security_groups)
+    if pool.networking.load_balancer_additional_security_groups:
+        load_balancer_security_groups.extend(pool.networking.load_balancer_additional_security_groups)
+
+    return load_balancer_security_groups
+
+
 def add_cluster_iam_resource_prefix(stack_name, config, name: str, iam_type: str):
     """Return a path and Name prefix from the Resource prefix config option."""
     full_resource_path = None

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -274,7 +274,8 @@ def get_login_nodes_security_groups_full(
     managed_login_security_group: ec2.CfnSecurityGroup,
     pool: LoginNodesPool,
 ):
-    """Return full security groups to be used for the login node, default plus additional ones."""
+    """Return full security groups to be used for the login nodes and network load balancer,
+    default plus additional ones."""
     login_nodes_security_groups = []
 
     # Default security groups, created by us or provided by the user
@@ -289,21 +290,14 @@ def get_login_nodes_security_groups_full(
 
     return login_nodes_security_groups
 
-
-def get_load_balancer_security_groups_full(
-    pool: LoginNodesPool,
-):
-    """
-    Return all of the user-defined security groups to be used for the login node pool Network Load Balancer.
-    """
-    load_balancer_security_groups = []
-
-    if pool.networking.load_balancer_security_groups:
-        load_balancer_security_groups.extend(pool.networking.load_balancer_security_groups)
-    if pool.networking.load_balancer_additional_security_groups:
-        load_balancer_security_groups.extend(pool.networking.load_balancer_additional_security_groups)
-
-    return load_balancer_security_groups
+def get_source_ingress_rule(setting):
+    """Returns security group ingress property depending on whether the input setting is a prefix list or CIDR ip"""
+    if setting.startswith("pl"):
+        return ec2.CfnSecurityGroup.IngressProperty(
+            ip_protocol="tcp", from_port=22, to_port=22, source_prefix_list_id=setting
+        )
+    else:
+        return ec2.CfnSecurityGroup.IngressProperty(ip_protocol="tcp", from_port=22, to_port=22, cidr_ip=setting)
 
 
 def add_cluster_iam_resource_prefix(stack_name, config, name: str, iam_type: str):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -290,6 +290,7 @@ def get_login_nodes_security_groups_full(
 
     return login_nodes_security_groups
 
+
 def get_source_ingress_rule(setting):
     """Returns security group ingress property depending on whether the input setting is a prefix list or CIDR ip"""
     if setting.startswith("pl"):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -274,8 +274,7 @@ def get_login_nodes_security_groups_full(
     managed_login_security_group: ec2.CfnSecurityGroup,
     pool: LoginNodesPool,
 ):
-    """Return full security groups to be used for the login nodes and network load balancer,
-    default plus additional ones."""
+    """Return security groups to be used for the login nodes and network load balancer, default plus additional ones."""
     login_nodes_security_groups = []
 
     # Default security groups, created by us or provided by the user
@@ -292,7 +291,7 @@ def get_login_nodes_security_groups_full(
 
 
 def get_source_ingress_rule(setting):
-    """Returns security group ingress property depending on whether the input setting is a prefix list or CIDR ip"""
+    """Return security group ingress property depending on whether the input setting is a prefix list or CIDR ip."""
     if setting.startswith("pl"):
         return ec2.CfnSecurityGroup.IngressProperty(
             ip_protocol="tcp", from_port=22, to_port=22, source_prefix_list_id=setting

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -194,7 +194,7 @@ class ClusterCdkStack:
             if isinstance(self.config, SlurmClusterConfig) and self.config.login_nodes
             else []
         )
-        # Add the managed login security groups, if there are any
+        # Add the managed login node security groups
         if self._login_security_group:
             for _, managed_security_group in self._login_security_group.items():
                 login_security_groups.append(managed_security_group.ref)
@@ -876,7 +876,7 @@ class ClusterCdkStack:
         return compute_security_group
 
     def _add_login_nodes_security_group(self):
-        """Returns a dictionary mapping each login node pool name to its respective managed security group"""
+        """Return a dictionary mapping each login node pool name to its respective managed security group."""
         pool_to_managed_security_group_dict = dict()
 
         for pool in self.config.login_nodes.pools:

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -98,6 +98,7 @@ from pcluster.templates.cdk_builder_utils import (
     get_log_group_deletion_policy,
     get_shared_storage_ids_by_type,
     get_slurm_specific_dna_json_for_head_node,
+    get_source_ingress_rule,
     get_user_data_content,
     to_comma_separated_string,
 )
@@ -193,9 +194,10 @@ class ClusterCdkStack:
             if isinstance(self.config, SlurmClusterConfig) and self.config.login_nodes
             else []
         )
-
-        if self._login_security_group:
-            login_security_groups.append(self._login_security_group.ref)
+        # Add the managed login security groups, if there are any
+        if self._login_security_groups:
+            for _pool_name, managed_security_group in self._login_security_groups.items():
+                login_security_groups.append(self._login_security_groups.ref)
 
         return login_security_groups
 
@@ -255,7 +257,7 @@ class ClusterCdkStack:
         (
             self._head_security_group,
             self._compute_security_group,
-            self._login_security_group,
+            self._login_security_groups,
         ) = self._add_security_groups()
         # Head Node ENI
         self._head_eni = self._add_head_eni()
@@ -467,7 +469,7 @@ class ClusterCdkStack:
                 shared_storage_infos=self.shared_storage_infos,
                 shared_storage_mount_dirs=self.shared_storage_mount_dirs,
                 shared_storage_attributes=self.shared_storage_attributes,
-                login_security_group=self._login_security_group,
+                login_security_groups=self._login_security_groups,
                 head_eni=self._head_eni,
                 cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
                 cluster_bucket=self.bucket,
@@ -576,7 +578,7 @@ class ClusterCdkStack:
         head_node_security_groups, managed_head_security_group = self._head_security_groups()
         (
             login_security_groups,
-            managed_login_security_group,
+            managed_login_security_groups,
             custom_login_security_groups,
         ) = self._login_security_groups()
         (
@@ -596,7 +598,7 @@ class ClusterCdkStack:
             managed_login_security_group,
         )
 
-        return managed_head_security_group, managed_compute_security_group, managed_login_security_group
+        return managed_head_security_group, managed_compute_security_group, managed_login_security_groups
 
     def _head_security_groups(self):
         managed_head_security_group = None
@@ -609,7 +611,15 @@ class ClusterCdkStack:
         return head_node_security_groups, managed_head_security_group
 
     def _login_security_groups(self):
-        managed_login_security_group = None
+        """
+        Return the security groups of the login nodes.
+
+        :return:
+        login_security_groups - a list containing all security groups for all pools, managed and custom
+        managed_login_security_groups - a dictionary mapping each pool name to its respective managed security group
+        custom_login_security_groups - a list containing all custom security groups for all pools
+        """
+        managed_login_security_groups = None
         custom_login_security_groups = set()
         managed_login_security_group_required = False
         if self._condition_is_slurm() and self.config.login_nodes:
@@ -622,9 +632,11 @@ class ClusterCdkStack:
                     managed_login_security_group_required = True
         login_security_groups = list(custom_login_security_groups)
         if managed_login_security_group_required:
-            managed_login_security_group = self._add_login_nodes_security_group()
-            login_security_groups.append(managed_login_security_group.ref)
-        return login_security_groups, managed_login_security_group, custom_login_security_groups
+            managed_login_security_groups = self._add_login_nodes_security_group()
+            login_security_groups.extend(
+                [security_group.ref for security_group in managed_login_security_groups.values()]
+            )
+        return login_security_groups, managed_login_security_groups, custom_login_security_groups
 
     def _compute_security_groups(self):
         managed_compute_security_group = None
@@ -652,17 +664,17 @@ class ClusterCdkStack:
         custom_login_security_groups,
         managed_compute_security_group,
         managed_head_security_group,
-        managed_login_security_group,
+        managed_login_security_groups,
     ):
         self._add_inbounds_to_managed_head_security_group(
             compute_security_groups, login_security_groups, managed_head_security_group
         )
 
-        self._add_inbounds_to_managed_login_security_group(
+        self._add_inbounds_to_managed_login_security_groups(
             head_node_security_groups,
             compute_security_groups,
             custom_login_security_groups,
-            managed_login_security_group,
+            managed_login_security_groups,
         )
 
         self._add_inbounds_to_managed_compute_security_group(
@@ -698,29 +710,35 @@ class ClusterCdkStack:
                     port=NFS_PORT,
                 )
 
-    def _add_inbounds_to_managed_login_security_group(
+    def _add_inbounds_to_managed_login_security_groups(
         self,
         head_node_security_groups,
         compute_security_groups,
         custom_login_security_groups,
-        managed_login_security_group,
+        managed_login_security_groups,
     ):
-        if managed_login_security_group:
-            # Access to login nodes from head node and compute nodes
-            for index, security_group in enumerate(head_node_security_groups):
-                self._allow_all_ingress(
-                    f"LoginSecurityGroupHeadNodeIngress{index}", security_group, managed_login_security_group.ref
-                )
-            for index, security_group in enumerate(compute_security_groups):
-                self._allow_all_ingress(
-                    f"LoginSecurityGroupComputeIngress{index}", security_group, managed_login_security_group.ref
-                )
-            for index, security_group in enumerate(custom_login_security_groups):
-                self._allow_all_ingress(
-                    f"LoginSecurityGroupCustomLoginSecurityGroupIngress{index}",
-                    security_group,
-                    managed_login_security_group.ref,
-                )
+        if managed_login_security_groups:
+            for pool_name, managed_security_group in managed_login_security_groups.items():
+                # Access to login nodes from head node and compute nodes to each managed security group
+                for index, security_group in enumerate(head_node_security_groups):
+                    self._allow_all_ingress(
+                        f"{pool_name}LoginSecurityGroupHeadNodeIngress{index}",
+                        security_group,
+                        managed_security_group.ref
+                    )
+                for index, security_group in enumerate(compute_security_groups):
+                    self._allow_all_ingress(
+                        f"{pool_name}LoginSecurityGroupComputeIngress{index}",
+                        security_group,
+                        managed_security_group.ref
+                    )
+                # Access to login nodes from custom login node security groups
+                for index, security_group in enumerate(custom_login_security_groups):
+                    self._allow_all_ingress(
+                        f"{pool_name}LoginSecurityGroupCustomLoginSecurityGroupIngress{index}",
+                        security_group,
+                        managed_security_group.ref,
+                    )
 
     def _add_inbounds_to_managed_compute_security_group(
         self,
@@ -878,44 +896,41 @@ class ClusterCdkStack:
 
         return compute_security_group
 
-    def _get_source_ingress_rule(self, setting):
-        if setting.startswith("pl"):
-            return ec2.CfnSecurityGroup.IngressProperty(
-                ip_protocol="tcp", from_port=22, to_port=22, source_prefix_list_id=setting
-            )
-        else:
-            return ec2.CfnSecurityGroup.IngressProperty(ip_protocol="tcp", from_port=22, to_port=22, cidr_ip=setting)
-
     def _add_login_nodes_security_group(self):
-        # TODO review this once we allow more pools to be defined in the LoginNodes section
-        login_nodes_security_group_ingress = [
-            # SSH access
-            self._get_source_ingress_rule(self.config.login_nodes.pools[0].ssh.allowed_ips)
-        ]
+        """Returns a dictionary mapping each login node pool name to its respective managed security group"""
+        pool_to_managed_security_group_dict = dict()
 
-        if self.config.login_nodes.has_dcv_enabled:
-            login_nodes_security_group_ingress.append(
-                # DCV access
-                ec2.CfnSecurityGroup.IngressProperty(
-                    ip_protocol="tcp",
-                    from_port=self.config.login_nodes.pools[0].dcv.port,
-                    to_port=self.config.login_nodes.pools[0].dcv.port,
-                    cidr_ip=self.config.login_nodes.pools[0].dcv.allowed_ips,
+        for pool in self.config.login_nodes.pools:
+            # Check if the pool has user-defined security groups
+            if not pool.networking.security_groups:
+                security_group_ingress_rule = [
+                    # Add rule for SSH access
+                    get_source_ingress_rule(pool.ssh.allowed_ips)
+                ]
+                # Add rule for DCV access if enabled
+                if pool.has_dcv_enabled:
+                    security_group_ingress_rules.append(
+                        ec2.CfnSecurityGroup.IngressProperty(
+                            ip_protocol="tcp",
+                            from_port=pool.dcv.port,
+                            to_port=pool.dcv.port,
+                            cidr_ip=pool.dcv.allowed_ips,
+                        )
+                    )
+                pool_to_managed_security_group_dict[pool.name] = ec2.CfnSecurityGroup(
+                    self.stack,
+                    f"{pool.name}LoginNodesSecurityGroup",
+                    group_description="Enable access to the login nodes",
+                    vpc_id=self.config.vpc_id,
+                    security_group_ingress=security_group_ingress_rules,
                 )
-            )
 
-        return ec2.CfnSecurityGroup(
-            self.stack,
-            "LoginNodesSecurityGroup",
-            group_description="Enable access to the login nodes",
-            vpc_id=self.config.vpc_id,
-            security_group_ingress=login_nodes_security_group_ingress,
-        )
+        return pool_to_managed_security_group_dict
 
     def _add_head_security_group(self):
         head_security_group_ingress = [
             # SSH access
-            self._get_source_ingress_rule(self.config.head_node.ssh.allowed_ips)
+            get_source_ingress_rule(self.config.head_node.ssh.allowed_ips)
         ]
 
         if self.config.is_dcv_enabled:

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -442,7 +442,7 @@ class Pool(Construct):
         load_balancer_managed_security_group = ec2.CfnSecurityGroup(
             Stack.of(self),
             f"{self._pool.name}LoadBalancerSecurityGroup",
-            group_description=f"Enable access to the load balancer",
+            group_description="Enable access to the load balancer",
             vpc_id=self._config.vpc_id,
             security_group_ingress=load_balancer_security_group_ingress,
         )

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -800,22 +800,22 @@ class TestBaseClusterConfig:
             (
                 HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
                 LoginNodesSsh(key_name="login-node-key", allowed_ips="6.5.4.3/24"),
-                {"key_name": "login-node-key", "allowed_ips": "6.5.4.3/24"}
+                {"key_name": "login-node-key", "allowed_ips": "6.5.4.3/24"},
             ),
             (
                 HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
                 LoginNodesSsh(key_name=None),
-                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"}
+                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"},
             ),
             (
                 HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
                 None,
-                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"}
-             ),
+                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"},
+            ),
             (
                 None,
                 LoginNodesSsh(key_name="login-node-key"),
-                {"key_name": "login-node-key", "allowed_ips": "0.0.0.0/0"}
+                {"key_name": "login-node-key", "allowed_ips": "0.0.0.0/0"},
             ),
         ],
     )

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -795,32 +795,31 @@ class TestBaseClusterConfig:
         assert_that(queue.job_exclusive_allocation).is_equal_to(expected_value)
 
     @pytest.mark.parametrize(
-        "head_node_ssh, login_node_ssh, expected_value",
+        "head_node_ssh, login_node_ssh, expected_values",
         [
             (
-                HeadNodeSsh(key_name="head-node-key"),
-                LoginNodesSsh(key_name="login-node-key"),
-                "login-node-key",
-            ),
-            (HeadNodeSsh(key_name="head-node-key"), None, "head-node-key"),
-            (
-                None,
-                LoginNodesSsh(key_name="login-node-key"),
-                "login-node-key",
+                HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
+                LoginNodesSsh(key_name="login-node-key", allowed_ips="6.5.4.3/24"),
+                {"key_name": "login-node-key", "allowed_ips": "6.5.4.3/24"}
             ),
             (
-                HeadNodeSsh(key_name="head-node-key"),
+                HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
                 LoginNodesSsh(key_name=None),
-                "head-node-key",
+                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"}
             ),
             (
+                HeadNodeSsh(key_name="head-node-key", allowed_ips="1.2.3.4/24"),
                 None,
+                {"key_name": "head-node-key", "allowed_ips": "1.2.3.4/24"}
+             ),
+            (
                 None,
-                None,
+                LoginNodesSsh(key_name="login-node-key"),
+                {"key_name": "login-node-key", "allowed_ips": "0.0.0.0/0"}
             ),
         ],
     )
-    def test_login_nodes_ssh_key_default_value(self, head_node_ssh, login_node_ssh, expected_value, mocker):
+    def test_login_nodes_ssh_default_values(self, head_node_ssh, login_node_ssh, expected_values, mocker):
         cluster_config = SlurmClusterConfig(
             cluster_name="clustername",
             login_nodes=LoginNodes(
@@ -856,7 +855,8 @@ class TestBaseClusterConfig:
         )
         print(cluster_config.head_node.ssh.key_name)
         print(cluster_config.login_nodes.pools[0].ssh.key_name)
-        assert_that(cluster_config.login_nodes.pools[0].ssh.key_name).is_equal_to(expected_value)
+        assert_that(cluster_config.login_nodes.pools[0].ssh.key_name).is_equal_to(expected_values["key_name"])
+        assert_that(cluster_config.login_nodes.pools[0].ssh.allowed_ips).is_equal_to(expected_values["allowed_ips"])
 
 
 class TestSharedEbs:

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -17,6 +17,7 @@ LoginNodes:
       - subnet-12345678
     Ssh:
       KeyName: ec2-key-name
+      AllowedIps: 1.2.3.4/32
     Dcv:
       Enabled: true
       Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1226,10 +1226,8 @@ def test_security_group_with_restricted_ssh_access(
     """
     Validates that both HeadNode and LoginNoes SecurityGroups have restricted SSH access.
 
-    If AllowedIPs setting is defined in the HeadNode SSH section both HeadNode and LoginNoes SecurityGroups
+    If AllowedIPs setting is defined in the HeadNode SSH section, both HeadNode and LoginNodes SecurityGroups
     should have restricted SSH access.
-    LoginNodes do not expose this parameter in the config, so they rely on what is specified on the HeadNode.
-    This may change once we remove access for regular users to the HeadNode.
     """
     mock_aws_api(mocker)
     mock_bucket_object_utils(mocker)

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -20,6 +20,7 @@ LoginNodes:
         HttpProxyAddress: https://proxy-address:port
     Ssh:
       KeyName: validate_key_name
+      AllowedIps: 1.2.3.4/32
     Dcv:
       Enabled: true
       Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -132,6 +132,7 @@ LoginNodes:
       SubnetIds:
       - subnet-12345678
     Ssh:
+      AllowedIps: 1.2.3.4/32
       KeyName: validate_key_name
 Monitoring:
   Alarms:

--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -104,7 +104,7 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
     login_nodes_sg_name = (
         login_nodes_networking.security_groups[0]
         if login_nodes_networking.security_groups
-        else "LoginNodesSecurityGroup"
+        else f"{cluster_config.login_nodes.pools[0].name}LoginNodesSecurityGroup"
     )
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", login_nodes_sg_name, mount_target_sg_name]:
         ingress_ip_protocol = "tcp" if sg == login_nodes_sg_name else "-1"
@@ -170,7 +170,7 @@ def test_shared_storage_fsx(mocker, test_datadir, config_file_name, storage_name
     login_nodes_sg_name = (
         login_nodes_networking.security_groups[0]
         if login_nodes_networking.security_groups
-        else "LoginNodesSecurityGroup"
+        else f"{cluster_config.login_nodes.pools[0].name}LoginNodesSecurityGroup"
     )
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", login_nodes_sg_name, file_system_sg_name]:
         ingress_ip_protocol = "tcp" if sg == login_nodes_sg_name else "-1"

--- a/tests/integration-tests/tests/common/networking/security_groups.py
+++ b/tests/integration-tests/tests/common/networking/security_groups.py
@@ -23,12 +23,12 @@ def delete_security_group(region: str, security_group_id: str):
 def describe_security_groups_for_network_interface(region: str, network_interface_id: str):
     logging.info(f"Describing Security Groups for Network Interface {network_interface_id}")
     try:
-        network_inyterface_description = _ec2(region).describe_network_interfaces(
+        network_interface_description = _ec2(region).describe_network_interfaces(
             NetworkInterfaceIds=[network_interface_id]
         )
         return [
             security_group["GroupId"]
-            for security_group in network_inyterface_description["NetworkInterfaces"][0]["Groups"]
+            for security_group in network_interface_description["NetworkInterfaces"][0]["Groups"]
         ]
     except Exception as e:
         logging.error(f"Cannot describe Security Groups for Network Interface {network_interface_id}: {e}")

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -54,8 +54,8 @@ def _test_dcv_configuration(
     login_node_remote_command_executor = RemoteCommandExecutor(cluster, use_login_node=True)
 
     # check configuration parameters of the head and login nodes
-    check_node_security_group(region, cluster, dcv_port, expected_cidr=access_from, node_type="HeadNode")
-    check_node_security_group(region, cluster, dcv_port, expected_cidr=access_from, node_type="LoginNode")
+    check_node_security_group(region, cluster, dcv_port, expected_cidr=access_from)
+    check_node_security_group(region, cluster, dcv_port, expected_cidr=access_from, login_pool_name="pool")
 
     shared_dir = f"/home/{get_username_for_os(os)}"
 

--- a/tests/integration-tests/tests/networking/test_security_groups/test_login_node_security_groups/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_login_node_security_groups/pcluster.config.yaml
@@ -1,0 +1,40 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_ids[0] }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+LoginNodes:
+  Pools:
+    - Name: pool1
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_ids[0] }}
+        {% if assign_additional_security_groups == False %}
+        SecurityGroups:
+          - {{ default_security_group_id }}
+        {% else %}
+        AdditionalSecurityGroups:
+          - {{ default_security_group_id }}
+        {% endif %}
+      Ssh:
+        AllowedIps: {{ ssh_from }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_ids[1] }}


### PR DESCRIPTION
### Description of changes
* Added `AllowedIps` configuration to login node pool config.
  * A user can now restrict SSH access to a login node pool with a specific CIDR or prefix-list. The default behavior is maintained, where the login node pool inherits the head node SSH restrictions if `AllowedIps` isn't specified for the login node pool.
 
* Added a managed security group to the login node pool load balancer.
  * The load balancer managed security group contains the same SSH restriction that applies to the login node managed security group.
  
* Aligned login node and load balancer security groups.
  * When a user attaches security groups to a login node pool with `SecurityGroups` or `AdditionalSecurityGroups`, the security groups are also applied to the pool’s load balancer. This change was made to address user’s having to manage multiple access points to the login nodes.
  
* Added inbound rule to the login node pool managed security group which references the load balancer managed security group.
  * This addresses a bug where a user restricts SSH access and the load balancer is unable to perform health checks on the login nodes and they are marked unhealthy. If a user defines their own security group (via `SecurityGroups` in the login node pool config), then the user will need to ensure access from the load balancer to the login nodes.
  
* Changed login node managed security groups to support multiple pools. 
  * Configured each pool to have its own managed security group. This is to allow flexibility in security posture of each pool. For example by having pools with dcv enabled or SSH restrictions.
  
* Updated CHANGELOG

### Tests

#### Manual Testing:

* AllowedIPs:
    * Verified separate login node and head node `AllowedIps`.
    * Verified login nodes maintain head node `AllowedIPs` when not specified.
    * Verified update possible when login nodes are stopped.

* Load balancer security groups
    * Verified managed security group on load balancer.
    * Verified that load balancer security group is added as reference to managed login security group.
    * Verified shared load balancer security group has aligned SSH restriction with login node security group.
    * Verified `SecurityGroups` shared between login node pool and load balancer.
    * Verified `AdditionalSecurityGroups`:
        * Verified managed security group still exists for both login node pool and load balancer.
        * Verified `AdditionalSecurityGroups` shared between login node pool and load balancer.
    * Verified updates to security groups works correctly.

#### Unit tests

* Updated `test_cluster_stack`, `test_shared_storage`, and `test_cluster_config` to support new configuration. 

#### Integration tests

* Created `test_login_node_security_groups` to verify changed made to load balancer and login node security groups.


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
