### PR TITLE
[Dependencies] Upgrade Python version to 3.12 and removed pinning for setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.12.0
+------
+
+**CHANGES**
+- Upgrade Python to version 3.12 and NodeJS to version 18 in ParallelCluster Lambda Layer.
+
 3.11.1
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 CHANGELOG
 =========
 
-3.12.0
-------
-
-**CHANGES**
-- Upgrade Python to version 3.12 and NodeJS to version 18 in ParallelCluster Lambda Layer.
-
 3.11.1
 ------
 
 **CHANGES**
 - Pyxis is now disabled by default and it must be manually enabled on the head node.
+- Upgrade Python runtime to version 3.12 in ParallelCluster Lambda Layer.
+- Remove version pinning for setuptools to version prior to 70.0.0.
 
 **BUG FIXES**
 - Fix an issue in the way we configure the Pyxis Slurm plugin in ParallelCluster that can lead to job submission failures.

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -200,7 +200,7 @@ Resources:
           - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
           - { Version: !FindInMap [ParallelCluster, Constants, Version]}
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
 
   # We need to define three AWS::Serverless::Api due to an issue with the handling of AWS::NoValue
   # See related GitHub issue: https://github.com/aws/serverless-application-model/issues/1435
@@ -294,7 +294,7 @@ Resources:
           Value: api
         - Key: 'parallelcluster:version'
           Value: !FindInMap [ParallelCluster, Constants, Version]
-      Runtime: python3.9
+      Runtime: python3.12
       Handler: pcluster.api.awslambda.entrypoint.lambda_handler
       Layers:
         - !Ref PclusterLayer

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -22,7 +22,7 @@ def readme():
 
 VERSION = "1.4.0"
 REQUIRES = [
-    "setuptools<70.0.0",
+    "setuptools",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
 ]

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -23,7 +23,7 @@ def readme():
 VERSION = "3.11.1"
 CDK_VERSION = "1.164"
 REQUIRES = [
-    "setuptools<70.0.0",
+    "setuptools",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
     "PyYAML>=5.3.1,!=5.4",

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -45,7 +45,7 @@ Resources:
         - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
         - { Version: !FindInMap [ParallelCluster, Constants, Version] }
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
 
   PclusterPolicies:
     Condition: UsePCPolicies
@@ -341,7 +341,7 @@ Resources:
               helper(event, context)
 
       Handler: index.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !If [CustomRoleCondition, !Ref CustomLambdaRole, !GetAtt PclusterLambdaRole.Arn]
       Layers:
         - !Ref PclusterLayer
@@ -395,7 +395,7 @@ Resources:
                   reason = str(e)
               cfnresponse.send(event, context, response_status, {}, event.get('PhysicalResourceId', 'CleanupS3bucketCustomResource'), reason)
       Handler: index.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !If [CustomRoleCondition, !Ref CustomLambdaRole, !GetAtt PclusterLambdaRole.Arn]
 
   CleanupS3bucketCustomResource:

--- a/cloudformation/external-slurmdbd/requirements.txt
+++ b/cloudformation/external-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
-setuptools<70.0.0
+setuptools
 aws-cdk-lib~=2.105
 constructs>=10.0.0,<11.0.0

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -40,7 +40,9 @@ def install_pc(basepath, pc_version):
     cli_dir = root / "cli"
     try:
         logger.info("installing ParallelCluster packages...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{cli_dir}[awslambda]", "-t", tempdir])
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "jsonschema==4.17.3", f"{cli_dir}[awslambda]", "-t", tempdir]
+        )
         # The following are provided by the lambda runtime
         shutil.rmtree(tempdir / "botocore")
         shutil.rmtree(tempdir / "boto3")

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -30,7 +30,7 @@ from framework.fixture_utils import xdist_session_fixture
 from tests.common.utils import get_installed_parallelcluster_version
 
 logger = logging.getLogger()
-NODE_VERSION = "v16.19.0"  # maintenance version compatible with alinux2's GLIBC
+NODE_VERSION = "v18.20.3"
 
 
 def install_pc(basepath, pc_version):


### PR DESCRIPTION
### Description of changes
* Removed version pinning for setuptools - cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6456
* Upgrade Python version from 3.9 to 3.12 in PC Lambda Layer -- cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6455
* Integ Test: Upgrade NodeJS version from 16.19.0 to 18.20.3  in PC Lambda Layer -- cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6455
* Integ Test: Pin jsonschema to 4.17.3 -- cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6460
* Updated changelog entries for 3.11.1

### Tests
Tested in the original PR.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
