### PR TITLE
[Test] Prevent intermittent failures in test_update_slurm by giving max 6 minutes to compute nodes to complete the bootstrap.

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -191,7 +191,8 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     # On the other hand, the update workflow waits for existing nodes to complete their update recipes.
     # As a consequence, the stack may reach the UPDATE_COMPLETE state
     # without waiting for new static nodes to complete their bootstrap recipes.
-    retry(wait_fixed=seconds(10), stop_max_delay=minutes(3))(assert_instance_config_version_on_ddb)(
+    # We wait at most 6 minutes because we know that compute nodes may take 4/5 minutes to bootstrap.
+    retry(wait_fixed=seconds(10), stop_max_delay=minutes(6))(assert_instance_config_version_on_ddb)(
         cluster, last_cluster_config_version
     )
 


### PR DESCRIPTION
### Description of changes
Prevent intermittent failures in test_update_slurm by giving max 6 minutes to compute nodes to complete the bootstrap.
We decided to wait max 6 minutes because we know that compute nodes may take even 4/5 minutes to bootstrap.

### Tests
* test `test_update_slurm` succeeded with 3 minutes, so this change cannot introduce regressions, it's just a safeguard against intermittent failures.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
