### PR TITLE
Force currentValue and requestedValue to be string in changeset response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - When mounting an external OpenZFS, it is no longer required to set the outbound rules for ports 111, 2049, 20001, 20002, 20003.
 - Fix an issue where changes in sequence of custom actions scripts were not detected during cluster updates.
 - Add missing permissions for ParallelCluster API to create the service linked roles for Elastic Load Balancing and Auto Scaling, that are required to deploy login nodes.
+- Fix an issue where when using PCAPI, cluster update could fail when updating a parameter that is not type `String` (e.g. `MaxCount`).
 
 3.11.1
 ------

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -461,9 +461,9 @@ def _analyze_changes(changes):
         message = _create_message(row[key_indexes["reason"]], row[key_indexes["action_needed"]])
         if not _cluster_update_change_succeded(check_result):
             errors.append(
-                UpdateError(parameter=parameter, requested_value=new_value, message=message, current_value=old_value)
+                UpdateError(parameter=parameter, requested_value=str(new_value), message=message, current_value=str(old_value))
             )
-        change_set.append(Change(parameter=parameter, requested_value=new_value, current_value=old_value))
+        change_set.append(Change(parameter=parameter, requested_value=str(new_value), current_value=str(old_value)))
     return change_set, errors
 
 

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -455,17 +455,15 @@ def _analyze_changes(changes):
 
     for row in changes[1:]:
         parameter = ConfigPatch.build_config_param_path(row[key_indexes["param_path"]], row[key_indexes["parameter"]])
-        new_value = row[key_indexes["new value"]] if not row[key_indexes["new value"]] is None else "-"
-        old_value = row[key_indexes["old value"]] if not row[key_indexes["old value"]] is None else "-"
+        new_value = str(row[key_indexes["new value"]]) if not row[key_indexes["new value"]] is None else "-"
+        old_value = str(row[key_indexes["old value"]]) if not row[key_indexes["old value"]] is None else "-"
         check_result = row[key_indexes["check"]]
         message = _create_message(row[key_indexes["reason"]], row[key_indexes["action_needed"]])
         if not _cluster_update_change_succeded(check_result):
             errors.append(
-                UpdateError(
-                    parameter=parameter, requested_value=str(new_value), message=message, current_value=str(old_value)
-                )
+                UpdateError(parameter=parameter, requested_value=new_value, message=message, current_value=old_value)
             )
-        change_set.append(Change(parameter=parameter, requested_value=str(new_value), current_value=str(old_value)))
+        change_set.append(Change(parameter=parameter, requested_value=new_value, current_value=old_value))
     return change_set, errors
 
 

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -461,7 +461,9 @@ def _analyze_changes(changes):
         message = _create_message(row[key_indexes["reason"]], row[key_indexes["action_needed"]])
         if not _cluster_update_change_succeded(check_result):
             errors.append(
-                UpdateError(parameter=parameter, requested_value=str(new_value), message=message, current_value=str(old_value))
+                UpdateError(
+                    parameter=parameter, requested_value=str(new_value), message=message, current_value=str(old_value)
+                )
             )
         change_set.append(Change(parameter=parameter, requested_value=str(new_value), current_value=str(old_value)))
     return change_set, errors

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1969,9 +1969,9 @@ class TestUpdateCluster:
             "message": "Request would have succeeded, but DryRun flag is set.",
             "changeSet": [
                 {
-                    "currentValue": 10,
+                    "currentValue": "10",
                     "parameter": "Scheduling.SlurmQueues[queue0].ComputeResources[queue0-i0].MaxCount",
-                    "requestedValue": 11,
+                    "requestedValue": "11",
                 }
             ],
         }
@@ -2460,10 +2460,12 @@ def test_cluster_update_change_succeded(check_result):
                 ],
             ],
             "-",
-            {
-                "ComputeResources": [{"InstanceType": "c5.9xlarge", "MinCount": 0, "Name": "compute2"}],
-                "Name": "queue2",
-            },
+            str(
+                {
+                    "Name": "queue2",
+                    "ComputeResources": [{"Name": "compute2", "InstanceType": "c5.9xlarge", "MinCount": 0}],
+                }
+            ),
         ),
         (
             [
@@ -2491,10 +2493,12 @@ def test_cluster_update_change_succeded(check_result):
                     "COMPUTE_FLEET_STOP_ON_REMOVE",
                 ],
             ],
-            {
-                "ComputeResources": [{"InstanceType": "c5.xlarge", "MinCount": 0, "Name": "compute1"}],
-                "Name": "queue1",
-            },
+            str(
+                {
+                    "Name": "queue1",
+                    "ComputeResources": [{"Name": "compute1", "InstanceType": "c5.xlarge", "MinCount": 0}],
+                }
+            ),
             "-",
         ),
     ],

--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -302,7 +302,7 @@ def _test_cluster_workflow(
     # Update cluster with new configuration
     with open(updated_config_file, encoding="utf-8") as config_file:
         updated_cluster_config = config_file.read()
-    _test_update_cluster_dryrun(region, cluster_operations_client, cluster_name, updated_cluster_config)
+    _test_update_cluster(region, cluster_operations_client, cluster_name, updated_cluster_config)
 
     head_node = _test_describe_cluster_head_node(region, cluster_instances_client, cluster_name)
     compute_node_map = _test_describe_cluster_compute_nodes(region, cluster_instances_client, cluster_name)
@@ -495,11 +495,9 @@ def _test_create_cluster(client, create_cluster, cluster_name, config):
     return cluster
 
 
-def _test_update_cluster_dryrun(region, client, cluster_name, config):
+def _test_update_cluster(region, client, cluster_name, config):
     body = UpdateClusterRequestContent(config)
-    error_message = "Request would have succeeded, but DryRun flag is set."
-    with pytest.raises(ApiException, match=error_message):
-        client.update_cluster(cluster_name, body, region=region, dryrun=True)
+    client.update_cluster(cluster_name, body, region=region, dryrun=False)
 
 
 def _test_delete_cluster(region, client, cluster_name):

--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -23,7 +23,6 @@ from benchmarks.common.util import get_instance_vcpus
 from botocore.config import Config
 from cfn_stacks_factory import CfnStack
 from clusters_factory import Cluster, ClustersFactory
-from pcluster_client import ApiException
 from pcluster_client.api import (
     cluster_compute_fleet_api,
     cluster_instances_api,


### PR DESCRIPTION
### Description of changes
* PCAPI updates were failing when updating a parameter that is not a string (eg. `MaxCount`)
```
pcluster_client.exceptions.ApiTypeError: Invalid type for variable 'current_value'. Required value type is str and passed type was int at ['received_data']['change_set'][0]['current_value']
```
* Forces `currentValue` and `requestedValue` for changeset to be strings

### Tests
* Ran `test_api.test_cluster_slurm[us-east-1-c5.xlarge-alinux2-slurm-None]` integration test
* Update `MaxCount` on a cluster using the cli to make sure no unexpected errors occured.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
