### PR TITLE
[integ-tests-framework] Avoid running DCV tests on AL2023 and another minor bug fix

### DIFF
--- a/cli/src/pcluster/cli/commands/dcv_util.py
+++ b/cli/src/pcluster/cli/commands/dcv_util.py
@@ -9,9 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.constants import SUPPORTED_OSES
-
-UNSUPPORTED_OSES_FOR_DCV = ["alinux2023"]
+from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_OSES_FOR_DCV
 
 
 def get_supported_dcv_os(architecture):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -26,6 +26,7 @@ SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm"]
 SUPPORTED_OSES = ["alinux2", "alinux2023", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8", "rhel9", "rocky9"]
 SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "awsbatch": ["alinux2", "alinux2023"]}
 UNSUPPORTED_OSES_FOR_MICRO_NANO = ["ubuntu2004", "ubuntu2204", "rhel8", "rocky8", "rhel9", "rocky9"]
+UNSUPPORTED_OSES_FOR_DCV = ["alinux2023"]
 DELETE_POLICY = "Delete"
 RETAIN_POLICY = "Retain"
 DELETION_POLICIES = [DELETE_POLICY, RETAIN_POLICY]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -241,18 +241,18 @@ test-suites:
         # DCV in cn regions and non GPU enabled instance
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_2 }}]
+          oss: [{{ DCV_OS_X86_2 }}]
           schedulers: ["slurm"]
         # DCV in gov-cloud regions and non GPU enabled instance
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_4 }}]
+          oss: [{{ DCV_OS_X86_4 }}]
           schedulers: ["slurm"]
     test_dcv.py::test_dcv_with_remote_access:
       dimensions:
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_6 }}]
+          oss: [{{ DCV_OS_X86_6 }}]
           schedulers: ["slurm"]
   dns:
     test_dns.py::test_hit_no_cluster_dns_mpi:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -50,7 +50,7 @@ test-suites:
           schedulers: {{ common.SCHEDULERS_TRAD }}
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_2 }}]
+          oss: ["alinux2"]
           schedulers: ["awsbatch"]
         # 2) run the test for all OSes with slurm
         - regions: ["ap-east-1"]

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -19,7 +19,7 @@ from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
-from pcluster.constants import SUPPORTED_OSES
+from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_OSES_FOR_DCV
 
 
 def _get_os_parameters(config=None, args=None):
@@ -36,6 +36,18 @@ def _get_os_parameters(config=None, args=None):
     for index in range(len(SUPPORTED_OSES)):
         result[f"OS_X86_{index}"] = available_amis_oss_x86[(today_number + index) % len(available_amis_oss_x86)]
         result[f"OS_ARM_{index}"] = available_amis_oss_arm[(today_number + index) % len(available_amis_oss_arm)]
+
+    # DCV doesn't support AL2023. Therefore, the following logic makes sure the DCV jinja parameter is not AL2023
+    dcv_supported_oses = [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_DCV]
+    dcv_available_amis_oss_x86 = list(set(dcv_supported_oses) & set(available_amis_oss_x86))
+    dcv_available_amis_oss_arm = list(set(dcv_supported_oses) & set(available_amis_oss_arm))
+    for index in range(len(dcv_supported_oses)):
+        result[f"DCV_OS_X86_{index}"] = dcv_available_amis_oss_x86[
+            (today_number + index) % len(dcv_available_amis_oss_x86)
+        ]
+        result[f"DCV_OS_ARM_{index}"] = dcv_available_amis_oss_arm[
+            (today_number + index) % len(dcv_available_amis_oss_arm)
+        ]
     return result
 
 


### PR DESCRIPTION
AL2023 does not support DCV and see commits for details

### Tests
* Integration tests can start. I didn't let the tests finish because the code changes are in the setup stage of the integration tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
