### PR TITLE
[Release-3.10] Fix retrieve_supported_regions to get the correct S3 Url

### DIFF
--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -570,7 +570,7 @@ def retrieve_supported_regions():
         try:
             url = "https://{region}-aws-parallelcluster.s3.{region}.{aws_domain}/supported-regions".format(
                 region=region,
-                aws_domain=get_partition(region),
+                aws_domain=get_url_domain_suffix(region),
             )
             with urllib.request.urlopen(url) as f:  # nosec B310 nosemgrep
                 retrieve_supported_regions.cache = f.read().decode("utf-8").split("\n")


### PR DESCRIPTION
### Description of changes
* Fix retrieve_supported_regions to get the correct S3 Url.

### Tests
* Manually test done, passed.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
