### PR TITLE
Upgrade rocky9 version in createami to 9.4

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -53,7 +53,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.3*_HVM-*", "owners": RHEL_OWNERS},
-    "rocky9": {"name": "Rocky-9-EC2-Base-9.3*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky9": {"name": "Rocky-9-EC2-Base-9.4*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
 # Remarkable AMIs are latest deep learning base AMI and FPGA developer AMI without pcluster infrastructure
@@ -68,7 +68,7 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.3*_HVM-*", "owners": RHEL_OWNERS},
-    "rocky9": {"name": "Rocky-9-EC2-Base-9.3*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky9": {"name": "Rocky-9-EC2-Base-9.4*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
 OS_TO_KERNEL4_AMI_NAME_OWNER_MAP = {


### PR DESCRIPTION
### Description of changes
* Upgrade rocky9 version in createami to 9.4
* When using a rocky9.3 base image instead of a rocky9.4 base image, the lustre client will not work unless we update the kernel, which caused build-image to fail
* Cherry pick of: https://github.com/aws/aws-parallelcluster/pull/6438


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
