### PR TITLE
[integ-test-framework] Terminate processes where tests have finished

### DIFF
--- a/tests/integration-tests/framework/fixture_utils.py
+++ b/tests/integration-tests/framework/fixture_utils.py
@@ -9,6 +9,7 @@ import functools
 import logging
 import os
 import pickle
+import re
 import time
 from dataclasses import dataclass, field
 from inspect import getfullargspec, isgeneratorfunction
@@ -53,6 +54,7 @@ class SharedFixture:
         fixture_func_args: tuple,
         fixture_func_kwargs: dict,
         xdist_worker_id_and_pid: str,
+        log_file: str,
     ):
         self.name = name
         self.shared_save_location = shared_save_location
@@ -60,6 +62,7 @@ class SharedFixture:
         self.fixture_func_args = fixture_func_args
         self.fixture_func_kwargs = fixture_func_kwargs
         self.xdist_worker_id_and_pid = xdist_worker_id_and_pid
+        self.log_file = log_file
         self._lock_file = shared_save_location / f"{name}.lock"
         self._fixture_file = shared_save_location / f"{name}.fixture"
         self._generator = None
@@ -95,6 +98,19 @@ class SharedFixture:
         except Exception:
             logging.error("Error terminating process %s.", pid)
 
+    @staticmethod
+    def _completed_in_the_past(minutes: int, line: str):
+        if line is None or "- Completed test" not in line:
+            return False
+        regex = r"^(.*?) \- .*"
+        re_result = re.search(regex, line)
+        if re_result:
+            date = re_result.group(1)
+            try:
+                return (time.time() - time.mktime(time.strptime(date, "%Y-%m-%d %H:%M:%S,%f"))) / 60 > minutes
+            except Exception:
+                return False
+
     def release(self):
         """
         Release a shared fixture.
@@ -119,6 +135,16 @@ class SharedFixture:
             )
             time.sleep(30)
 
+            last_message_of_each_proc = {}
+            with open(self.log_file, "r") as f:
+                lines = f.readlines()
+                for line in lines:
+                    regex = r"^.* \- .* \- (\d+) - .*"
+                    re_result = re.search(regex, line)
+                    if re_result:
+                        pid = re.search(regex, line).group(1)
+                        last_message_of_each_proc[pid] = line
+
             with FileLock(self._lock_file):
                 for worker in data.currently_using_processes.copy():
                     pid = int(worker.split(" ")[1])
@@ -132,6 +158,11 @@ class SharedFixture:
                             data.counter,
                         )
                         self._save_fixture_data(data)
+                    elif self._completed_in_the_past(30, last_message_of_each_proc.get(str(pid))):
+                        logging.warning(
+                            "%s is sleeping but the test has been finished. Terminating the process... ", worker
+                        )
+                        self._terminate_process(pid)
                 data = self._load_fixture_data()
 
             if time.time() > timeout:
@@ -222,6 +253,7 @@ def xdist_session_fixture(**pytest_fixture_args):
                 fixture_func_args=args,
                 fixture_func_kwargs=kwargs,
                 xdist_worker_id_and_pid=f"{xdist_worker_id}: {pid}",
+                log_file=request.config.getoption("tests_log_file"),
             )
             try:
                 yield shared_fixture.acquire().fixture_return_value


### PR DESCRIPTION
Some processes could hang in `sleeping` status forever. The suspected reason is that when tests fail, sometimes network connections are not closed, causing the parent process to hang in `sleeping`.

Prior to this commit, we have a 4-hour timeout for processes. This commit adds another check to read the Pytest logs to terminate processes where tests have finished for more than 30 minutes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
