### PR TITLE
[Integ-tests] Use right permission to operate on log files

### DIFF
--- a/tests/integration-tests/tests/basic/log_rotation_utils.py
+++ b/tests/integration-tests/tests/basic/log_rotation_utils.py
@@ -179,9 +179,11 @@ def _test_logs_uploaded_to_cloudwatch(
     # write a log message to log file after log rotation in case log is empty
     for log in logs:
         if log.get("existence"):
+            log_path = log.get("log_path")
+            log_file_user = remote_command_executor.get_user_to_operate_on_file(log_path)
             _run_command_on_node(
                 remote_command_executor,
-                f"echo '{after_log_rotation_message}' | sudo tee --append {log.get('log_path')}",
+                f"echo '{after_log_rotation_message}' | sudo -u {log_file_user} tee --append {log_path}",
                 compute_private_ip,
             )
             # assert both logs are in the cloudwatch logs


### PR DESCRIPTION
In many of the operating systems ParallelCluster supported, `root` user could bypass any files permissions. However, with RHEL9 and Rocky9, `root` user could not bypass files permissions by default. Therefore, this commit improves integration tests to operate on files with the owner users of the files

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
