### PR TITLE
[Security] Add permissions to create/delete service linked role for ELB and ASG, required by login nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 **BUG FIXES**
 - When mounting an external OpenZFS, it is no longer required to set the outbound rules for ports 111, 2049, 20001, 20002, 20003.
 - Fix an issue where changes in sequence of custom actions scripts were not detected during cluster updates. 
+- Add missing permissions for ParallelCluster API to create the service linked roles for Elastic Load Balancing and Auto Scaling, that are required to deploy login nodes.
 
 3.11.1
 ------

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -489,6 +489,8 @@ Resources:
                 iam:AWSServiceName:
                   - fsx.amazonaws.com
                   - s3.data-source.lustre.fsx.amazonaws.com
+                  - elasticloadbalancing.amazonaws.com
+                  - autoscaling.amazonaws.com
           - Action:
               - lambda:CreateFunction
               - lambda:TagResource


### PR DESCRIPTION
### Description of changes
Add permissions to create/delete service linked roles for ELB and ASG.
These permissions are required to create clusters with login nodes.

These permissions were required since the introduction of login nodes in PC 3.6.0. However, we did not figure out it was necessary because in all our accounts the service roles were already created and the creation is hence not triggered.

### Tests
Verified that this permission is enough to let ELB and ASG create their linked roles.
Tested in an account where the linked roles were not created (otherwise the creation is not even triggered).

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
