### PR TITLE
[1-click] In the 1-click template ad_integration.yaml, add retry for domain join

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -424,7 +424,16 @@ Resources:
               sed -i 's/PEERDNS=.*/PEERDNS=no/' /etc/sysconfig/network-scripts/ifcfg-eth0
               chattr +i /etc/resolv.conf
               ADMIN_PW="${AdminPassword}"
-              echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}"
+              
+              attempt=0
+              max_attempts=5
+              until [ $attempt -ge $max_attempts ]; do
+                attempt=$((attempt+1))
+                echo "Joining domain (attempt $attempt/$max_attempts) ..."
+                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}" && echo "Domain joined" && break
+                sleep 10
+              done
+              
               sleep 10
               echo "Registering ReadOnlyUser..."
               echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain="${DirectoryDomain}" --display-name=ReadOnlyUser ReadOnlyUser


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6494

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
