### PR TITLE
[Github workflow] Fix Slurmdbd tempate Github check by pinning typeguard version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           python-version: '3.12'
       - name: Install AWS CDK
         run: |
+          pip install typeguard~=2.13
           npm install -g aws-cdk
           pip install -r cloudformation/external-slurmdbd/requirements.txt
       - working-directory: cloudformation/external-slurmdbd


### PR DESCRIPTION
An upgrade in AWS CDK dependencies started to use typeguard 4.x, which is failing the template generation. Example failure: https://github.com/aws/aws-parallelcluster/actions/runs/11257806474/job/31369657650?pr=6454

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
