### PR TITLE
[Test] Removing color from output of ip command

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -54,7 +54,7 @@ def _test_head_node_nics(remote_command_executor, region):
     ).stdout
 
     head_node_ip_addresses = _get_private_ip_addresses(head_node_instance_id, region, remote_command_executor)
-    ip_a_result = remote_command_executor.run_remote_command("ip a").stdout
+    ip_a_result = remote_command_executor.run_remote_command("ip a | col -b").stdout
 
     for ip_address in head_node_ip_addresses:
         assert_that(ip_a_result).matches(".* inet {0}.*".format(ip_address))


### PR DESCRIPTION
### Description of changes
* O/p of `ip a` command adds color for ALinux2023
* Removing color from output of ip command
ANSI code for colors like `#x1B*` is being added 
```
#x1B[36mens5: #x1B[0m<BROADCAST,MULTICAST,UP,LOWER_UP> .....
```
### Tests
* Ran `ip a | col -b` on all Osses 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
