### PR TITLE
[Permissions] Add permissions required by login nodes to public policies

### DIFF
--- a/awsbatch-cli/src/awsbatch/awsbhosts.py
+++ b/awsbatch-cli/src/awsbatch/awsbhosts.py
@@ -66,7 +66,7 @@ class Host:
         mem_registered,
         cpu_avail,
         mem_avail,
-    ):
+    ):  # pylint: disable=too-many-positional-arguments
         """Initialize the object."""
         self.container_instance_arn = container_instance_arn
         self.status = status

--- a/awsbatch-cli/src/awsbatch/awsbout.py
+++ b/awsbatch-cli/src/awsbatch/awsbout.py
@@ -81,7 +81,9 @@ class AWSBoutCommand:
         self.log = log
         self.boto3_factory = boto3_factory
 
-    def run(self, job_id, head=None, tail=None, stream=None, stream_period=None):
+    def run(
+        self, job_id, head=None, tail=None, stream=None, stream_period=None
+    ):  # pylint: disable=too-many-positional-arguments
         """Print job output."""
         log_stream = self.__get_log_stream(job_id)
         if log_stream:
@@ -124,7 +126,9 @@ class AWSBoutCommand:
             fail("Error listing jobs from AWS Batch. Failed with exception: %s" % e)
         return log_stream
 
-    def __print_log_stream(self, log_stream, head=None, tail=None, stream=None, stream_period=None):  # noqa: C901 FIXME
+    def __print_log_stream(  # noqa: C901 FIXME
+        self, log_stream, head=None, tail=None, stream=None, stream_period=None
+    ):  # pylint:disable=too-many-positional-arguments
         """
         Ask for log stream and print it.
 

--- a/awsbatch-cli/src/awsbatch/awsbqueues.py
+++ b/awsbatch-cli/src/awsbatch/awsbqueues.py
@@ -50,7 +50,7 @@ def _get_parser():
 class Queue:
     """Generic queue object."""
 
-    def __init__(self, arn, name, priority, status, status_reason):
+    def __init__(self, arn, name, priority, status, status_reason):  # pylint: disable=too-many-positional-arguments
         """Initialize the object."""
         self.arn = arn
         self.name = name

--- a/awsbatch-cli/src/awsbatch/awsbstat.py
+++ b/awsbatch-cli/src/awsbatch/awsbstat.py
@@ -94,7 +94,7 @@ class Job:
         log_stream,
         log_stream_url,
         s3_folder_url,
-    ):
+    ):  # pylint: disable=too-many-positional-arguments
         """Initialize the object."""
         self.id = job_id
         self.name = name
@@ -282,7 +282,9 @@ class AWSBstatCommand:
         self.boto3_factory = boto3_factory
         self.batch_client = boto3_factory.get_client("batch")
 
-    def run(self, job_status, expand_children, job_queue=None, job_ids=None, show_details=False):
+    def run(
+        self, job_status, expand_children, job_queue=None, job_ids=None, show_details=False
+    ):  # pylint: disable=too-many-positional-arguments
         """Print list of jobs, by filtering by queue or by ids."""
         if job_ids:
             self.__populate_output_by_job_ids(job_ids, show_details or len(job_ids) == 1, include_parents=True)

--- a/awsbatch-cli/src/awsbatch/awsbsub.py
+++ b/awsbatch-cli/src/awsbatch/awsbsub.py
@@ -444,7 +444,7 @@ class AWSBsubCommand:
         timeout=None,
         dependencies=None,
         env=None,
-    ):
+    ):  # pylint: disable=too-many-positional-arguments
         """Submit the job."""
         try:
             # array properties

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -572,11 +572,13 @@ Resources:
               - autoscaling:DeleteAutoScalingGroup
               - autoscaling:DeleteLifecycleHook
               - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeLifecycleHooks
               - autoscaling:DescribeScalingActivities
               - autoscaling:PutLifecycleHook
               - autoscaling:UpdateAutoScalingGroup
               - elasticloadbalancing:CreateListener
               - elasticloadbalancing:CreateTargetGroup
+              - elasticloadbalancing:DescribeTags
               - elasticloadbalancing:DeleteListener
               - elasticloadbalancing:DeleteLoadBalancer
               - elasticloadbalancing:DeleteTargetGroup


### PR DESCRIPTION
**Cherry Picked from https://github.com/aws/aws-parallelcluster/pull/6452**

### Description of changes
Add permissions required by login nodes to public policies:
  1. 'autoscaling:DescribeLifecycleHooks'
  2. 'elasticloadbalancing:DescribeTags'

The lack of these permissions causes describe-cluster failures when login nodes are used in the cluster.

These permissions where already added to the policies used by our integ tests [here](https://github.com/aws/aws-parallelcluster/tree/0c71f5e7b2a76722a9eca81e74c61fba7dba3b80/tests/iam_policies), but were not reflected into the public policies.

Also added a commit to ignore a linter rule 'too-many-positional-arguments' on awsbatch cli package.
It's not a good practice to have many positional arguments, however we do not see a value in refactoring a module that is barely used.

### Tests
Tested in the original PR

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
