### PR TITLE
[integ-tests] Remove test_create_wrong_pcluster_version

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -110,12 +110,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]  # os must be different from ubuntu2004 to test os validation logic when wrong os is provided
           schedulers: ["slurm"]
-    test_create.py::test_create_wrong_pcluster_version:
-      dimensions:
-        - regions: ["ca-central-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: ["eu-south-1"]

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -102,12 +102,6 @@ test-suites:
 #          instances: {{ INSTANCES }}
 #          oss: {{ OSS }}
 #          schedulers: {{ SCHEDULERS }}
-#    test_create.py::test_create_wrong_pcluster_version:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: {{ REGIONS }}

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -61,12 +61,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]  # os must be different from ubuntu2004 to test os validation logic when wrong os is provided
           schedulers: ["slurm"]
-    test_create.py::test_create_wrong_pcluster_version:
-      dimensions:
-        - regions: ["ca-central-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: ["eu-south-1"]


### PR DESCRIPTION
This test is intentionally using a custom AMI with the wrong ParallelCluster version and expecting error messages in cloud-init-output.log. This test is not stable because as soon as we make major cookbook changes, the error messages might not appear. This integration test was created by me. It really seems superfluous.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
