### PR TITLE
Move reboot step to be before installing kernel package during OS update

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -443,7 +443,7 @@ test-suites:
           schedulers: [ "slurm" ]
     test_slurm.py::test_error_handling:
       dimensions:
-        - regions: ["ap-southeast-3"]
+        - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Cherry-pick of: https://github.com/aws/aws-parallelcluster/pull/6486

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
