### PR TITLE
[integ-test] Fix build_image_custom_resource fixture

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -418,7 +418,6 @@ def build_image_custom_resource(cfn_stacks_factory, region, request):
                 ]
             },
         )
-        role_name = "".join(["dummyInstanceRole", generate_random_string()])
         instance_role = iam.Role(
             "CustomInstanceRole",
             AssumeRolePolicyDocument={
@@ -430,7 +429,6 @@ def build_image_custom_resource(cfn_stacks_factory, region, request):
             ManagedPolicyArns=managed_policy_arns,
             Path="/parallelcluster/",
             Policies=[policy_document],
-            RoleName=role_name,
         )
 
         custom_resource_template.add_resource(instance_role)
@@ -442,6 +440,7 @@ def build_image_custom_resource(cfn_stacks_factory, region, request):
         )
         cfn_stacks_factory.create_stack(custom_resource_stack)
 
+        role_name = custom_resource_stack.cfn_resources["CustomInstanceRole"]
         instance_role_arn = boto3.client("iam").get_role(RoleName=role_name).get("Role").get("Arn")
         logging.info("Custom instance role arn %s", instance_role_arn)
 


### PR DESCRIPTION
Before this commit, `instance_role_arn` of another role could be returned just because the other role has the same role name prefix "dummyInstanceRole". This commit uses the complete role name to get the `instance_role_arn`

### Tests
* `test_build_image` has been passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
