### PR TITLE
[Semgrep] Ignore semgrep rule `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint` in Dockerfiles used by the AWS Batch scheduler.

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -57,4 +57,8 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
+# We can ignore this rule because we expect the entrypoint to be executed as root.
+# Furthermore, specifying USER root in front of ENTRYPOINT throws the below error:
+# "unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file"
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
@@ -57,4 +57,8 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
+# We can ignore this rule because we expect the entrypoint to be executed as root.
+# Furthermore, specifying USER root in front of ENTRYPOINT throws the below error:
+# "unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file"
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -294,7 +294,6 @@ Resources:
     Properties:
       GroupSet:
         - !Ref ProxySecurityGroup
-      InterfaceType: interface
       SourceDestCheck: false
       SubnetId: !Ref PublicSubnet
 


### PR DESCRIPTION
### Description of changes
Ignore semgrep rule `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint` in Dockerfiles used by the AWS Batch scheduler.

Ignoring semgrep rules is always discouraged. However in this case we can ignore this rule because we expect the entrypoint to be executed as root. Furthermore, specifying USER root in front of ENTRYPOINT throws the below error: 

> unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file

Also cherry-picked 5004e87d2dc6d0883099372840bf5ea1c10895c7 to fix a cfn-linter issue blocking the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
