### PR TITLE
[integ-test-framework] Ensure xdist fixture cleans up even when test crashes

### DIFF
--- a/tests/integration-tests/framework/fixture_utils.py
+++ b/tests/integration-tests/framework/fixture_utils.py
@@ -221,8 +221,10 @@ def xdist_session_fixture(**pytest_fixture_args):
                 fixture_func_kwargs=kwargs,
                 xdist_worker_id_and_pid=f"{xdist_worker_id}: {pid}",
             )
-            yield shared_fixture.acquire().fixture_return_value
-            shared_fixture.release()
+            try:
+                yield shared_fixture.acquire().fixture_return_value
+            finally:
+                shared_fixture.release()
 
         return _xdist_session_fixture
 


### PR DESCRIPTION
Prior to this commit, the fixture was cleaned up if tests succeeded or tests failed assertion. The fixture was SOMETIMES not cleaned up if tests failed severely (e.g. index an item not existed in a list). This commit makes sure the cleanup is always executed

This commit could fix long integration tests running

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
