### PR TITLE
Move reboot step to be before installing kernel package during OS update

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -244,7 +244,12 @@ phases:
                 fi
                 apt-get --purge autoremove -y
               fi
-
+      - name: RebootStep
+        action: Reboot
+        onFailure: Abort
+        maxAttempts: 2
+        inputs:
+          delaySeconds: 10
       - name: InstallAdditionalKernelPackages
         action: ExecuteBash
         inputs:


### PR DESCRIPTION
### Description of changes
* Cherry-pick: https://github.com/aws/aws-parallelcluster/pull/6486

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
