### PR TITLE
Refactor snapshot factory to use f strings instead of bizarre {}1 syntax

### DIFF
--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -133,10 +133,10 @@ class EBSSnapshotsFactory:
         device_name = ssh_conn.run("readlink -f /dev/sdf").stdout.strip()
         # formats the 1st partition of disk
         logging.info("Formatting 1st partition...")
-        ssh_conn.run("sudo sh -c 'mkfs.ext4 {}1'".format(device_name))
+        ssh_conn.run(f"sudo sh -c 'mkfs.ext4 {device_name}'")
         logging.info("Mounting partition...")
         ssh_conn.run("sudo mkdir /mnt/tmp")
-        ssh_conn.run("sudo mount {}1 /mnt/tmp".format(device_name))
+        ssh_conn.run(f"sudo mount {device_name} /mnt/tmp")
         logging.info("Writing test data...")
         ssh_conn.run("echo 'hello world' | sudo tee -a /mnt/tmp/test.txt")
         logging.info("Device ready")


### PR DESCRIPTION
### Tests
* Ran local test_ebs_existing integ test and it is passing

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
