### PR TITLE
[integ-tests-framework] Change integration tests OS daily to increase coverage and avoid false failures when AMIs failed to build

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -36,19 +36,19 @@ that lists all the available options:
 
 ```
 python -m test_runner --help
-usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELISM] [--sequential] [--credential CREDENTIAL] [--use-default-iam-credentials] [--retry-on-failures] [--tests-root-dir TESTS_ROOT_DIR] [-c TESTS_CONFIG]
-                      [-i [INSTANCES [INSTANCES ...]]] [-o [OSS [OSS ...]]] [-s [SCHEDULERS [SCHEDULERS ...]]] [-r [REGIONS [REGIONS ...]]] [-f FEATURES [FEATURES ...]] [--show-output]
-                      [--reports {html,junitxml,json,cw} [{html,junitxml,json,cw} ...]] [--cw-region CW_REGION] [--cw-namespace CW_NAMESPACE] [--cw-timestamp-day-start] [--output-dir OUTPUT_DIR] [--custom-node-url CUSTOM_NODE_URL]
-                      [--custom-cookbook-url CUSTOM_COOKBOOK_URL] [--createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL] [--createami-custom-node-url CREATEAMI_CUSTOM_NODE_URL] [--custom-awsbatchcli-url CUSTOM_AWSBATCHCLI_URL]
-                      [--pre-install PRE_INSTALL] [--post-install POST_INSTALL] [--instance-types-data INSTANCE_TYPES_DATA] [--custom-ami CUSTOM_AMI] [--pcluster-git-ref PCLUSTER_GIT_REF] [--cookbook-git-ref COOKBOOK_GIT_REF]
-                      [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
-                      [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
-                      [--no-delete] [--retain-ad-stack] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
-                      [--bucket-name BUCKET_NAME] [--proxy-stack PROXY_STACK_NAME] [--build-image-roles-stack BUILD_IMAGE_ROLES_STACK_NAME] [--api-stack API_STACK_NAME]
+usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELISM] [--sequential] [--credential CREDENTIAL] [--use-default-iam-credentials] [--retry-on-failures] [--tests-root-dir TESTS_ROOT_DIR] [--global-build-number GLOBAL_BUILD_NUMBER] [-c TESTS_CONFIG] [-i [INSTANCES ...]]
+                      [-o [OSS ...]] [-s [SCHEDULERS ...]] [-r [REGIONS ...]] [-f FEATURES [FEATURES ...]] [--show-output] [--reports {html,junitxml,json,cw} [{html,junitxml,json,cw} ...]] [--cw-region CW_REGION] [--cw-namespace CW_NAMESPACE] [--cw-timestamp-day-start] [--output-dir OUTPUT_DIR]
+                      [--custom-node-url CUSTOM_NODE_URL] [--custom-cookbook-url CUSTOM_COOKBOOK_URL] [--createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL] [--createami-custom-node-url CREATEAMI_CUSTOM_NODE_URL] [--custom-awsbatchcli-url CUSTOM_AWSBATCHCLI_URL] [--pre-install PRE_INSTALL]
+                      [--post-install POST_INSTALL] [--instance-types-data INSTANCE_TYPES_DATA] [--custom-ami CUSTOM_AMI] [--pcluster-git-ref PCLUSTER_GIT_REF] [--cookbook-git-ref COOKBOOK_GIT_REF] [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--available-amis-oss-x86 [AVAILABLE_AMIS_OSS_X86 ...]]
+                      [--available-amis-oss-arm [AVAILABLE_AMIS_OSS_ARM ...]] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME] [--scaling-test-config SCALING_TEST_CONFIG]
+                      [--cluster-custom-resource-service-token CLUSTER_CUSTOM_RESOURCE_SERVICE_TOKEN] [--resource-bucket RESOURCE_BUCKET] [--lambda-layer-source LAMBDA_LAYER_SOURCE] [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI]
+                      [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--no-delete] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--iam-user-role-stack-name IAM_USER_ROLE_STACK_NAME] [--directory-stack-name DIRECTORY_STACK_NAME]
+                      [--slurm-database-stack-name SLURM_DATABASE_STACK_NAME] [--slurm-dbd-stack-name SLURM_DBD_STACK_NAME] [--munge-key-secret-arn MUNGE_KEY_SECRET_ARN] [--external-shared-storage-stack-name EXTERNAL_SHARED_STORAGE_STACK_NAME] [--bucket-name BUCKET_NAME]
+                      [--custom-security-groups-stack-name CUSTOM_SECURITY_GROUPS_STACK_NAME] [--force-run-instances] [--force-elastic-ip] [--retain-ad-stack] [--proxy-stack PROXY_STACK] [--build-image-roles-stack BUILD_IMAGE_ROLES_STACK] [--api-stack API_STACK]
 
 Run integration tests suite.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --key-name KEY_NAME   Key to use for EC2 instances (default: None)
   --key-path KEY_PATH   Path to the key to use for SSH connections (default: None)
@@ -56,26 +56,27 @@ optional arguments:
                         Tests parallelism for every region. (default: None)
   --sequential          Run tests in a single process. When not specified tests will spawn a process for each region under test. (default: False)
   --credential CREDENTIAL
-                        STS credential to assume when running tests in a specific region.Credentials need to be in the format <region>,<endpoint>,<ARN>,<externalId> and can be specified multiple times. <region> represents the region
-                        credentials are used for, <endpoint> is the sts endpoint to contact in order to assume credentials, <account-id> is the id of the account where the role to assume is defined, <externalId> is the id to use when
-                        assuming the role. (e.g. ap-east-1,https://sts.us-east-1.amazonaws.com,arn:aws:iam::<account-id>:role/role-to-assume,externalId) (default: None)
+                        STS credential to assume when running tests in a specific region.Credentials need to be in the format <region>,<endpoint>,<ARN>,<externalId> and can be specified multiple times. <region> represents the region credentials are used for, <endpoint> is the sts endpoint to contact in
+                        order to assume credentials, <account-id> is the id of the account where the role to assume is defined, <externalId> is the id to use when assuming the role. (e.g. ap-east-1,https://sts.us-east-1.amazonaws.com,arn:aws:iam::<account-id>:role/role-to-assume,externalId) (default: None)
   --use-default-iam-credentials
                         Use the default IAM creds to run pcluster CLI commands. Skips the creation of pcluster CLI IAM role. (default: False)
   --retry-on-failures   Retry once more the failed tests after a delay of 60 seconds. (default: False)
   --tests-root-dir TESTS_ROOT_DIR
                         Root dir where integration tests are defined (default: ./tests)
+  --global-build-number GLOBAL_BUILD_NUMBER
+                        The build number passed from the testing pipelines (default: 0)
 
 Test dimensions:
   -c TESTS_CONFIG, --tests-config TESTS_CONFIG
-                        Config file that specifies the tests to run and the dimensions to enable for each test. Note that when a config file is used the following flags are ignored: instances, regions, oss, schedulers. Refer to the docs
-                        for further details on the config format: https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/README.md (default: None)
-  -i [INSTANCES [INSTANCES ...]], --instances [INSTANCES [INSTANCES ...]]
+                        Config file that specifies the tests to run and the dimensions to enable for each test. Note that when a config file is used the following flags are ignored: instances, regions, oss, schedulers. Refer to the docs for further details on the config format: https://github.com/aws/aws-
+                        parallelcluster/blob/develop/tests/integration-tests/README.md (default: None)
+  -i [INSTANCES ...], --instances [INSTANCES ...]
                         AWS instances under test. Ignored when tests-config is used. (default: [])
-  -o [OSS [OSS ...]], --oss [OSS [OSS ...]]
+  -o [OSS ...], --oss [OSS ...]
                         OSs under test. Ignored when tests-config is used. (default: [])
-  -s [SCHEDULERS [SCHEDULERS ...]], --schedulers [SCHEDULERS [SCHEDULERS ...]]
+  -s [SCHEDULERS ...], --schedulers [SCHEDULERS ...]
                         Schedulers under test. Ignored when tests-config is used. (default: [])
-  -r [REGIONS [REGIONS ...]], --regions [REGIONS [REGIONS ...]]
+  -r [REGIONS ...], --regions [REGIONS ...]
                         AWS regions where tests are executed. Ignored when tests-config is used. (default: [])
   -f FEATURES [FEATURES ...], --features FEATURES [FEATURES ...]
                         Run only tests for the listed features. Prepending the not keyword to the feature name causes the feature to be excluded. (default: )
@@ -83,8 +84,7 @@ Test dimensions:
 Test reports:
   --show-output         Do not redirect tests stdout to file. Not recommended when running in multiple regions. (default: None)
   --reports {html,junitxml,json,cw} [{html,junitxml,json,cw} ...]
-                        create tests report files. junitxml creates a junit-xml style report file. html creates an html style report file. json creates a summary with details for each dimensions. cw publishes tests metrics into
-                        CloudWatch (default: [])
+                        create tests report files. junitxml creates a junit-xml style report file. html creates an html style report file. json creates a summary with details for each dimensions. cw publishes tests metrics into CloudWatch (default: [])
   --cw-region CW_REGION
                         Region where to publish CloudWatch metrics (default: us-east-1)
   --cw-namespace CW_NAMESPACE
@@ -123,19 +123,27 @@ AMI selection parameters:
                         Git ref of the custom node package used to build the AMI. (default: None)
   --ami-owner AMI_OWNER
                         Override the owner value when fetching AMIs to use with cluster. By default pcluster uses amazon. (default: None)
+  --available-amis-oss-x86 [AVAILABLE_AMIS_OSS_X86 ...]
+                        (optional) set to available x86 AMIs OSes in the account. If not specified, all supported OSes will be used. (default: [])
+  --available-amis-oss-arm [AVAILABLE_AMIS_OSS_ARM ...]
+                        (optional) set to available ARM AMIs OSes in the account. If not specified, all supported OSes will be used. (default: [])
 
 Benchmarks:
-  --benchmarks          Run benchmarks tests. Benchmarks tests will be run together with functionality tests. (default: False)
-  
-Scaling test options:
-    --scaling-test-config SCALING_TEST_CONFIG
-                        Path to the config file containing scaling stress test parameters  (default: None)
+  --benchmarks          run benchmarks tests. This disables the execution of all tests defined under the tests directory. (default: False)
+  --benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY
+                        set the target capacity for benchmarks tests (default: 200)
+  --benchmarks-max-time BENCHMARKS_MAX_TIME
+                        set the max waiting time in minutes for benchmarks tests (default: 30)
+
+Scaling stress test options:
+  --scaling-test-config SCALING_TEST_CONFIG
+                        config file with scaling test parameters (default: None)
 
 CloudFormation / Custom Resource options:
   --cluster-custom-resource-service-token CLUSTER_CUSTOM_RESOURCE_SERVICE_TOKEN
                         ServiceToken (ARN) Cluster CloudFormation custom resource provider (default: None)
   --resource-bucket RESOURCE_BUCKET
-                        Name of bucket to use to to retrieve standard hosted resources like CloudFormation templates. {region} can be used to parametrize this value, and the bucket name will be formatted with the region where the test will be run (default: None)
+                        Name of bucket to use to to retrieve standard hosted resources like CloudFormation templates. (default: None)
   --lambda-layer-source LAMBDA_LAYER_SOURCE
                         S3 URI of lambda layer to copy instead of building. (default: None)
 
@@ -152,36 +160,39 @@ Debugging/Development options:
   --vpc-stack VPC_STACK
                         Name of an existing vpc stack. (default: None)
   --cluster CLUSTER     Use an existing cluster instead of creating one. (default: None)
-  --iam-user-role-stack-name
-                        Name of an existing IAM user role stack. (default: None)
-  --directory-stack-name
-                        Name of CFN stack providing AD domain to be used for testing AD integration feature. (default: None)
-  --ldaps-nlb-stack-name
-                        Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
-
   --no-delete           Don't delete stacks after tests are complete. (default: False)
-
-  --retain-ad-stack     Retain AD stack and corresponding VPC stack after tests are complete. (default: False)
-
   --delete-logs-on-success
                         delete CloudWatch logs when a test succeeds (default: False)
   --stackname-suffix STACKNAME_SUFFIX
                         set a suffix in the integration tests stack names (default: )
   --dry-run             Only show the list of tests that would run with specified options. (default: False)
+  --iam-user-role-stack-name IAM_USER_ROLE_STACK_NAME
+                        Name of an existing IAM user role stack. (default: None)
   --directory-stack-name DIRECTORY_STACK_NAME
                         Name of CFN stack providing AD domain to be used for testing AD integration feature. (default: None)
-  --ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME
-                        Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD integration feature. (default: None)
-  --external-shared-storage-stack-name
-                        Name of an existing external shared storage stack. (default: None)
-  --bucket-name
-                        Name of an existing bucket. (default: None)
-  --proxy-stack
-                        Name of an existing proxy stack. (default: None)
-  --build-image-roles-stack
-                        Name of CFN stack providing the build image permissions. (default: None)
-  --api-stack
+  --slurm-database-stack-name SLURM_DATABASE_STACK_NAME
+                        Name of CFN stack providing database stack to be used for testing Slurm accounting feature. (default: None)
+  --slurm-dbd-stack-name SLURM_DBD_STACK_NAME
+                        Name of CFN stack providing external Slurm dbd stack to be used for testing Slurm accounting feature. (default: None)
+  --munge-key-secret-arn MUNGE_KEY_SECRET_ARN
+                        ARN of the secret containing the munge key to be used for testing Slurm accounting feature. (default: None)
+  --external-shared-storage-stack-name EXTERNAL_SHARED_STORAGE_STACK_NAME
+                        Name of existing external shared storage stack. (default: None)
+  --bucket-name BUCKET_NAME
+                        Name of existing bucket. (default: None)
+  --custom-security-groups-stack-name CUSTOM_SECURITY_GROUPS_STACK_NAME
+                        Name of existing custom security groups stack. (default: None)
+  --force-run-instances
+                        Force the usage of EC2 run-instances boto3 API instead of create-fleet for compute fleet scaling up.Note: If there are multiple instances in the list, only the first will be used. (default: False)
+  --force-elastic-ip    Force the usage of Elastic IP for Multi network interface EC2 instances (default: False)
+  --retain-ad-stack     Retain AD stack and corresponding VPC stack. (default: False)
+  --proxy-stack PROXY_STACK
+                        Name of CFN stack providing a Proxy environment. (default: None)
+  --build-image-roles-stack BUILD_IMAGE_ROLES_STACK
+                        Name of CFN stack providing build image permissions. (default: None)
+  --api-stack API_STACK
                         Name of CFN stack providing the ParallelCluster API infrastructure. (default: None)
+
 ```
 
 Here is an example of tests submission:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -8,35 +8,35 @@ test-suites:
       dimensions:
         - regions: [ "ap-southeast-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "rhel8"]
+          oss: [ {{ OS_X86_0 }}, {{ OS_X86_2 }}]
           schedulers: ["slurm"]
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204", "rhel9"]
+          oss: [{{ OS_X86_4 }}, {{ OS_X86_6 }}]
           schedulers: ["slurm"]
   basic:
     test_essential_features.py::test_essential_features:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
   capacity_reservations:
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:
         - regions: ["us-west-2"]
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_3 }}]
     test_capacity_blocks.py::test_capacity_blocks:
       dimensions:
         - regions: ["eu-west-1"]
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
   cli_commands:
     test_cli_commands.py::test_slurm_cli_commands:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
   cloudwatch_logging:
     test_cloudwatch_logging.py::test_cloudwatch_logging:
@@ -44,35 +44,31 @@ test-suites:
         # 1) run the test for all the schedulers with alinux2
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: {{ common.SCHEDULERS_TRAD }}
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["awsbatch"]
         # 2) run the test for all OSes with slurm
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204", "rhel8"]
+          oss: [{{ OS_ARM_0 }}]
           schedulers: ["slurm"]
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["ubuntu2004"]
-        - regions: ["ap-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_4 }}]
     test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_compute_console_output_logging.py::test_custom_action_error:
       dimensions:
         - regions: ["ap-east-1"]
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_1 }}]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
   configure:
@@ -80,30 +76,30 @@ test-suites:
       dimensions:
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["alinux2"]
+          oss: [{{ OS_ARM_2 }}]
           schedulers: ["slurm"]
     test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
       dimensions:
         - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
     test_pcluster_configure.py::test_region_without_t2micro:
       dimensions:
         - regions: ["eu-north-1"] # must be regions that do not have t2.micro
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
     test_pcluster_configure.py::test_efa_and_placement_group:
       dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_EFA_SUPPORTED_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_pcluster_configure.py::test_efa_unsupported:
       dimensions:
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_EFA_UNSUPPORTED_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
   create:
     test_create.py::test_create_wrong_os:
@@ -122,38 +118,38 @@ test-suites:
       dimensions:
         - regions: ["eu-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{common.OSS_COMMERCIAL_X86}}
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
     test_create.py::test_cluster_creation_with_problematic_preinstall_script:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           schedulers: ["slurm"]
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_ARM_4 }}]
     test_create.py::test_cluster_creation_timeout:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
     test_create.py::test_cluster_creation_with_invalid_ebs:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           schedulers: ["slurm"]
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_ARM_6 }}]
     test_create.py::test_create_disable_sudo_access_for_default_user:
       dimensions:
         - regions: [ "ap-northeast-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: [ "rocky8", "ubuntu2204" ]
+          oss: [ {{ OS_X86_1 }} ]
   createami:
     test_createami.py::test_invalid_config:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_3 }}]
     test_createami.py::test_build_image:
       dimensions:
         - regions: ["eu-west-3"]
@@ -163,24 +159,24 @@ test-suites:
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_7 }}]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_0 }}]
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["alinux2"]
+          oss: [{{ OS_ARM_1 }}]
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["alinux2"]
+          oss: [{{ OS_ARM_3 }}]
     test_createami.py::test_build_image_wrong_pcluster_version:
       dimensions:
         - regions: ["ca-central-1"]
@@ -189,42 +185,42 @@ test-suites:
   custom_resource:
     test_cluster_custom_resource.py::test_cluster_create:
       dimensions:
-        - oss: ["alinux2"]
+        - oss: [{{ OS_X86_2 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_create_invalid:
       dimensions:
-        - oss: ["alinux2"]
+        - oss: [{{ OS_X86_4 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update:
       dimensions:
-        - oss: ["rocky8"]
+        - oss: [{{ OS_X86_6 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update_invalid:
       dimensions:
-        - oss: ["alinux2023"]
+        - oss: [{{ OS_X86_1 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
       dimensions:
-        - oss: [ "ubuntu2004" ]
+        - oss: [{{ OS_X86_3 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
       dimensions:
-        - oss: ["ubuntu2204"]
+        - oss: [{{ OS_X86_5 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_delete_retain:
       dimensions:
-        - oss: ["rocky9"]
+        - oss: [{{ OS_X86_7 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
       dimensions:
-        - oss: ["rhel8"]
+        - oss: [{{ OS_X86_0 }}]
           regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
   dcv:
@@ -243,31 +239,31 @@ test-suites:
         # DCV in cn regions and non GPU enabled instance
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
         # DCV in gov-cloud regions and non GPU enabled instance
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
     test_dcv.py::test_dcv_with_remote_access:
       dimensions:
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
   dns:
     test_dns.py::test_hit_no_cluster_dns_mpi:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_dns.py::test_existing_hosted_zone:
       dimensions:
         - regions: ["eu-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
@@ -297,7 +293,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
   iam:
     test_iam.py::test_iam_policies:
@@ -315,19 +311,19 @@ test-suites:
     test_iam_image.py::test_iam_roles:
       dimensions:
         - regions: ["eu-south-1"]
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_7 }}]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_iam.py::test_s3_read_write_resource:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
     test_iam.py::test_iam_resource_prefix:
       dimensions:
         - regions: [ "eu-north-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "alinux2" ]
+          oss: [{{ OS_X86_2 }}]
           schedulers: [ "slurm" ]
   monitoring:
     test_monitoring.py::test_monitoring:
@@ -335,7 +331,7 @@ test-suites:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_4 }}]
   multiple_nics:
     test_multiple_nics.py::test_multiple_nics:
       dimensions:
@@ -348,13 +344,13 @@ test-suites:
       dimensions:
         - regions: ["il-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_cluster_networking.py::test_existing_eip:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_networking.py::test_public_network_topology:
       dimensions:
@@ -368,54 +364,54 @@ test-suites:
         # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
+          oss: [{{ OS_ARM_3 }}]
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_security_groups.py::test_additional_sg_and_ssh_from:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
     test_security_groups.py::test_overwrite_sg:
       dimensions:
         - regions: ["ap-southeast-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_placement_group.py::test_placement_group:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
   scaling:
     test_scaling.py::test_job_level_scaling:
       dimensions:
         - regions: ["ap-southeast-3"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_ARM_3 }}]
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
@@ -434,143 +430,143 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_from_login_nodes_in_private_network:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
-          oss: [ "alinux2023" ]
+          oss: [{{ OS_X86_4 }}]
           schedulers: [ "slurm" ]
     test_slurm.py::test_error_handling:
       dimensions:
         - regions: ["ap-southeast-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_1 }}"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_protected_mode_on_cluster_create:
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_fast_capacity_failover:
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_config_update:
       dimensions:
         - regions: [ "ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: [ "slurm" ]
     test_slurm.py::test_slurm_memory_based_scheduling:
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_scontrol_reboot:
       dimensions:
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_scontrol_reboot_ec2_health_checks:
       dimensions:
         - regions: ["us-east-2"]
           instances: ["t3.medium"]
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_overrides:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_slurm_accounting.py::test_slurm_accounting:
       dimensions:
         - regions: ["ap-south-1"]
           instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_slurm_accounting.py::test_slurm_accounting_external_dbd:
       dimensions:
         - regions: [ "ap-south-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_custom_config_parameters:
       dimensions:
         - regions: ["ap-southeast-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_custom_partitions:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_custom_munge_key.py::test_custom_munge_key:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
   spot:
     test_spot.py::test_spot_default:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_spot.py::test_spot_price_capacity_optimized:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
   storage:
     test_fsx_lustre.py::test_fsx_lustre:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_ARM_1 }}]
           schedulers: ["slurm"]
     test_fsx_lustre.py::test_fsx_lustre_dra:
       dimensions:
         - regions: [ "eu-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "alinux2" ]
+          oss: [{{ OS_X86_3 }}]
           schedulers: [ "slurm" ]
         - regions: [ "eu-north-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: [ "ubuntu2204" ]
+          oss: [{{ OS_ARM_5 }}]
           schedulers: [ "slurm" ]
     test_fsx_lustre.py::test_file_cache:
       dimensions:
         - regions: [ "eu-north-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: [ "ubuntu2204" ]
+          oss: [{{ OS_ARM_7 }}]
           schedulers: [ "slurm" ]
     # The checks performed in test_multiple_fsx is the same as test_fsx_lustre.
     # We should consider this when assigning dimensions to each test.
@@ -578,50 +574,50 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_ARM_2 }}]
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
         - regions: [ "us-gov-west-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: [ "slurm" ]
     test_fsx_lustre.py::test_multi_az_fsx:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_fsx_lustre.py::test_fsx_lustre_configuration_options:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
     test_fsx_lustre.py::test_fsx_lustre_backup:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
+          oss: [{{ OS_ARM_5 }}]
           schedulers: ["slurm"]
     # EFS tests can be done in any region.
     test_efs.py::test_efs_compute_az:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_efs.py::test_efs_same_az:
       dimensions:
         - regions: [ "ca-central-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: [ "slurm" ]
     # The checks performed in test_efs_same_az is similar to test_multiple_efs.
     # We should consider this when assigning dimensions to each test.
@@ -633,90 +629,90 @@ test-suites:
           schedulers: ["awsbatch"]
         - regions: [ "ca-central-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_ARM_2 }}]
           schedulers: [ "slurm" ]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: ["slurm"]
     test_efs.py::test_efs_access_point:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_raid.py::test_raid_fault_tolerance_mode:
       dimensions:
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_raid.py::test_raid_performance_mode:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
         - regions: [ "ap-south-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_5 }}]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_multiple:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2204"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_single:
       dimensions:
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_snapshot:
       dimensions:
         - regions: [ "us-east-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_4 }}]
           schedulers: [ "slurm" ]
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_existing:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
     test_deletion_policy.py::test_retain_on_deletion:
       dimensions:
         - regions: ["ap-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
     # Ephemeral test requires instance type with instance store
     test_ephemeral.py::test_head_node_stop:
       dimensions:
         - regions: ["use1-az4"]
           instances: ["m5d.xlarge"]  # SSD based instance
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
     test_internal_efs.py::test_internal_efs:
       dimensions:
         - regions: [ "us-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT }}
-          oss: [ "ubuntu2204" ]
+          oss: [{{ OS_X86_7 }}]
           schedulers: [ "slurm" ]
     test_shared_home.py::test_shared_home:
       dimensions:
         - regions: [ "us-west-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "alinux2023" ]
+          oss: [{{ OS_X86_0 }}]
           schedulers: [ "slurm" ]
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
@@ -729,25 +725,25 @@ test-suites:
       dimensions:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky9"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_api.py::test_custom_image:
       dimensions:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_4 }}]
     test_api.py::test_login_nodes:
       dimensions:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2023"]
+          oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
   resource_bucket:
     test_resource_bucket.py::test_resource_bucket:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
   tags:
     test_tag_propagation.py::test_tag_propagation:
@@ -767,39 +763,39 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_3 }}]
     test_update.py::test_update_compute_ami:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_5 }}]
     test_update.py::test_update_instance_list:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]
     test_update.py::test_queue_parameters_update:
       dimensions:
         - regions: [ "ap-south-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rocky8"]
+          oss: [{{ OS_X86_0 }}]
           schedulers: [ "slurm" ]
     test_update.py::test_dynamic_file_systems_update:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
     test_update.py::test_dynamic_file_systems_update_data_loss:
       dimensions:
         - regions: [ "eu-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "alinux2023" ]
+          oss: [{{ OS_X86_4 }}]
           schedulers: [ "slurm" ]
     test_update.py::test_dynamic_file_systems_update_rollback:
       dimensions:
-        - regions: [ "eu-west-2" ]
+        - regions: [{{ OS_X86_6 }}]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [ "rhel8" ]
           schedulers: [ "slurm" ]
@@ -807,18 +803,18 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           schedulers: ["slurm"]
-          oss: ["alinux2"]
+          oss: [{{ OS_X86_1 }}]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_update.py::test_login_nodes_update:
       dimensions:
         - regions: ["us-east-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: [{{ OS_X86_3 }}]
           schedulers: ["slurm"]
   users:
     test_default_user_home.py::test_default_user_local_home:
       dimensions:
-        - oss: [ "alinux2" ]
+        - oss: [{{ OS_X86_5 }}]
           regions: [ "us-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
@@ -827,5 +823,5 @@ test-suites:
       dimensions:
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: [{{ OS_X86_7 }}]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -124,6 +124,16 @@ def pytest_addoption(parser):
         "--ami-owner",
         help="Override the owner value when fetching AMIs to use with cluster. By default pcluster uses amazon.",
     )
+    parser.addoption(
+        "--available-amis-oss-x86",
+        help="(optional) set to available x86 AMIs OSes in the account. "
+        "If not specified, all supported OSes will be used.",
+    )
+    parser.addoption(
+        "--available-amis-oss-arm",
+        help="(optional) set to available ARM AMIs OSes in the account. "
+        "If not specified, all supported OSes will be used.",
+    )
     parser.addoption("--createami-custom-node-package", help="url to a custom node package for the build-image command")
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")
     parser.addoption("--cw-dashboard-template-url", help="url to a custom Dashboard cfn template")
@@ -240,7 +250,7 @@ def pytest_configure(config):
     """This hook is called for every plugin and initial conftest file after command line options have been parsed."""
     # read tests config file if used
     if config.getoption("tests_config_file", None):
-        config.option.tests_config = read_config_file(config.getoption("tests_config_file"))
+        config.option.tests_config = read_config_file(config.getoption("tests_config_file"), config=config)
 
     # Read instance types data file if used
     if config.getoption("instance_types_data_file", None):

--- a/tests/integration-tests/tox.ini
+++ b/tests/integration-tests/tox.ini
@@ -6,6 +6,7 @@ basepython = python3
 skip_install = true
 deps = -r requirements.txt
 commands =
+    pip install ../../cli
     python -m framework.tests_configuration.config_validator {posargs:--tests-configs-dir configs/} --tests-root-dir tests/
 
 [testenv:generate-test-config]


### PR DESCRIPTION


### Description of changes
Prior to this commit, OSes were specified for each integration test. For example, in [`develop.yaml`](https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/configs/develop.yaml)
```
test-suites:
  ad_integration:
    test_ad_integration.py::test_ad_integration:
      dimensions:
        - regions: [ "ap-southeast-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2", "rhel8"]
          schedulers: ["slurm"]
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2204", "rhel9"]
          schedulers: ["slurm"]
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: ["af-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
  capacity_reservations:
    test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
      dimensions:
        - regions: ["us-west-2"]
          oss: ["alinux2023"]
```

This approach has the following shortcomings:
1. Functionality is not validated on all OSes
2. If AMIs are missing for some OSes, relevant integration tests will generate meaningless failures.

Therefore, this commit changes the test definition file to:
```
test-suites:
  ad_integration:
    test_ad_integration.py::test_ad_integration:
      dimensions:
        - regions: [ "ap-southeast-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ common.OS_X86_1 }}]
          schedulers: ["slurm"]
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: ["af-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ common.OS_X86_2 }}]
          schedulers: ["slurm"]
  capacity_reservations:
    test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
      dimensions:
        - regions: ["us-west-2"]
          oss: [{{ common.OS_X86_3 }}]
```
Where the OS is rotated each day. For example:
This new change is compatible with the old approach of hard-coding OSes. i.e. both approaches can appear in the same test configuration file.

### Tests
* dry run of develop.yaml is successful

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
