### PR TITLE
[1-click] Improvements to 1-click template for AD

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -68,6 +68,30 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64'
 
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Directory
+        Parameters:
+          - DirectoryType
+          - DomainName
+          - Vpc
+          - PrivateSubnetOne
+          - PrivateSubnetTwo
+      - Label:
+          default: Users
+        Parameters:
+          - AdminPassword
+          - ReadOnlyPassword
+          - UserNames
+          - UserPassword
+      - Label:
+          default: Administrative Node
+        Parameters:
+          - AdminNodeAmiId
+          - Keypair
+
 Transform: AWS::Serverless-2016-10-31
 
 Conditions:

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -66,7 +66,7 @@ Parameters:
   AdminNodeAmiId:
     Description: AMI for the Admin Node
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+    Default: '/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64'
 
 Transform: AWS::Serverless-2016-10-31
 
@@ -387,7 +387,6 @@ Resources:
               samba-common-tools: []
               krb5-workstation: []
               openldap-clients: []
-              policycoreutils-python: []
               openssl: []
     Properties:
       IamInstanceProfile:
@@ -416,25 +415,25 @@ Resources:
               echo "Domain Name: ${DirectoryDomain}"
               echo "Domain Certificate Secret: ${DomainCertificateSecretArn}"
               echo "Domain Private Key Secret: ${DomainPrivateKeySecretArn}"
-              cat << EOF > /etc/resolv.conf
-              search           ${DirectoryDomain}
-              nameserver       ${DnsIp1}
-              nameserver       ${DnsIp2}
+              
+              mkdir -p /etc/systemd/resolved.conf.d
+              cat << EOF > /etc/systemd/resolved.conf.d/pcluster-ad-domain-dns-server.conf
+              [Resolve]
+              DNS=${DnsIp1} ${DnsIp2}
+              Domains=~.
               EOF
-              sed -i 's/PEERDNS=.*/PEERDNS=no/' /etc/sysconfig/network-scripts/ifcfg-eth0
-              chattr +i /etc/resolv.conf
+              service systemd-resolved restart
+              
               ADMIN_PW="${AdminPassword}"
               
               attempt=0
               max_attempts=5
               until [ $attempt -ge $max_attempts ]; do
                 attempt=$((attempt+1))
-                echo "[DEBUG] Content of /etc/resolv.conf is:"
-                cat /etc/resolv.conf
-                echo "[DEBUG] Resolving ${DirectoryDomain} ..."
-                dig ${DirectoryDomain} 
+                echo "[DEBUG] Checking domain name resolution for ${DirectoryDomain} ..."
+                dig ${DirectoryDomain}
                 echo "Joining domain (attempt $attempt/$max_attempts) ..."
-                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain} --verbose" && echo "Domain joined" && break
+                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}" --verbose && echo "Domain joined" && break
                 sleep 10
               done
               

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -183,10 +183,6 @@ def _get_stack_parameters(directory_type, vpc_stack, keypair):
         {"ParameterKey": "PrivateSubnetOne", "ParameterValue": private_subnet},
         {"ParameterKey": "PrivateSubnetTwo", "ParameterValue": private_subnets[0]},
         {"ParameterKey": "Keypair", "ParameterValue": keypair},
-        {
-            "ParameterKey": "AdminNodeAmiId",
-            "ParameterValue": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
-        },
     ]
     return stack_parameters
 


### PR DESCRIPTION
### Description of changes
 Improvements to 1-click template for AD, used by integ tests to cover AD feature.

In particular:
* Use AL2023 for AD Admin node rather than AL2. This was necessary to solve an intermittent failure in the AD amdin node. Followed approach suggested in https://repost.aws/knowledge-center/ec2-static-dns-ubuntu-debian
* group stack parameters for better user experience when deploying the stack manually 

### Tests
* Deploy the template in personal account.
* Integ `test_ad_integration` succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
