### PR TITLE
[Test] Move AD integ test from eu-central-1 to ap-northeast-1 because SimpleAD is not available in eu-central-1.

### DIFF
--- a/tests/integration-tests/configs/ad_integration.yaml
+++ b/tests/integration-tests/configs/ad_integration.yaml
@@ -4,7 +4,7 @@ test-suites:
   ad_integration:
     test_ad_integration.py::test_ad_integration:
       dimensions:
-        - regions: ["eu-central-1"]
+        - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -10,7 +10,7 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [ {{ OS_X86_0 }}, {{ OS_X86_2 }}]
           schedulers: ["slurm"]
-        - regions: ["eu-central-1"]
+        - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_4 }}, {{ OS_X86_6 }}]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
Move AD integ test from eu-central-1 to ap-northeast-1 because SimpleAD is not available in eu-central-1.

### Tests
Verified that SimpleAd is available in ap-northeast-1.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
