### PR TITLE
[integ-test] Fix build-image test failures

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -84,11 +84,11 @@ test-suites:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-        - regions: ["eu-west-3"]
+          oss: ["ubuntu2004", "alinux2", "alinux2023"]
+        - regions: ["us-east-1"] # This region has to have first stage AMIs.
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
-          oss: ["rocky8"]
+          oss: ["rocky8", "rhel8", "rhel9", "rocky9", "ubuntu2204"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -89,11 +89,24 @@ OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP = {
     "rocky9": {"name": "rocky9-hvm-*-*", "owners": PCLUSTER_AMI_OWNERS},
 }
 
+FIRST_STAGE_AMI_OWNERS = ["self", "447714826191"]
+OS_TO_FIRST_STAGE_AMI_NAME_MAP = {
+    "alinux2": {"name": "first-stage-aws-parallelcluster-*-amzn2-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "alinux2023": {"name": "first-stage-aws-parallelcluster-*-amzn2023-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "ubuntu2004": {"name": "first-stage-aws-parallelcluster-*-ubuntu-2004-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "ubuntu2204": {"name": "first-stage-aws-parallelcluster-*-ubuntu-2204-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "rhel8": {"name": "first-stage-aws-parallelcluster-*-rhel8-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "rocky8": {"name": "first-stage-aws-parallelcluster-*-rocky8-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "rhel9": {"name": "first-stage-aws-parallelcluster-*-rhel9-*", "owners": FIRST_STAGE_AMI_OWNERS},
+    "rocky9": {"name": "first-stage-aws-parallelcluster-*-rocky9-*", "owners": FIRST_STAGE_AMI_OWNERS},
+}
+
 AMI_TYPE_DICT = {
     "official": OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP,
     "remarkable": OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP,
     "pcluster": OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP,
     "kernel4": OS_TO_KERNEL4_AMI_NAME_OWNER_MAP,
+    "first_stage": OS_TO_FIRST_STAGE_AMI_NAME_MAP,
 }
 
 

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -123,11 +123,15 @@ def test_build_image(
     bucket_name = s3_bucket_factory()
 
     # Get base AMI
-    # remarkable AMIs are not available for ARM and ubuntu2204 yet
-    if os not in ["ubuntu2204", "alinux2023"]:
+    if os in ["alinux2", "ubuntu2004"]:
+        # Test Deep Learning AMIs
         base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
+    elif "rhel" in os or "rocky" in os or "ubuntu" in os:
+        # Test AMIs from first stage build. Because RHEL/Rocky and Ubuntu have specific requirement of kernel versions.
+        base_ami = retrieve_latest_ami(region, os, ami_type="first_stage", architecture=architecture)
     else:
-        base_ami = retrieve_latest_ami(region, os, architecture=architecture)
+        # Test vanilla AMIs.
+        base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
 
     image_config = pcluster_config_reader(
         config_file="image.config.yaml", parent_image=base_ami, instance_role=instance_role, bucket_name=bucket_name

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -14,8 +14,11 @@ Build:
     Tags:
         - Key: dummyBuildTag
           Value: dummyBuildTag
+{% if os in ["alinux2", "alinux2023"] %}
+# Use UpdateOSPackages for alinux is optional. Use UpdateOSPackages on Ubuntu, RHEL/Rocky is not recommended because it intermittently fails because of kernel issues.
     UpdateOsPackages:
         Enabled: true
+{% endif %}
 
 CustomS3Bucket: {{ bucket_name }}
 


### PR DESCRIPTION
Use proper base image to build AMIs to avoid kernels not supported by other software (e.g. Lustre)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
