### PR TITLE
Delete InterfaceType to use the default attribute interface

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -294,7 +294,6 @@ Resources:
     Properties:
       GroupSet:
         - !Ref ProxySecurityGroup
-      InterfaceType: interface
       SourceDestCheck: false
       SubnetId: !Ref PublicSubnet
 


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/commit/5004e87d2dc6d0883099372840bf5ea1c10895c7
Needed to unblock Pr checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
