### PR TITLE
[Test] Upgrade fabtests to version 1.22.0 so that it is aligned to the current version of libfabric.

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
@@ -8,7 +8,7 @@ set -ex
 FABTESTS_DIR="$1"
 
 FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"
-FABTESTS_VERSION="1.21.0"
+FABTESTS_VERSION="1.22.0"
 FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
 CUDA_DIR="/usr/local/cuda"


### PR DESCRIPTION
### Description of changes
Upgrade fabtests to version 1.22.0 so that it is aligned to the current version of libfabric.

In general, the versions of fabtests should always be aligned to the one of libfabric to prevent false positive test failures.
In this specific case there is only one nice to have test that is failing, but it's worth aligning.

### Tests
Will be tested on the pipeline.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
