### PR TITLE
Remove requirement on outbound ports for FSx for OpenZFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 CHANGELOG
 =========
-3.11.0
+3.12.0
 ------
 
 **BUG FIXES**
-- Remove requirement of outbound ports on VPC security groups for FSx for OpenZFS
+- When mounting an external OpenZFS, it is no longer required to set the outbound rules for ports 111, 2049, 20001, 20002, 20003
 
 3.11.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 CHANGELOG
 =========
+3.11.0
+------
+
+**BUG FIXES**
+- Remove requirement of outbound ports on VPC security groups for FSx for OpenZFS
 
 3.11.0
 ------

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -667,10 +667,13 @@ class ExistingFsxNetworkingValidator(Validator):
                     )
 
                     if missing_ports:
+                        direction = "inbound and outbound"
+                        if file_storage.file_storage_type == "OPENZFS":
+                            direction = "inbound"
                         self._add_failure(
                             f"The current security group settings on file storage '{file_storage_id}' does not"
                             " satisfy mounting requirement. The file storage must be associated to a security group"
-                            f" that allows inbound and outbound {protocol.upper()} traffic through ports {ports}. "
+                            f" that allows {direction } {protocol.upper()} traffic through ports {ports}. "
                             f"Missing ports: {missing_ports}",
                             FailureLevel.ERROR,
                         )


### PR DESCRIPTION
### Description of changes
* Remove requirement on outbound ports for FSx for OpenZFS
* Do not check outbound security group rules for OpenZFS during cluster configuration validation

### Tests
* Tested cluster creation without the vpc for the FSx OpenZFS file system having outbound rule
  * No cluster creation error
* Tested cluster creation with missing inbound ports in the vpcs
  * cluster creation error
* Tested cluster creation with missing outbound ports for FSx Lustre
  * cluster creation error

### References
* https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/limit-access-security-groups.html


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
