### PR TITLE
[Integ-Test] Fix test_build_image_custom_components integration test

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/image.config.yaml
@@ -2,9 +2,9 @@ Build:
   InstanceType: {{ instance_type }}
   ParentImage: {{ parent_image }}
   Components:
-    # Test arn custom component in eu-west-1 except Rocky because stig-build-linux-high component doesn't support Rocky
+    # Test arn custom component in eu-west-1 except Rocky and Ubuntu because stig-build-linux-high component doesn't support these ParallelCuster AMIs.
     # Test script custom component in other regions.
-    {% if region == "eu-west-1" and "rocky" not in os %}
+    {% if region == "eu-west-1" and "rocky" not in os and "ubuntu" not in os %}
     - Type: arn
       Value: arn:{{ partition }}:imagebuilder:{{ region }}:aws:component/stig-build-linux-high/2024.2.3/1
     {% else %}


### PR DESCRIPTION
### Description
- Failed reason:
   ```
   Failed to set restriction for unauthenticated users, not in compliance with V-260526.',
   STIG configuration script failed to run. Exiting.',
   ```
- Stig(Custom component we chose) configuration wants to set the parameters `PermitEmptyPasswords` and `PermitUserEnvironment` in the `sshd_config` file to `no`, but ParallelCluster Ubuntu AMI does not allow.
- Fixed by skip Ubuntu OS.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
