### PR TITLE
Increase default PCLUSTER_RESERVED_VOLUME_SIZE to 32

### DIFF
--- a/cli/src/pcluster/imagebuilder_utils.py
+++ b/cli/src/pcluster/imagebuilder_utils.py
@@ -16,7 +16,7 @@ from pcluster.aws.aws_api import AWSApi
 from pcluster.utils import get_url_scheme, yaml_load
 
 ROOT_VOLUME_TYPE = "gp3"
-PCLUSTER_RESERVED_VOLUME_SIZE = 27
+PCLUSTER_RESERVED_VOLUME_SIZE = 32
 AMI_NAME_REQUIRED_SUBSTRING = " {{ imagebuilder:buildDate }}"
 
 

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -3317,7 +3317,7 @@ def test_imagebuilder_distribution_configuraton(mocker, resource, response, expe
                     }
                 ],
             },
-            {"Encrypted": False, "VolumeSize": 35, "VolumeType": "gp3"},
+            {"Encrypted": False, "VolumeSize": 40, "VolumeType": "gp3"},
         ),
         (
             {
@@ -3399,7 +3399,7 @@ def test_imagebuilder_distribution_configuraton(mocker, resource, response, expe
             },
             {
                 "Encrypted": True,
-                "VolumeSize": 77,
+                "VolumeSize": 82,
                 "VolumeType": "gp3",
                 "KmsKeyId": "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
             },


### PR DESCRIPTION
The vanilla AL2 AMI is 8GB, with additional 32 GB, the outcome 40GB is the same size as our official AMI

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
