### PR TITLE
Force delete if delete fails during cleanup

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -228,6 +228,9 @@ class CfnStacksFactory:
                             return
                     cfn_client.delete_stack(StackName=stack.name)
                     final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
+                    if final_status == "DELETE_FAILED":
+                        cfn_client.delete_stack(StackName=stack.name, DeletionMode="FORCE_DELETE_STACK")
+                        final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
                     self.__assert_stack_status(
                         final_status, "DELETE_COMPLETE", stack_name=stack.cfn_stack_id, region=region
                     )


### PR DESCRIPTION
### Description of changes
* Force delete if delete fails during cleanup
* Fixes teardown failures for test_cluster_update due to getting DELETE_FAILED when trying to delete a custom resource.

### Tests
* ran test_cluster_update

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
