### PR TITLE
[1-click] In the 1-click template `ad_integration.yaml`, add retry for domain join.

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -424,7 +424,16 @@ Resources:
               sed -i 's/PEERDNS=.*/PEERDNS=no/' /etc/sysconfig/network-scripts/ifcfg-eth0
               chattr +i /etc/resolv.conf
               ADMIN_PW="${AdminPassword}"
-              echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}"
+              
+              attempt=0
+              max_attempts=5
+              until [ $attempt -ge $max_attempts ]; do
+                attempt=$((attempt+1))
+                echo "Joining domain (attempt $attempt/$max_attempts) ..."
+                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}" && echo "Domain joined" && break
+                sleep 10
+              done
+              
               sleep 10
               echo "Registering ReadOnlyUser..."
               echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain="${DirectoryDomain}" --display-name=ReadOnlyUser ReadOnlyUser


### PR DESCRIPTION
### Description of changes
In the 1-click template `ad_integration.yaml`, add retry for domain join.
This template is also used by our integration tests, sop the change is useful to make AD deployment more robust and prevent intermittend failures caused by temporary unavailability of AD backend from Directory service.

### Tests
* Template deployed in personal account.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
