### PR TITLE
Remove ubuntu2004 from tested OSs for tests that use DCV with ARM architecture

### DIFF
--- a/cli/src/pcluster/cli/commands/dcv_util.py
+++ b/cli/src/pcluster/cli/commands/dcv_util.py
@@ -9,13 +9,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_OSES_FOR_DCV
+from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_ARM_OSES_FOR_DCV, UNSUPPORTED_OSES_FOR_DCV
 
 
 def get_supported_dcv_os(architecture):
     """Return a list of all the operating system supported by DCV."""
     architectures_dict = {
         "x86_64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_DCV],
-        "arm64": ["alinux2", "rhel8", "rocky8", "rhel9", "rocky9"],
+        "arm64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_DCV + UNSUPPORTED_ARM_OSES_FOR_DCV],
     }
     return architectures_dict.get(architecture, [])

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -27,6 +27,7 @@ SUPPORTED_OSES = ["alinux2", "alinux2023", "ubuntu2004", "ubuntu2204", "rhel8", 
 SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "awsbatch": ["alinux2", "alinux2023"]}
 UNSUPPORTED_OSES_FOR_MICRO_NANO = ["ubuntu2004", "ubuntu2204", "rhel8", "rocky8", "rhel9", "rocky9"]
 UNSUPPORTED_OSES_FOR_DCV = ["alinux2023"]
+UNSUPPORTED_ARM_OSES_FOR_DCV = ["ubuntu2004"]
 DELETE_POLICY = "Delete"
 RETAIN_POLICY = "Retain"
 DELETION_POLICIES = [DELETE_POLICY, RETAIN_POLICY]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -365,11 +365,11 @@ test-suites:
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_5 }}]
+          oss: [{{ DCV_OS_X86_3 }}]
           schedulers: ["slurm"]
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ OS_X86_7 }}]
+          oss: [{{ DCV_OS_X86_4 }}]
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -361,7 +361,7 @@ test-suites:
         # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: [{{ OS_ARM_3 }}]
+          oss: [{{ DCV_OS_ARM_3 }}]
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -19,7 +19,7 @@ from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
-from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_OSES_FOR_DCV
+from pcluster.constants import SUPPORTED_OSES, UNSUPPORTED_ARM_OSES_FOR_DCV, UNSUPPORTED_OSES_FOR_DCV
 
 
 def _get_os_parameters(config=None, args=None):
@@ -39,8 +39,11 @@ def _get_os_parameters(config=None, args=None):
 
     # DCV doesn't support AL2023. Therefore, the following logic makes sure the DCV jinja parameter is not AL2023
     dcv_supported_oses = [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_DCV]
+    dcv_supported_arm_oses = [
+        os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_DCV + UNSUPPORTED_ARM_OSES_FOR_DCV
+    ]
     dcv_available_amis_oss_x86 = list(set(dcv_supported_oses) & set(available_amis_oss_x86))
-    dcv_available_amis_oss_arm = list(set(dcv_supported_oses) & set(available_amis_oss_arm))
+    dcv_available_amis_oss_arm = list(set(dcv_supported_arm_oses) & set(available_amis_oss_arm))
     for index in range(len(dcv_supported_oses)):
         result[f"DCV_OS_X86_{index}"] = dcv_available_amis_oss_x86[
             (today_number + index) % len(dcv_available_amis_oss_x86)


### PR DESCRIPTION
### Description of changes
* DCV does not support ubuntu2004 with ARM architecture
* Fix `test_cluster_in_no_internet_subnet` failure due to the following error:
```
* ERROR - DcvValidator:
	NICE DCV can be used with one of the following operating systems when using arm64 architecture: ['alinux2', 'rhel8', 'rocky8', 'rhel9', 'rocky9']. Please double check the os configuration.
```

### References
* Based off of this PR: https://github.com/aws/aws-parallelcluster/pull/6503


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
