### PR TITLE
[Test] In test_update_slurm, use flexible instance types for spot instances to reduce the risk of ICEs.

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -133,7 +133,16 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "instances": [
                         {
                             "instance_type": "t3.small",
-                        }
+                        },
+                        {
+                            "instance_type": "t3a.small",
+                        },
+                        {
+                            "instance_type": "t3.medium",
+                        },
+                        {
+                            "instance_type": "t3a.medium",
+                        },
                     ],
                     "expected_running_instances": 1,
                     "expected_power_saved_instances": 9,
@@ -239,7 +248,16 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "instances": [
                         {
                             "instance_type": "t3.small",
-                        }
+                        },
+                        {
+                            "instance_type": "t3a.small",
+                        },
+                        {
+                            "instance_type": "t3.medium",
+                        },
+                        {
+                            "instance_type": "t3a.medium",
+                        },
                     ],
                     "expected_running_instances": 0,
                     "expected_power_saved_instances": 10,

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -59,6 +59,9 @@ Scheduling:
         - Name: queue1-i3 # New compute resource
           Instances:
             - InstanceType: t3.small
+            - InstanceType: t3a.small
+            - InstanceType: t3.medium
+            - InstanceType: t3a.medium
               # Removed MinCount
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -51,6 +51,9 @@ Scheduling:
         - Name: queue1-i2
           Instances:
             - InstanceType: t3.small
+            - InstanceType: t3a.small
+            - InstanceType: t3.medium
+            - InstanceType: t3a.medium
           MinCount: 1
       Networking:
         SubnetIds:


### PR DESCRIPTION
Cherry-pick from https://github.com/aws/aws-parallelcluster/pull/6581


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
