### PR TITLE
[integ-tests] Remove Rocky from daily integration tests

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -77,7 +77,7 @@ test-suites:
         - regions: [ "ap-northeast-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: [ "rocky8", "ubuntu2204" ]
+          oss: [ "rhel8", "ubuntu2204" ]
   createami:
     test_createami.py::test_invalid_config:
       dimensions:
@@ -165,7 +165,7 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
@@ -208,7 +208,7 @@ test-suites:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: ["rhel9"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:
@@ -220,7 +220,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: ["rhel8"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:


### PR DESCRIPTION
Because ParallelCluster does not release Rocky AMI, the integration tests for released version started to fail 40 days after the release, because we clean up resources older than 40 days.

This commit removes Rocky from daily integration tests. This commit is only pointed to integ-tests-3.10.1. develop and release-3.10 branch shouldn't be changed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
