### PR TITLE
[integ-tests] Fix test_essential_features test

### DIFF
--- a/tests/integration-tests/tests/basic/log_rotation_utils.py
+++ b/tests/integration-tests/tests/basic/log_rotation_utils.py
@@ -130,6 +130,8 @@ def _test_logs_are_rotated(os, logs, remote_command_executor, before_log_rotatio
         "sync",
         compute_node_ip,
     )
+    # remove date extension to old rotated file
+    _run_command_on_node(remote_command_executor, "sudo sed -i 's/dateext/nodateext/g' /etc/logrotate.conf", compute_node_ip)
     # force log rotate without waiting for logs to reach certain size
     _run_command_on_node(remote_command_executor, "sudo logrotate -f /etc/logrotate.conf", compute_node_ip)
     # check if logs are rotated

--- a/tests/integration-tests/tests/basic/log_rotation_utils.py
+++ b/tests/integration-tests/tests/basic/log_rotation_utils.py
@@ -131,7 +131,9 @@ def _test_logs_are_rotated(os, logs, remote_command_executor, before_log_rotatio
         compute_node_ip,
     )
     # remove date extension to old rotated file
-    _run_command_on_node(remote_command_executor, "sudo sed -i 's/dateext/nodateext/g' /etc/logrotate.conf", compute_node_ip)
+    _run_command_on_node(
+        remote_command_executor, "sudo sed -i 's/dateext/nodateext/g' /etc/logrotate.conf", compute_node_ip
+    )
     # force log rotate without waiting for logs to reach certain size
     _run_command_on_node(remote_command_executor, "sudo logrotate -f /etc/logrotate.conf", compute_node_ip)
     # check if logs are rotated

--- a/tests/integration-tests/tests/basic/test_essential_features.py
+++ b/tests/integration-tests/tests/basic/test_essential_features.py
@@ -147,7 +147,6 @@ def _test_mpi_ssh(remote_command_executor, test_datadir, scheduler_commands_fact
 
     # mpirun_out_ip = ["Warning: Permanently added '192.168.60.89' (ECDSA) to the list of known hosts.",
     # '', 'ip-192-168-60-89']
-    assert_that(len(mpirun_out_ip)).is_equal_to(3)
     assert_that(mpirun_out_ip[-1]).is_equal_to(remote_host)
 
     mpirun_out = remote_command_executor.run_remote_script(
@@ -156,7 +155,6 @@ def _test_mpi_ssh(remote_command_executor, test_datadir, scheduler_commands_fact
 
     # mpirun_out = ["Warning: Permanently added 'ip-192-168-60-89,192.168.60.89' (ECDSA) to the list of known hosts.",
     # '', 'ip-192-168-60-89']
-    assert_that(len(mpirun_out)).is_equal_to(3)
     assert_that(mpirun_out[-1]).is_equal_to(remote_host)
 
 


### PR DESCRIPTION
### Description of changes
* Fix test_essential_features.py integ test for rhel9 and rocky9
  * The default `/usr/share/logrotate/logrotate.conf` has dateext option enabled. With this option, all rotated log files will get suffix including the current date with day granularity. Since we force rotate, some files might already exist with the suffic of that current date, leading to the following error: `error: destination /var/log/hawkey.log-20241117 already exists, skipping rotation`
  * This fix removes the date suffix in the test
  
* Fix test_essential_features.py integ test for ubuntu
  * `Authorization required, but no authorization protocol specified` error was added to `mpirun_out_ip` array, making it's length greater than the expected 3
   * Checking array length in not necessary
   * Authorization protocol error is not related to this test. It has to do with hwloc
  
### Tests
* Ran test_essential_features with rhel9, rock9, and ubuntu2004


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
