### PR TITLE
[LoginNodes] Allow multiple login node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 - Add support for ap-southeast-3 region.
 - Add security groups to login node network load balancer.
 - Add `AllowedIps` configuration for login nodes.
+- Allow multiple login node pools.
 
 **BUG FIXES**
 - Fix validator `EfaPlacementGroupValidator` so that it does not suggest to configure a Placement Group when Capacity Blocks are used.

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -268,9 +268,9 @@ def _get_login_nodes(cluster):
 
     # TODO Fix once the API models are updated to support multiple pools in describe-cluster response
     if login_nodes_status.get_login_nodes_pool_available():
-        login_nodes = list()
+        login_nodes = []
 
-        for pool_name, pool_status in login_nodes_status.get_pool_status_dict().items():
+        for _pool_name, pool_status in login_nodes_status.get_pool_status_dict().items():
             status = LoginNodesState.FAILED
             if pool_status.get_status() == LoginNodesPoolState.ACTIVE:
                 status = LoginNodesState.ACTIVE

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -265,19 +265,27 @@ def describe_cluster(cluster_name, region=None):
 
 def _get_login_nodes(cluster):
     login_nodes_status = cluster.login_nodes_status
+
+    # TODO Fix once the API models are updated to support multiple pools in describe-cluster response
     if login_nodes_status.get_login_nodes_pool_available():
-        # TODO Change when describe-cluster API is updated to support multiple pools
-        status = LoginNodesState.FAILED
-        if login_nodes_status.get_status() == LoginNodesPoolState.ACTIVE:
-            status = LoginNodesState.ACTIVE
-        elif login_nodes_status.get_status() == LoginNodesPoolState.PENDING:
-            status = LoginNodesState.PENDING
-        login_nodes = LoginNodesPool(status=status)
-        login_nodes.address = login_nodes_status.get_address()
-        login_nodes.scheme = login_nodes_status.get_scheme()
-        login_nodes.healthy_nodes = login_nodes_status.get_total_healthy_nodes()
-        login_nodes.unhealthy_nodes = login_nodes_status.get_total_unhealthy_nodes()
-        return login_nodes
+        login_nodes = list()
+
+        for pool_name, pool_status in login_nodes_status.get_pool_status_dict().items():
+            status = LoginNodesState.FAILED
+            if pool_status.get_status() == LoginNodesPoolState.ACTIVE:
+                status = LoginNodesState.ACTIVE
+            elif pool_status.get_status() == LoginNodesPoolState.PENDING:
+                status = LoginNodesState.PENDING
+            pool = LoginNodesPool(status=status)
+            # pool.name = pool_name
+            pool.address = pool_status.get_address()
+            pool.scheme = pool_status.get_scheme()
+            pool.healthy_nodes = pool_status.get_healthy_nodes()
+            pool.unhealthy_nodes = pool_status.get_unhealthy_nodes()
+            login_nodes.append(pool)
+            break # remove
+
+        return login_nodes[0] # remove index
     return None
 
 

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -283,9 +283,9 @@ def _get_login_nodes(cluster):
             pool.healthy_nodes = pool_status.get_healthy_nodes()
             pool.unhealthy_nodes = pool_status.get_unhealthy_nodes()
             login_nodes.append(pool)
-            break # remove
+            break
 
-        return login_nodes[0] # remove index
+        return login_nodes[0]
     return None
 
 

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -266,6 +266,7 @@ def describe_cluster(cluster_name, region=None):
 def _get_login_nodes(cluster):
     login_nodes_status = cluster.login_nodes_status
     if login_nodes_status.get_login_nodes_pool_available():
+        # TODO Change when describe-cluster API is updated to support multiple pools
         status = LoginNodesState.FAILED
         if login_nodes_status.get_status() == LoginNodesPoolState.ACTIVE:
             status = LoginNodesState.ACTIVE
@@ -274,8 +275,8 @@ def _get_login_nodes(cluster):
         login_nodes = LoginNodesPool(status=status)
         login_nodes.address = login_nodes_status.get_address()
         login_nodes.scheme = login_nodes_status.get_scheme()
-        login_nodes.healthy_nodes = login_nodes_status.get_healthy_nodes()
-        login_nodes.unhealthy_nodes = login_nodes_status.get_unhealthy_nodes()
+        login_nodes.healthy_nodes = login_nodes_status.get_total_healthy_nodes()
+        login_nodes.unhealthy_nodes = login_nodes_status.get_total_unhealthy_nodes()
         return login_nodes
     return None
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1406,7 +1406,7 @@ class LoginNodes(Resource):
         super().__init__(**kwargs)
         self.pools = pools
 
-    def _register_validators(self, context: ValidatorContext = None):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             DuplicateNameValidator, name_list=[pool.name for pool in self.pools], resource_name="Pool"
         )

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1411,6 +1411,7 @@ class LoginNodes(Resource):
             DuplicateNameValidator, name_list=[pool.name for pool in self.pools], resource_name="Pool"
         )
 
+
 class HeadNode(Resource):
     """Represent the Head Node resource."""
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1406,6 +1406,10 @@ class LoginNodes(Resource):
         super().__init__(**kwargs)
         self.pools = pools
 
+    def _register_validators(self, context: ValidatorContext = None):
+        self._register_validator(
+            DuplicateNameValidator, name_list=[pool.name for pool in self.pools], resource_name="Pool"
+        )
 
 class HeadNode(Resource):
     """Represent the Head Node resource."""

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -491,6 +491,21 @@ def condition_checker_login_nodes_stop_policy(_, patch):
     return not patch.cluster.has_running_login_nodes()
 
 
+def condition_checker_login_nodes_pool_stop_policy(change, patch):
+    """Check if login nodes are running in the pool in which update was requested."""
+    pool_name = get_pool_name_from_change_paths(change)
+    return not patch.cluster.has_running_login_nodes(pool_name=pool_name)
+
+
+def get_pool_name_from_change_paths(change):
+    """Return the name of the pool in which update was requested."""
+    for path in change.path:
+        if re.search("Pools\\[", path):
+            _, pool_name = extract_type_and_name_from_path(path)
+            return pool_name
+    return ""
+
+
 # Common fail_reason messages
 UpdatePolicy.FAIL_REASONS = {
     "ebs_volume_resize": "Updating the file system after a resize operation requires commands specific to your "
@@ -501,6 +516,9 @@ UpdatePolicy.FAIL_REASONS = {
         "pcluster update-compute-fleet command and then run an update with the --force-update flag"
     ),
     "login_nodes_running": lambda change, patch: "The update is not supported when login nodes are running",
+    "login_nodes_pool_running": lambda change, patch: (
+        f"The update is not supported when login nodes in {get_pool_name_from_change_paths(change)} are running"
+    ),
     "compute_or_login_nodes_running": lambda change, patch: (
         "The update is not supported when compute or login nodes are running"
     ),
@@ -669,8 +687,7 @@ UpdatePolicy.MANAGED_FSX = UpdatePolicy(
     condition_checker=condition_checker_managed_fsx,
 )
 
-
-# Update policy for updating LoginNodes / Pools
+# Update policy for adding or removing a login node pool
 UpdatePolicy.LOGIN_NODES_POOLS = UpdatePolicy(
     name="LOGIN_NODES_POOLS_UPDATE_POLICY",
     level=6,
@@ -679,7 +696,7 @@ UpdatePolicy.LOGIN_NODES_POOLS = UpdatePolicy(
     action_needed=UpdatePolicy.ACTIONS_NEEDED["login_nodes_stop"],
 )
 
-# Update supported only with all login nodes down
+# Update supported only with all login nodes in the cluster down
 UpdatePolicy.LOGIN_NODES_STOP = UpdatePolicy(
     name="LOGIN_NODES_STOP",
     level=10,
@@ -688,6 +705,14 @@ UpdatePolicy.LOGIN_NODES_STOP = UpdatePolicy(
     action_needed=UpdatePolicy.ACTIONS_NEEDED["login_nodes_stop"],
 )
 
+# Update supported only with all login nodes in the pool down
+UpdatePolicy.LOGIN_NODES_POOL_STOP = UpdatePolicy(
+    name="LOGIN_NODES_POOL_STOP",
+    level=10,
+    condition_checker=condition_checker_login_nodes_pool_stop_policy,
+    fail_reason=UpdatePolicy.FAIL_REASONS["login_nodes_pool_running"],
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["login_nodes_stop"],
+)
 
 # Update supported only with all computre and login nodes down
 UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP = UpdatePolicy(

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -498,7 +498,11 @@ def condition_checker_login_nodes_pool_stop_policy(change, patch):
 
 
 def get_pool_name_from_change_paths(change):
-    """Return the name of the pool in which update was requested."""
+    """
+    Return the name of the pool in which update was requested.
+
+    Example path=['LoginNodes', 'Pools[pool2]', 'Ssh'].
+    """
     for path in change.path:
         if re.search("Pools\\[", path):
             _, pool_name = extract_type_and_name_from_path(path)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -754,13 +754,20 @@ class Cluster:
                 )
         return self.__has_running_capacity
 
-    def has_running_login_nodes(self, updated_value: bool = False) -> bool:
-        """Return True if the cluster has running login nodes. Note: the value will be cached."""
+    def has_running_login_nodes(self, updated_value: bool = False, pool_name: str = None) -> bool:
+        """
+        Return True if the cluster has running login nodes, or a specific pool if a pool name is provided.
+        Note: the value will be cached.
+        """
+        if pool_name:
+            healthy_nodes = self.login_nodes_status.get_healthy_nodes(pool_name=pool_name)
+            unhealthy_nodes = self.login_nodes_status.get_unhealthy_nodes(pool_name=pool_name)
+        else:
+            healthy_nodes = self.login_nodes_status.get_healthy_nodes()
+            unhealthy_nodes = self.login_nodes_status.get_unhealthy_nodes()
         if self.__has_running_login_nodes is None or updated_value:
             self.__has_running_login_nodes = (
-                self.login_nodes_status.get_total_healthy_nodes() is not None
-                and self.login_nodes_status.get_total_unhealthy_nodes() is not None
-                and self.login_nodes_status.get_total_healthy_nodes() + self.login_nodes_status.get_total_unhealthy_nodes() != 0
+                healthy_nodes is not None and unhealthy_nodes is not None and healthy_nodes + unhealthy_nodes != 0
             )
         return self.__has_running_login_nodes
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -284,12 +284,11 @@ class Cluster:
 
     @property
     def login_nodes_status(self):
-        """Status of the login nodes pool."""
+        """Status of the login nodes."""
         login_nodes_status = LoginNodesStatus(self.stack_name)
         if self.stack.scheduler == "slurm" and self.config.login_nodes:
-            # This approach works since by design we have now only one pool.
-            # We should fix this if we want to add more than a login nodes pool per cluster.
-            login_nodes_status.retrieve_data(self.config.login_nodes.pools[0].name)
+            login_node_pool_names = [pool.name for pool in self.config.login_nodes.pools]
+            login_nodes_status.retrieve_data(login_node_pool_names)
         return login_nodes_status
 
     @property
@@ -759,9 +758,9 @@ class Cluster:
         """Return True if the cluster has running login nodes. Note: the value will be cached."""
         if self.__has_running_login_nodes is None or updated_value:
             self.__has_running_login_nodes = (
-                self.login_nodes_status.get_healthy_nodes() is not None
-                and self.login_nodes_status.get_unhealthy_nodes() is not None
-                and self.login_nodes_status.get_healthy_nodes() + self.login_nodes_status.get_unhealthy_nodes() != 0
+                self.login_nodes_status.get_total_healthy_nodes() is not None
+                and self.login_nodes_status.get_total_unhealthy_nodes() is not None
+                and self.login_nodes_status.get_total_healthy_nodes() + self.login_nodes_status.get_total_unhealthy_nodes() != 0
             )
         return self.__has_running_login_nodes
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -757,14 +757,12 @@ class Cluster:
     def has_running_login_nodes(self, updated_value: bool = False, pool_name: str = None) -> bool:
         """
         Return True if the cluster has running login nodes, or a specific pool if a pool name is provided.
+
         Note: the value will be cached.
         """
-        if pool_name:
-            healthy_nodes = self.login_nodes_status.get_healthy_nodes(pool_name=pool_name)
-            unhealthy_nodes = self.login_nodes_status.get_unhealthy_nodes(pool_name=pool_name)
-        else:
-            healthy_nodes = self.login_nodes_status.get_healthy_nodes()
-            unhealthy_nodes = self.login_nodes_status.get_unhealthy_nodes()
+        healthy_nodes = self.login_nodes_status.get_healthy_nodes(pool_name=pool_name)
+        unhealthy_nodes = self.login_nodes_status.get_unhealthy_nodes(pool_name=pool_name)
+
         if self.__has_running_login_nodes is None or updated_value:
             self.__has_running_login_nodes = (
                 healthy_nodes is not None and unhealthy_nodes is not None and healthy_nodes + unhealthy_nodes != 0

--- a/cli/src/pcluster/models/login_nodes_status.py
+++ b/cli/src/pcluster/models/login_nodes_status.py
@@ -180,20 +180,14 @@ class LoginNodesStatus:
         return self._pool_status_dict
 
     def get_healthy_nodes(self, pool_name=None):
-        """
-        Return the total number of healthy login nodes in the cluster,
-        or the number of healthy nodes in a pool if a pool name is provided.
-        """
+        """Return the total number of healthy login nodes in the cluster or a specific pool."""
         healthy_nodes = (
             self._pool_status_dict.get(pool_name).get_healthy_nodes() if pool_name else self._total_healthy_nodes
         )
         return healthy_nodes
 
     def get_unhealthy_nodes(self, pool_name=None):
-        """
-        Return the total number of unhealthy login nodes in the cluster,
-        or the number of healthy nodes in a pool if a pool name is provided.
-        """
+        """Return the total number of unhealthy login nodes in the cluster or a specific pool."""
         unhealthy_nodes = (
             self._pool_status_dict.get(pool_name).get_unhealthy_nodes() if pool_name else self._total_unhealthy_nodes
         )
@@ -204,19 +198,19 @@ class LoginNodesStatus:
         for pool_name in login_node_pool_names:
             self._pool_status_dict[pool_name] = PoolStatus(self._stack_name, pool_name)
         self._total_healthy_nodes = sum(
-            [
+            (
                 pool_status.get_healthy_nodes()
                 for pool_status in self._pool_status_dict.values()
                 if pool_status.get_healthy_nodes()
-            ]
+            )
         )
         self._total_unhealthy_nodes = sum(
-            [
+            (
                 pool_status.get_unhealthy_nodes()
                 for pool_status in self._pool_status_dict.values()
                 if pool_status.get_unhealthy_nodes()
-            ]
+            )
         )
         self._login_nodes_pool_available = any(
-            [pool_status.get_pool_available() for pool_status in self._pool_status_dict.values()]
+            (pool_status.get_pool_available() for pool_status in self._pool_status_dict.values())
         )

--- a/cli/src/pcluster/models/login_nodes_status.py
+++ b/cli/src/pcluster/models/login_nodes_status.py
@@ -32,9 +32,9 @@ class PoolStatus:
     """Represents the status of a pool of login nodes."""
 
     def __init__(self, stack_name, pool_name):
-        self.dns_name = None
-        self.status = None
-        self.scheme = None
+        self._dns_name = None
+        self._status = None
+        self._scheme = None
         self._pool_name = pool_name
         self._pool_available = False
         self._stack_name = stack_name
@@ -47,7 +47,7 @@ class PoolStatus:
     def __str__(self):
         return (
             f'("status": "{self._status}", "address": "{self._dns_name}", "scheme": "{self._scheme}", '
-            f'"healthyNodes": "{self._healthy_nodes}", "unhealthy_nodes": "{self._unhealthy_nodes}")'
+            f'"healthy_nodes": "{self._healthy_nodes}", "unhealthy_nodes": "{self._unhealthy_nodes}"),'
         )
 
     def get_healthy_nodes(self):
@@ -61,6 +61,18 @@ class PoolStatus:
     def get_pool_available(self):
         """Return true if the pool is available."""
         return self._pool_available
+
+    def get_status(self):
+        """Return the status of the login node pool."""
+        return self._status
+
+    def get_address(self):
+        """Return the connection addresses of the login node pool."""
+        return self._dns_name
+
+    def get_scheme(self):
+        """Return the schema of the login node pool."""
+        return self._scheme
 
     def _retrieve_data(self):
         """Initialize the class with the information related to the login nodes pool."""
@@ -78,14 +90,14 @@ class PoolStatus:
             for load_balancer in load_balancers:
                 if load_balancer.get("LoadBalancerArn") == self._load_balancer_arn:
                     self._map_status(load_balancer.get("State").get("Code"))
-                    self.dns_name = load_balancer.get("DNSName")
-                    self.scheme = load_balancer.get("Scheme")
+                    self._dns_name = load_balancer.get("DNSName")
+                    self._scheme = load_balancer.get("Scheme")
                     break
 
     def _load_balancer_arn_from_tags(self, tags_list):
         for tags in tags_list:
             if self._key_value_tag_found(
-                    tags, "parallelcluster:cluster-name", self._stack_name
+                tags, "parallelcluster:cluster-name", self._stack_name
             ) and self._key_value_tag_found(tags, "parallelcluster:login-nodes-pool", self._pool_name):
                 self._load_balancer_arn = tags.get("ResourceArn")
                 break
@@ -105,14 +117,14 @@ class PoolStatus:
 
     def _map_status(self, load_balancer_state):
         if load_balancer_state == "provisioning":
-            self.status = LoginNodesPoolState.PENDING
+            self._status = LoginNodesPoolState.PENDING
         elif load_balancer_state == "active":
-            self.status = LoginNodesPoolState.ACTIVE
+            self._status = LoginNodesPoolState.ACTIVE
         else:
-            self.status = LoginNodesPoolState.FAILED
+            self._status = LoginNodesPoolState.FAILED
 
     def _populate_target_groups(self):
-        if self.status is LoginNodesPoolState.ACTIVE:
+        if self._status is LoginNodesPoolState.ACTIVE:
             try:
                 target_groups = AWSApi.instance().elb.describe_target_groups(self._load_balancer_arn)
                 if target_groups:
@@ -148,46 +160,63 @@ class LoginNodesStatus:
 
     def __init__(self, stack_name):
         self._stack_name = stack_name
-        self._pool_statuses: List(PoolStatus) = None
+        self._pool_status_dict = dict()
         self._login_nodes_pool_available = False
-        self._load_balancer_arn = None
-        self._target_group_arn = None
-        self._dns_name = None
-        self._scheme = None
         self._total_healthy_nodes = None
         self._total_unhealthy_nodes = None
-        self._status = None
+
+    def __str__(self):
+        out = ""
+        for pool_status in self._pool_status_dict.values():
+            out += str(pool_status)
+        return out
 
     def get_login_nodes_pool_available(self):
         """Return true if a pool is available in the login nodes fleet."""
         return self._login_nodes_pool_available
 
-    def get_status(self):
-        """Return the status of the login node pool."""
-        # TODO Change when the describe-cluster API is updated to support multiple pools
-        return self._pool_statuses[0].status
+    def get_pool_status_dict(self):
+        """Return a dictionary mapping each login node pool name to respective pool status."""
+        return self._pool_status_dict
 
-    def get_address(self):
-        """Return the connection addresses of a login nodes fleet."""
-        # TODO Change when the describe-cluster API is updated to support multiple pools
-        return self._pool_statuses[0].dns_name
+    def get_healthy_nodes(self, pool_name=None):
+        """
+        Return the total number of healthy login nodes in the cluster,
+        or the number of healthy nodes in a pool if a pool name is provided.
+        """
+        healthy_nodes = (
+            self._pool_status_dict.get(pool_name).get_healthy_nodes() if pool_name else self._total_healthy_nodes
+        )
+        return healthy_nodes
 
-    def get_scheme(self):
-        """Return the schema of a login nodes fleet."""
-        # TODO Change when the describe-cluster API is updated to support multiple pools
-        return self._pool_statuses[0].scheme
-
-    def get_total_healthy_nodes(self):
-        """Return the total number of healthy nodes of a login nodes fleet."""
-        return self._total_healthy_nodes
-
-    def get_total_unhealthy_nodes(self):
-        """Return the total number of unhealthy nodes of a login nodes fleet."""
-        return self._total_unhealthy_nodes
+    def get_unhealthy_nodes(self, pool_name=None):
+        """
+        Return the total number of unhealthy login nodes in the cluster,
+        or the number of healthy nodes in a pool if a pool name is provided.
+        """
+        unhealthy_nodes = (
+            self._pool_status_dict.get(pool_name).get_unhealthy_nodes() if pool_name else self._total_unhealthy_nodes
+        )
+        return unhealthy_nodes
 
     def retrieve_data(self, login_node_pool_names):
         """Initialize the class with the information related to the login node fleet."""
-        self._pool_statuses = [PoolStatus(self._stack_name, pool_name) for pool_name in login_node_pool_names]
-        self._total_healthy_nodes = sum([pool_status.get_healthy_nodes() for pool_status in self._pool_statuses])
-        self._total_unhealthy_nodes = sum([pool_status.get_unhealthy_nodes() for pool_status in self._pool_statuses])
-        self._login_nodes_pool_available = any([pool_status.get_pool_available() for pool_status in self._pool_statuses])
+        for pool_name in login_node_pool_names:
+            self._pool_status_dict[pool_name] = PoolStatus(self._stack_name, pool_name)
+        self._total_healthy_nodes = sum(
+            [
+                pool_status.get_healthy_nodes()
+                for pool_status in self._pool_status_dict.values()
+                if pool_status.get_healthy_nodes()
+            ]
+        )
+        self._total_unhealthy_nodes = sum(
+            [
+                pool_status.get_unhealthy_nodes()
+                for pool_status in self._pool_status_dict.values()
+                if pool_status.get_unhealthy_nodes()
+            ]
+        )
+        self._login_nodes_pool_available = any(
+            [pool_status.get_pool_available() for pool_status in self._pool_status_dict.values()]
+        )

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1008,17 +1008,18 @@ class LoginNodesIamSchema(BaseIamSchema):
     """Represent the IAM schema of LoginNodes."""
 
     instance_role = fields.Str(
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp(IAM_ROLE_REGEX)
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP}, validate=validate.Regexp(IAM_ROLE_REGEX)
     )
 
     additional_iam_policies = fields.Nested(
         AdditionalIamPolicySchema,
         many=True,
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP, "update_key": "Policy"},
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP, "update_key": "Policy"},
     )
 
     instance_profile = fields.Str(
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX)
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP},
+        validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX),
     )
 
     @post_load
@@ -1371,7 +1372,7 @@ class LoginNodesImageSchema(BaseSchema):
 
     custom_ami = fields.Str(
         validate=validate.Regexp(PCLUSTER_AMI_ID_REGEX),
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP},
     )
 
     @post_load
@@ -1383,8 +1384,10 @@ class LoginNodesImageSchema(BaseSchema):
 class LoginNodesSshSchema(BaseSshSchema):
     """Represent the Ssh schema of LoginNodes."""
 
-    key_name = fields.Str(metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
-    allowed_ips = fields.Str(validate=is_cidr_or_prefix_list, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    key_name = fields.Str(metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
+    allowed_ips = fields.Str(
+        validate=is_cidr_or_prefix_list, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP}
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1399,18 +1402,18 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
         validate=validate.Length(equal=1, error="Only one subnet can be associated with a login node pool."),
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP},
     )
     additional_security_groups = fields.List(
         fields.Str(validate=get_field_validator("security_group_id")),
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP},
     )
     security_groups = fields.List(
         fields.Str(validate=get_field_validator("security_group_id")),
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP},
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP},
     )
 
-    proxy = fields.Nested(LoginNodeProxySchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    proxy = fields.Nested(LoginNodeProxySchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1421,11 +1424,11 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
 class LoginNodesPoolSchema(BaseSchema):
     """Represent the schema of the LoginNodesPool."""
 
-    name = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
-    instance_type = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
-    image = fields.Nested(LoginNodesImageSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    name = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
+    instance_type = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
+    image = fields.Nested(LoginNodesImageSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
     networking = fields.Nested(
-        LoginNodesNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}
+        LoginNodesNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP}
     )
     count = fields.Int(
         required=True,
@@ -1436,9 +1439,9 @@ class LoginNodesPoolSchema(BaseSchema):
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
     dcv = fields.Nested(DcvSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
-    ssh = fields.Nested(LoginNodesSshSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    ssh = fields.Nested(LoginNodesSshSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
     custom_actions = fields.Nested(LoginNodesCustomActionsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
-    iam = fields.Nested(LoginNodesIamSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    iam = fields.Nested(LoginNodesIamSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_POOL_STOP})
     gracetime_period = fields.Int(
         validate=validate.Range(
             min=3, max=120, error="The gracetime period for LoginNodes Pool must be an integer from 3 to 120."

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1459,7 +1459,6 @@ class LoginNodesSchema(BaseSchema):
         LoginNodesPoolSchema,
         many=True,
         required=True,
-        validate=validate.Length(equal=1, error="Only one pool can be specified when using login nodes."),
         metadata={"update_policy": UpdatePolicy(UpdatePolicy.LOGIN_NODES_POOLS), "update_key": "Name"},
     )
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -40,7 +40,6 @@ from aws_cdk.core import (
     Duration,
     Fn,
     Stack,
-    Tags,
 )
 
 from pcluster.aws.aws_api import AWSApi

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -474,12 +474,6 @@ class ClusterCdkStack:
                 cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
                 cluster_bucket=self.bucket,
             )
-            Tags.of(self.login_nodes_stack).add(
-                # This approach works since by design we have now only one pool.
-                # We should fix this if we want to add more than a login nodes pool per cluster.
-                "parallelcluster:login-nodes-pool",
-                self.config.login_nodes.pools[0].name,
-            )
             # Add dependency on the Head Node construct
             self.login_nodes_stack.node.add_dependency(self.head_node_instance)
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -899,7 +899,7 @@ class ClusterCdkStack:
                 pool_to_managed_security_group_dict[pool.name] = ec2.CfnSecurityGroup(
                     self.stack,
                     f"{pool.name}LoginNodesSecurityGroup",
-                    group_description="Enable access to the login nodes",
+                    group_description=f"Enable access to {pool.name} login nodes",
                     vpc_id=self.config.vpc_id,
                     security_group_ingress=security_group_ingress_rules,
                 )

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -5,7 +5,7 @@ from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_logs as logs
-from aws_cdk.core import CfnTag, Construct, Fn, NestedStack, Stack
+from aws_cdk.core import CfnTag, Construct, Fn, NestedStack, Stack, Tags
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.config.cluster_config import LoginNodesPool, SharedStorageType, SlurmClusterConfig
@@ -88,6 +88,9 @@ class Pool(Construct):
 
         self._launch_template = self._add_login_nodes_pool_launch_template()
         self._add_login_nodes_pool_auto_scaling_group()
+
+        # Add a pool name tag to the pool's resources
+        Tags.of(self).add("parallelcluster:login-nodes-pool", self._pool.name)
 
     def _add_login_node_iam_resources(self):
         self._iam_resource = LoginNodesIamResources(

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -442,7 +442,7 @@ class Pool(Construct):
         load_balancer_managed_security_group = ec2.CfnSecurityGroup(
             Stack.of(self),
             f"{self._pool.name}LoadBalancerSecurityGroup",
-            group_description="Enable access to the load balancer",
+            group_description=f"Enable access to {self._pool.name} network load balancer",
             vpc_id=self._config.vpc_id,
             security_group_ingress=load_balancer_security_group_ingress,
         )
@@ -450,12 +450,12 @@ class Pool(Construct):
         # Add a rule to the managed login node security group which grants access from the managed NLB security group
         ec2.CfnSecurityGroupIngress(
             Stack.of(self),
-            "LoginSecurityGroupLoadBalancerIngress",
+            f"{self._pool.name}LoginSecurityGroupLoadBalancerIngress",
             ip_protocol="-1",
             from_port=0,
             to_port=65535,
             source_security_group_id=load_balancer_managed_security_group.ref,
-            description="Allow traffic from the Network Load Balancer",
+            description=f"Allow traffic from {self._pool.name} network load balancer",
             group_id=self._login_security_group.ref,
         )
 

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1494,12 +1494,12 @@ class TestDescribeCluster:
             mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.get_address", return_value=address)
         if healthy_nodes:
             mocker.patch(
-                "pcluster.models.login_nodes_status.LoginNodesStatus.get_healthy_nodes",
+                "pcluster.models.login_nodes_status.LoginNodesStatus.get_total_healthy_nodes",
                 return_value=healthy_nodes,
             )
         if unhealthy_nodes:
             mocker.patch(
-                "pcluster.models.login_nodes_status.LoginNodesStatus.get_unhealthy_nodes",
+                "pcluster.models.login_nodes_status.LoginNodesStatus.get_total_unhealthy_nodes",
                 return_value=unhealthy_nodes,
             )
 

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -28,7 +28,7 @@ from pcluster.models.cluster import (
     LimitExceededClusterActionError,
 )
 from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus
-from pcluster.models.login_nodes_status import LoginNodesPoolState
+from pcluster.models.login_nodes_status import LoginNodesPoolState, PoolStatus
 from pcluster.utils import get_installed_version, to_iso_timestr
 from pcluster.validators.common import FailureLevel, ValidationResult
 
@@ -1482,24 +1482,32 @@ class TestDescribeCluster:
         config_mock.return_value.scheduling.settings.scheduler_definition.metadata = ""
         config_mock.return_value.scheduling.scheduler = "slurm"
 
+        # TODO Update once multiple pools supported in describe-cluster API response
+        mocker.patch.object(PoolStatus, "_retrieve_data")
+        pool_status_1 = PoolStatus("clustername", "pool1")
+        pool_status_dict = {"pool1": pool_status_1}
+
         mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.retrieve_data")
+        mocker.patch(
+            "pcluster.models.login_nodes_status.LoginNodesStatus.get_pool_status_dict", return_value=pool_status_dict
+        )
         mocker.patch(
             "pcluster.models.login_nodes_status.LoginNodesStatus.get_login_nodes_pool_available",
             return_value=login_nodes_pool_available,
         )
-        mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.get_status", return_value=status)
+        mocker.patch("pcluster.models.login_nodes_status.PoolStatus.get_status", return_value=status)
         if scheme:
-            mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.get_scheme", return_value=scheme)
+            mocker.patch("pcluster.models.login_nodes_status.PoolStatus.get_scheme", return_value=scheme)
         if address:
-            mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.get_address", return_value=address)
+            mocker.patch("pcluster.models.login_nodes_status.PoolStatus.get_address", return_value=address)
         if healthy_nodes:
             mocker.patch(
-                "pcluster.models.login_nodes_status.LoginNodesStatus.get_total_healthy_nodes",
+                "pcluster.models.login_nodes_status.PoolStatus.get_healthy_nodes",
                 return_value=healthy_nodes,
             )
         if unhealthy_nodes:
             mocker.patch(
-                "pcluster.models.login_nodes_status.LoginNodesStatus.get_total_unhealthy_nodes",
+                "pcluster.models.login_nodes_status.PoolStatus.get_unhealthy_nodes",
                 return_value=unhealthy_nodes,
             )
 

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -6,8 +6,8 @@ Image:
   CustomAmi: ami-12345678
 LoginNodes:
   Pools:
-  - Name: test
-    InstanceType: t2.micro
+  - Name: pool1
+    InstanceType: c5.large
     Count: 1
     GracetimePeriod: 10
     Image:
@@ -38,6 +38,17 @@ LoginNodes:
         Args:
           - arg1
           - arg2
+  - Name: pool2
+    InstanceType: c5.xlarge
+    Count: 1
+    GracetimePeriod: 10
+    Image:
+      CustomAmi: ami-12345678
+    Networking:
+      SubnetIds:
+        - subnet-12345678
+    Ssh:
+      KeyName: ec2-key-name
     Iam:
       InstanceRole: arn:aws:iam::aws:role/LoginNodeRole
 HeadNode:

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -49,6 +49,7 @@ LoginNodes:
         - subnet-12345678
     Ssh:
       KeyName: ec2-key-name
+      AllowedIps: 1.2.3.4/32
     Iam:
       InstanceRole: arn:aws:iam::aws:role/LoginNodeRole
 HeadNode:

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -7,7 +7,7 @@ Image:
 LoginNodes:
   Pools:
   - Name: pool1
-    InstanceType: c5.large
+    InstanceType: t2.micro
     Count: 1
     GracetimePeriod: 10
     Image:
@@ -39,7 +39,7 @@ LoginNodes:
           - arg1
           - arg2
   - Name: pool2
-    InstanceType: c5.xlarge
+    InstanceType: t2.small
     Count: 1
     GracetimePeriod: 10
     Image:

--- a/cli/tests/pcluster/models/test_login_nodes_status.py
+++ b/cli/tests/pcluster/models/test_login_nodes_status.py
@@ -6,32 +6,43 @@ from pcluster.models.login_nodes_status import LoginNodesPoolState, LoginNodesSt
 
 class TestLoginNodesStatus:
     dummy_stack_name = "dummy_cluster_name"
-    dummy_load_balancer_arn = "dummy_load_balancer_arn"
+    dummy_load_balancer_arn_1 = "dummy_load_balancer_arn_1"
     dummy_load_balancer_arn_2 = "dummy_load_balancer_arn_2"
-    dummy_pool_name = "dummy_pool_name"
-    dummy_scheme = "internet-facing"
+    dummy_target_group_arn_1 = "dummy_target_group_arn_1"
+    dummy_target_group_arn_2 = "dummy_target_group_arn_2"
+    dummy_pool_name_1 = "dummy_pool_name_1"
+    dummy_pool_name_2 = "dummy_pool_name_2"
+    dummy_scheme_1 = "internet-facing"
+    dummy_scheme_2 = "internal"
+    dummy_dns_name_1 = "dummy_dns_name_1"
+    dummy_dns_name_2 = "dummy_dns_name_2"
     dummy_status = "active"
-    dummy_dns_name = "dummy_dns_name"
-    dummy_target_group_arn = "dummy_target_group_arn"
 
-    dummy_load_balancers = {
-        "LoadBalancerArn": dummy_load_balancer_arn,
-        "DNSName": dummy_dns_name,
-        "LoadBalancerName": "dummy-load-balancer",
-        "Scheme": dummy_scheme,
+    dummy_load_balancer_1 = {
+        "LoadBalancerArn": dummy_load_balancer_arn_1,
+        "DNSName": dummy_dns_name_1,
+        "LoadBalancerName": "dummy-load-balancer-1",
+        "Scheme": dummy_scheme_1,
         "State": {"Code": dummy_status},
     }
     dummy_load_balancer_2 = {
         "LoadBalancerArn": dummy_load_balancer_arn_2,
-        "DNSName": "dummy_dns_name",
+        "DNSName": dummy_dns_name_2,
         "LoadBalancerName": "dummy-load-balancer-2",
-        "Scheme": "internal",
+        "Scheme": dummy_scheme_2,
+        "State": {"Code": dummy_status},
+    }
+    dummy_load_balancer_3 = {
+        "LoadBalancerArn": "dummy_load_balancer_arn_3",
+        "DNSName": "dummy_dns_name_3",
+        "LoadBalancerName": "dummy-load-balancer-3",
+        "Scheme": dummy_scheme_2,
         "State": {"Code": "provisioning"},
     }
 
     dummy_tags_description = [
         {
-            "ResourceArn": dummy_load_balancer_arn,
+            "ResourceArn": dummy_load_balancer_arn_1,
             "Tags": [
                 {
                     "Key": "parallelcluster:cluster-name",
@@ -39,7 +50,20 @@ class TestLoginNodesStatus:
                 },
                 {
                     "Key": "parallelcluster:login-nodes-pool",
-                    "Value": dummy_pool_name,
+                    "Value": dummy_pool_name_1,
+                },
+            ],
+        },
+        {
+            "ResourceArn": dummy_load_balancer_arn_2,
+            "Tags": [
+                {
+                    "Key": "parallelcluster:cluster-name",
+                    "Value": dummy_stack_name,
+                },
+                {
+                    "Key": "parallelcluster:login-nodes-pool",
+                    "Value": dummy_pool_name_2,
                 },
             ],
         },
@@ -52,7 +76,7 @@ class TestLoginNodesStatus:
                 },
                 {
                     "Key": "parallelcluster:login-nodes-pool",
-                    "Value": "dummy_pool_name_2",
+                    "Value": "dummy_pool_name_3",
                 },
             ],
         },
@@ -60,10 +84,15 @@ class TestLoginNodesStatus:
 
     dummy_target_groups = [
         {
-            "TargetGroupArn": dummy_target_group_arn,
+            "TargetGroupArn": dummy_target_group_arn_1,
             "HealthCheckPort": "22",
-            "LoadBalancerArns": [dummy_load_balancer_arn],
-        }
+            "LoadBalancerArns": [dummy_load_balancer_arn_1],
+        },
+        {
+            "TargetGroupArn": dummy_target_group_arn_2,
+            "HealthCheckPort": "22",
+            "LoadBalancerArns": [dummy_load_balancer_arn_2],
+        },
     ]
 
     dummy_targets_health = [
@@ -103,23 +132,44 @@ class TestLoginNodesStatus:
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
         mocker.patch(
             "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_2, self.dummy_load_balancers],
+            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2, self.dummy_load_balancer_3],
         )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
+
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
+
+        pool_1_status = login_nodes_status.get_pool_status_dict().get(self.dummy_pool_name_1)
+        pool_2_status = login_nodes_status.get_pool_status_dict().get(self.dummy_pool_name_2)
+
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
-        assert_that(login_nodes_status.get_status()).is_equal_to(LoginNodesPoolState.ACTIVE)
-        assert_that(login_nodes_status.get_address()).is_equal_to(self.dummy_dns_name)
-        assert_that(login_nodes_status.get_scheme()).is_equal_to(self.dummy_scheme)
-        assert_that(login_nodes_status.get_healthy_nodes()).is_equal_to(2)
-        assert_that(login_nodes_status.get_unhealthy_nodes()).is_equal_to(1)
+
+        assert_that(pool_1_status.get_status()).is_equal_to(LoginNodesPoolState.ACTIVE)
+        assert_that(pool_2_status.get_status()).is_equal_to(LoginNodesPoolState.ACTIVE)
+
+        assert_that(pool_1_status.get_address()).is_equal_to(self.dummy_dns_name_1)
+        assert_that(pool_2_status.get_address()).is_equal_to(self.dummy_dns_name_2)
+
+        assert_that(pool_1_status.get_scheme()).is_equal_to(self.dummy_scheme_1)
+        assert_that(pool_2_status.get_scheme()).is_equal_to(self.dummy_scheme_2)
+
+        assert_that(pool_1_status.get_healthy_nodes()).is_equal_to(2)
+        assert_that(pool_2_status.get_healthy_nodes()).is_equal_to(2)
+
+        assert_that(pool_1_status.get_unhealthy_nodes()).is_equal_to(1)
+        assert_that(pool_2_status.get_unhealthy_nodes()).is_equal_to(1)
+
+        assert_that(login_nodes_status.get_healthy_nodes()).is_equal_to(4)
+        assert_that(login_nodes_status.get_unhealthy_nodes()).is_equal_to(2)
+
         string_representation = str(login_nodes_status)
         assert_that(string_representation).is_equal_to(
-            f'("status": "{LoginNodesPoolState.ACTIVE}", "address": "{self.dummy_dns_name}", '
-            f'"scheme": "{self.dummy_scheme}", "healthyNodes": "2", "unhealthy_nodes": "1")'
+            f'("status": "{LoginNodesPoolState.ACTIVE}", "address": "{self.dummy_dns_name_1}", '
+            f'"scheme": "{self.dummy_scheme_1}", "healthy_nodes": "2", "unhealthy_nodes": "1"),'
+            f'("status": "{LoginNodesPoolState.ACTIVE}", "address": "{self.dummy_dns_name_2}", '
+            f'"scheme": "{self.dummy_scheme_2}", "healthy_nodes": "2", "unhealthy_nodes": "1"),'
         )
 
     def test_retrieve_data_no_called(self):
@@ -130,7 +180,7 @@ class TestLoginNodesStatus:
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
         mocker.patch("pcluster.aws.elb.ElbClient.list_load_balancers", return_value=[])
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_wrong_load_balancer_available(self, mocker):
@@ -149,30 +199,30 @@ class TestLoginNodesStatus:
         ]
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=dummy_tags_description)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_target_group_arn_not_available(self, mocker):
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
         mocker.patch(
             "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_2, self.dummy_load_balancers],
+            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2, self.dummy_load_balancer_3],
         )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
         mocker.patch(
             "pcluster.aws.elb.ElbClient.describe_target_groups", side_effect=Exception("Target Group Not Available")
         )
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
-        assert_that(login_nodes_status.get_healthy_nodes()).is_none()
-        assert_that(login_nodes_status.get_unhealthy_nodes()).is_none()
+        assert_that(login_nodes_status.get_healthy_nodes()).is_equal_to(0)
+        assert_that(login_nodes_status.get_unhealthy_nodes()).is_equal_to(0)
 
     def test_target_group_health_not_available(self, mocker):
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
         mocker.patch(
             "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_2, self.dummy_load_balancers],
+            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2],
         )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
@@ -180,10 +230,10 @@ class TestLoginNodesStatus:
             "pcluster.aws.elb.ElbClient.describe_target_health", side_effect=Exception("Target Group Not Available")
         )
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
-        assert_that(login_nodes_status.get_healthy_nodes()).is_none()
-        assert_that(login_nodes_status.get_unhealthy_nodes()).is_none()
+        assert_that(login_nodes_status.get_healthy_nodes()).is_equal_to(0)
+        assert_that(login_nodes_status.get_unhealthy_nodes()).is_equal_to(0)
 
     @pytest.mark.parametrize(
         "load_balancer_status, expected_status",
@@ -196,21 +246,37 @@ class TestLoginNodesStatus:
     )
     def test_login_nodes_pool_state(self, mocker, load_balancer_status, expected_status):
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        dummy_load_balancers = {
-            "LoadBalancerArn": self.dummy_load_balancer_arn,
-            "DNSName": self.dummy_dns_name,
-            "LoadBalancerName": "dummy-load-balancer",
-            "Scheme": self.dummy_scheme,
-            "State": {"Code": load_balancer_status},
-        }
+        dummy_load_balancers = [
+            {
+                "LoadBalancerArn": self.dummy_load_balancer_arn_1,
+                "DNSName": self.dummy_dns_name_1,
+                "LoadBalancerName": "dummy-load-balancer-1",
+                "Scheme": self.dummy_scheme_1,
+                "State": {"Code": load_balancer_status},
+            },
+            {
+                "LoadBalancerArn": self.dummy_load_balancer_arn_2,
+                "DNSName": self.dummy_dns_name_2,
+                "LoadBalancerName": "dummy-load-balancer-2",
+                "Scheme": self.dummy_scheme_2,
+                "State": {"Code": load_balancer_status},
+            },
+        ]
         mocker.patch(
             "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_2, dummy_load_balancers],
+            return_value=dummy_load_balancers,
         )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data(self.dummy_pool_name)
-        assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
-        assert_that(login_nodes_status.get_status()).is_equal_to(expected_status)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
+
+        pool_1_status = login_nodes_status.get_pool_status_dict().get(self.dummy_pool_name_1)
+        pool_2_status = login_nodes_status.get_pool_status_dict().get(self.dummy_pool_name_2)
+
+        assert_that(pool_1_status.get_pool_available()).is_true()
+        assert_that(pool_2_status.get_pool_available()).is_true()
+
+        assert_that(pool_1_status.get_status()).is_equal_to(expected_status)
+        assert_that(pool_2_status.get_status()).is_equal_to(expected_status)

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -34,7 +34,6 @@ from pcluster.schemas.cluster_schema import (
     LoginNodesIamSchema,
     LoginNodesImageSchema,
     LoginNodesPoolSchema,
-    LoginNodesSchema,
     QueueEphemeralVolumeSchema,
     QueueNetworkingSchema,
     QueueRootVolumeSchema,

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -730,53 +730,6 @@ def test_login_node_pool_count_validator(count, expected_message):
 
 
 @pytest.mark.parametrize(
-    "pools, expected_message",
-    [
-        ([], "Only one pool can be specified when using login nodes."),
-        (
-            [
-                {
-                    "Name": "validname1",
-                    "InstanceType": "t2.micro",
-                    "Networking": {"SubnetIds": ["subnet-01b4c1fa1de8a507f"]},
-                    "Count": 1,
-                    "Ssh": {"KeyName": "valid_key_name1"},
-                },
-                {
-                    "Name": "validname2",
-                    "InstanceType": "t2.micro",
-                    "Networking": {"SubnetIds": ["subnet-01b4c1fa1de8a507f"]},
-                    "Count": 1,
-                    "Ssh": {"KeyName": "valid_key_name2"},
-                },
-            ],
-            "Only one pool can be specified when using login nodes.",
-        ),
-        (
-            [
-                {
-                    "Name": "validname",
-                    "InstanceType": "t2.micro",
-                    "Networking": {"SubnetIds": ["subnet-01b4c1fa1de8a507f"]},
-                    "Count": 1,
-                    "Ssh": {"KeyName": "valid_key_name"},
-                }
-            ],
-            None,
-        ),
-    ],
-)
-def test_pools_validator(pools, expected_message):
-    _validate_and_assert_error(
-        LoginNodesSchema(),
-        {
-            "Pools": pools,
-        },
-        expected_message,
-    )
-
-
-@pytest.mark.parametrize(
     "instance_role, instance_profile, expected_message",
     [
         (

--- a/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pcluster.config.yaml
+++ b/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pcluster.config.yaml
@@ -28,6 +28,7 @@ HeadNode:
   Dcv:
     Enabled: True
   {% endif %}
+{% if scheduler != "awsbatch" %}
 LoginNodes:
   Pools:
     - Name: pool
@@ -52,6 +53,7 @@ LoginNodes:
       Iam:
         AdditionalIamPolicies:
           - Policy: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+{% endif %}
 Scheduling:
   Scheduler: {{ scheduler }}
   {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -194,7 +194,7 @@ def _check_response(actual_response, expected_response, validation_key):
 
 
 def _test_describe_cluster(cluster):
-    # TODO Add section for login nodes
+    # TODO Add section for login nodes once describe-cluster updated to support multiple pools
     cluster_info = cluster.describe_cluster()
     assert_that(cluster_info).is_not_none()
     assert_that(cluster_info).contains("clusterName")

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -194,6 +194,7 @@ def _check_response(actual_response, expected_response, validation_key):
 
 
 def _test_describe_cluster(cluster):
+    # TODO Add section for login nodes
     cluster_info = cluster.describe_cluster()
     assert_that(cluster_info).is_not_none()
     assert_that(cluster_info).contains("clusterName")

--- a/tests/integration-tests/tests/networking/test_security_groups/test_login_node_security_groups/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_login_node_security_groups/pcluster.config.yaml
@@ -18,13 +18,28 @@ LoginNodes:
           - {{ public_subnet_ids[0] }}
         {% if assign_additional_security_groups == False %}
         SecurityGroups:
-          - {{ default_security_group_id }}
+          - {{ default_security_group_ids[0] }}
         {% else %}
         AdditionalSecurityGroups:
-          - {{ default_security_group_id }}
+          - {{ default_security_group_ids[0] }}
         {% endif %}
       Ssh:
-        AllowedIps: {{ ssh_from }}
+        AllowedIps: {{ ssh_from[0] }}
+    - Name: pool2
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_ids[0] }}
+        {% if assign_additional_security_groups == False %}
+        SecurityGroups:
+          - {{ default_security_group_ids[1]}}
+        {% else %}
+        AdditionalSecurityGroups:
+          - {{ default_security_group_ids[1] }}
+        {% endif %}
+      Ssh:
+        AllowedIps: {{ ssh_from[1] }}
 Scheduling:
   Scheduler: slurm
   SlurmQueues:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1950,6 +1950,7 @@ def test_login_nodes_count_update(os, pcluster_config_reader, clusters_factory, 
     update_config_1 = pcluster_config_reader(config_file="pcluster_update_login_nodes_count_to_3.config.yaml")
     cluster.update(str(update_config_1))
 
+    # TODO Update once describe-cluster API response supports multiple pools
     # Describe cluster, verify the response has the login node section and the sum of healthy and unhealthy nodes is 3
     cluster_info = cluster.describe_cluster()
     assert_that(cluster_info).is_not_none()


### PR DESCRIPTION
### Description of changes
This change allows users to deploy clusters with multiple login node pools.

* Removed validator restricting number of pools to 1.
* Added duplicate name validator to `LoginNodes` resource to check that pool names are unique.
* Refactored `login_nodes_status` to support multiple pools.
    * Previously only configured to get information of the first pool. Now retrieves information for all pools in the cluster. This is used in the `update_policy.py` and `cluster_operations_controller.py` to get both total login nodes and pool specific statuses.
* Added `LOGIN_NODES_POOL_STOP` update policy.
    * The policy requires that all nodes in the pool in which the update is taking place are terminated. The previous policy, `LOGIN_NODES_STOP`, still remains and checks that all login nodes in the cluster are terminated. 
    * Changed each pool specific field with `LOGIN_NODES_STOP` update policy to `LOGIN_NODES_POOL_STOP`.
* Moved login node’s `pool-name` tag creation to Pool construct in `login_nodes_stack` so that each pool resource has correct tag.
* Added pool names to security group descriptions.
* Updated `CHANGELOG`

### Tests

#### Manual Testing:

* Created cluster containing up to five login node pools with various node counts and instance types.
    * Ensured able to connect with DCV on each pool only when configured
    * Tested slurm job submission for each pool
    * Verified managed security groups for each pool’s nodes and load balancer
* Update cluster
    * Verified new `LOGIN_NODES_POOL_STOP` update policy only applies to pool in which update is requested
    * Verified able to add pools 
    * Verified only able to remove pools when all login nodes are stopped

#### Unit tests

* Updated `test_cluster_operations_controller.py`, `test_update_policy.py`, `test_login_nodes_status.py`, `test_cluster_schema.py` to test multiple pools.
* Removed `pool_validator` unit test

#### Integration tests
* Updated `test_login_node_security_groups` to test security groups of multiple pools.


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
