### PR TITLE
Revert "Fix code linter error" causing job submission failure on AWS Batch

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]


### PR DESCRIPTION
This reverts commit 96d9d05b1313be8b60674e76313abbdcbb862b29.

The commit must be reverted because it causes consistent job submission failures with error:

```
CannotStartContainerError:
Error response from daemon: unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file
```

### Description of changes
With this revetr the job submission succeeds.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
