### PR TITLE
[Develop] Fix No route tables found bug when specifying default VPC subnet to LoginNodes/Networking/SubnetIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - Fix issue with login nodes being marked unhealthy when restricting SSH access.
 - Fix `retrieve_supported_regions` so that it can get the correct S3 url.
 - Fix `describe_images` so that it uses pagination.
+- Fix `No route tables found` bug when specifying default VPC subnet to LoginNodes/Networking/SubnetIds.
 
 3.10.1
 ------

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -565,7 +565,7 @@ class Ec2Client(Boto3Client):
             subnets = self.describe_subnets([subnet_id])
             if not subnets:
                 raise Exception(f"No subnet found with ID {subnet_id}")
-            vpc_id = subnets[0].get('VpcId')
+            vpc_id = subnets[0].get("VpcId")
 
             route_tables = self.describe_route_tables(filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
             if not route_tables:


### PR DESCRIPTION
### Description of changes
* If the subnet doesn't have a specific route table, this typically happens when the subnet is using the VPC's main route table. So add steps to fetch the VPC-level route table.

### Tests
* Manually test done and worked as expected.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
