### PR TITLE
[Dependencies] Remove support for Python 3.7 and Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.7 Tests
-          - Python 3.8 Tests
           - Python 3.9 Tests
           - Python 3.10 Tests
           - Python 3.11 Tests
@@ -50,14 +48,6 @@ jobs:
           - API CloudFormation Templates Checks
           - Integration Tests Config Checks
         include:
-          - name: Python 3.7 Tests
-            python: 3.7
-            toxdir: cli
-            toxenv: py37-nocov
-          - name: Python 3.8 Tests
-            python: 3.8
-            toxdir: cli
-            toxenv: py38-nocov
           - name: Python 3.9 Tests
             python: 3.9
             toxdir: cli
@@ -119,8 +109,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.7 AWS Batch CLI Tests
-          - Python 3.8 AWS Batch CLI Tests
           - Python 3.9 AWS Batch CLI Tests
           - Python 3.10 AWS Batch CLI Tests
           - Python 3.11 AWS Batch CLI Tests
@@ -128,14 +116,6 @@ jobs:
           - Python 3.10 AWS Batch CLI Tests Coverage
           - Code Checks AWS Batch CLI
         include:
-          - name: Python 3.7 AWS Batch CLI Tests
-            python: 3.7
-            toxdir: awsbatch-cli
-            toxenv: py37-nocov
-          - name: Python 3.8 AWS Batch CLI Tests
-            python: 3.8
-            toxdir: awsbatch-cli
-            toxenv: py38-nocov
           - name: Python 3.9 AWS Batch CLI Tests
             python: 3.9
             toxdir: awsbatch-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
   - gl: `2024.0.1078-1`
   - web_viewer: `2024.0-18131-1`
 - Upgrade mysql-community-client to version 8.0.39.
+- Remove support for Python 3.7 and 3.8, which are in end of life.
 
 **BUG FIXES**
 - When mounting an external OpenZFS, it is no longer required to set the outbound rules for ports 111, 2049, 20001, 20002, 20003.

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -67,7 +67,7 @@ setup(
     license="Apache License 2.0",
     package_dir={"": "src"},
     packages=find_namespace_packages("src"),
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=REQUIRES,
     extras_require={
         "awslambda": LAMBDA_REQUIRES,
@@ -86,8 +86,6 @@ setup(
         "Environment :: Console",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{37,38,39,310}-{cov,nocov}
+    py{39,310}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{39,310}-{cov,nocov}
+    py{39,310,311,312}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 


### PR DESCRIPTION
### Description of changes
Remove support for Python 3.7 and Python 3.8, which are in EOL.
Also, added Python 3.11 and 3.12 to tox configurations for testing.

### Tests
* PR checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
