### PR TITLE
Move reboot step to be before installing kernel package during OS update

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -244,7 +244,12 @@ phases:
                 fi
                 apt-get --purge autoremove -y
               fi
-
+      - name: RebootStep
+        action: Reboot
+        onFailure: Abort
+        maxAttempts: 2
+        inputs:
+          delaySeconds: 10
       - name: InstallAdditionalKernelPackages
         action: ExecuteBash
         inputs:
@@ -321,13 +326,6 @@ phases:
               else
                  echo "SSM agent is installed by default"
               fi
-
-      - name: RebootStep
-        action: Reboot
-        onFailure: Abort
-        maxAttempts: 2
-        inputs:
-            delaySeconds: 10
 
   - name: validate
     steps:


### PR DESCRIPTION
### Description of changes
* Move reboot step to be before installing kernel package during OS update
* If the reboot does not happened before the installation of the kernel package, `uname -r` returns the old kernel version and thus it tries to install the wrong package.

### Tests
* Ran `test_build_image` integration test with Rocky8



Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
