### PR TITLE
[integ-test-framework] Retrieve private Rocky AMIs according to the architecture of instance

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -578,7 +578,7 @@ def test_datadir(request, datadir):
 
 
 @pytest.fixture()
-def pcluster_config_reader(test_datadir, vpc_stack, request, region):
+def pcluster_config_reader(test_datadir, vpc_stack, request, region, architecture):
     """
     Define a fixture to render pcluster config templates associated to the running test.
 
@@ -605,7 +605,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region):
         rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
         output_file_path.write_text(rendered_template)
         if not config_file.endswith("image.config.yaml"):
-            inject_additional_config_settings(output_file_path, request, region, benchmarks)
+            inject_additional_config_settings(output_file_path, request, region, architecture, benchmarks)
         else:
             inject_additional_image_configs_settings(output_file_path, request)
         return output_file_path
@@ -672,7 +672,7 @@ def _inject_additional_iam_policies_for_nodes(
             _inject_additional_iam_policies(pool, policies)
 
 
-def inject_additional_config_settings(cluster_config, request, region, benchmarks=None):  # noqa C901
+def inject_additional_config_settings(cluster_config, request, region, architecture, benchmarks=None):  # noqa C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 
@@ -708,6 +708,7 @@ def inject_additional_config_settings(cluster_config, request, region, benchmark
                 region,
                 config_content["Image"]["Os"],
                 ami_type="pcluster",
+                architecture=architecture,
             ),
             ("Image", "CustomAmi"),
         )


### PR DESCRIPTION
We didn't discover this issue, because we didn't run Rocky on ARM

### Tests
* The following tests startup succeeded. (I didn't wait for the full test run because the change is only related to setup)
```
test-suites:
  scaling:
    test_scaling.py::test_job_level_scaling:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["m6g.xlarge"]
          schedulers: [ "slurm" ]
          oss: ["rocky8"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
