### PR TITLE
Fix storage-stack.yaml

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -221,6 +221,7 @@ changedir =
 deps = cfn-lint
 commands =
     cfn-lint --info networking/*.cfn.json
+    cfn-lint --non-zero-exit-code error */*.yaml
 
 # Validates that cfn json templates are correctly formatted.
 [testenv:cfn-format-check]

--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -40,6 +40,10 @@ Metadata:
         default: "The CIDR block to be used for the first Subnet if its creation is requested."
       Subnet2CidrBlock:
         default: "The CIDR block to be used for the second Subnet if its creation is requested."
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E3690
 Parameters:
   ClusterName:
     Description: Database Cluster Name

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -28,6 +28,10 @@ Metadata:
           default: Permissions
         Parameters:
           - Keypair
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E1152
 
 Resources:
 

--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -75,7 +75,8 @@ Parameters:
     Default: ''
   SubnetThree:
     Description: ID of the Subnet (third Availability Zone) where the storage will be deployed.
-    Type: AWS::EC2::Subnet::Id
+    # The type has to be String to allow empty values.
+    Type: String
     Default: ''
   EbsVolumeAz:
     Description: AZ where the EBS Volume will be deployed. It must be the same AZ used by the cluster head node.


### PR DESCRIPTION
1. Change the type of `SubnetThree` from `AWS::EC2::Subnet::Id` to `String` to allow empty value.
2. Add `cfn-lint` for the template

### References
* Cherry picked from https://github.com/aws/aws-parallelcluster/pull/6402

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
