### PR TITLE
Reapply "Pin jsonschema for Lambda Layer to version 4.17.3"

### DIFF
--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -40,7 +40,9 @@ def install_pc(basepath, pc_version):
     cli_dir = root / "cli"
     try:
         logger.info("installing ParallelCluster packages...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{cli_dir}[awslambda]", "-t", tempdir])
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "jsonschema==4.17.3", f"{cli_dir}[awslambda]", "-t", tempdir]
+        )
         # The following are provided by the lambda runtime
         shutil.rmtree(tempdir / "botocore")
         shutil.rmtree(tempdir / "boto3")


### PR DESCRIPTION
This reverts commit 9277bda130c2314b6c5bfa6db2085923c66a0f36.

This was not necessary because we used Lambda runtime Python 3.9, which contains boto3-1.26.90, which does not rely on jsonschema. After using Lambda runtime Python 3.12, we are using a newer boto3 version and reply on jsonschema. We need to pin the jsonschema because of a known issue: https://github.com/aws/aws-cdk/issues/26300


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
