### PR TITLE
[AWSBatch] Remove offending specification of USER in front of ENTRYPOINT + ignore not unseful semgrep rules

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -57,4 +57,8 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
+# We can ignore this rule because we expect the entrypoint to be executed as root.
+# Furthermore, specifying USER root in front of ENTRYPOINT throws the below error:
+# "unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file"
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
@@ -57,4 +57,8 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
+# We can ignore this rule because we expect the entrypoint to be executed as root.
+# Furthermore, specifying USER root in front of ENTRYPOINT throws the below error:
+# "unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file"
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]

--- a/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2023/Dockerfile
@@ -57,4 +57,4 @@ ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib6
 # expose ssh port
 EXPOSE 22
 
-USER root ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]
+ENTRYPOINT ["/parallelcluster/bin/entrypoint.sh"]


### PR DESCRIPTION
### Description of changes
This reverts commit 96d9d05b1313be8b60674e76313abbdcbb862b29.

The commit must be reverted because it causes consistent job submission failures with error:

```
CannotStartContainerError:
Error response from daemon: unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file
```

Consequently, we ignore the semgrep rule `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint` in Dockerfiles used by the AWS Batch scheduler.

Ignoring semgrep rules is always discouraged. However in this case we can ignore this rule because we expect the entrypoint to be executed as root. Furthermore, specifying USER root in front of ENTRYPOINT throws the below error: 

> unable to find user root ENTRYPOINT [/parallelcluster/bin/entrypoint.sh]: no matching entries in passwd file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
