### PR TITLE
[Test] In AD 1-click template, add verbosity to the realm command to make it easier to troubleshoot failures

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -434,7 +434,7 @@ Resources:
                 echo "[DEBUG] Resolving ${DirectoryDomain} ..."
                 dig ${DirectoryDomain} 
                 echo "Joining domain (attempt $attempt/$max_attempts) ..."
-                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}" && echo "Domain joined" && break
+                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain} --verbose" && echo "Domain joined" && break
                 sleep 10
               done
               


### PR DESCRIPTION
### Description of changes
In AD 1-click template, add verbosity to the realm command to make it easier to troubleshoot failures

### Tests
Deployed in personal account and verified verbosity

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
