### PR TITLE
[Test] Remove pinning for setuptools to version 70.0.0 in tox configurations

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -133,7 +133,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
-    setuptools<70.0.0
+    setuptools
     pyflakes
     pylint
 commands =

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -16,7 +16,7 @@ usedevelop =
 allowlist_externals =
     bash
 deps =
-    setuptools<70.0.0
+    setuptools
     -rtests/requirements.txt
 extras =
     awslambda
@@ -147,7 +147,7 @@ commands =
 [testenv:pylint]
 basepython = python3
 deps =
-    setuptools<70.0.0
+    setuptools
     pyflakes
     pylint
 commands =


### PR DESCRIPTION
### Description of changes
 Remove pinning for setuptools to version 70.0.0 in tox configurations

### Tests
PR checks (they exercise the tox configurations).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
