### PR TITLE
[Test] Fix test_essential_features by using the correct partition in IAM policy ARNs.

### DIFF
--- a/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pcluster.config.yaml
+++ b/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pcluster.config.yaml
@@ -52,7 +52,7 @@ LoginNodes:
             - 'arg3 arg3'
       Iam:
         AdditionalIamPolicies:
-          - Policy: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+          - Policy: "arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess"
 {% endif %}
 Scheduling:
   Scheduler: {{ scheduler }}


### PR DESCRIPTION
### Description of changes
Fix test_essential_features by using the correct partition in IAM policy ARNs.
Without this change the test fails in GovCloud with error:

```
	* ERROR - AdditionalIamPolicyValidator:
		Invalid ARN partition
```

### Tests
* [ONGOING] `test_essential_features` in us-gov-west-1 (previously failing).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
