### PR TITLE
Change test_error_handling region to eu-west-1

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -443,7 +443,7 @@ test-suites:
           schedulers: [ "slurm" ]
     test_slurm.py::test_error_handling:
       dimensions:
-        - regions: ["ap-southeast-3"]
+        - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Change test_error_handling region to eu-west-1 due to credential time out in optin-regions

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
