### PR TITLE
[Test] Fix test 'test_update_instance_list' by making use of the expected instance types.

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -16,8 +16,8 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5d.xlarge
-            - InstanceType: c5.xlarge
+            - InstanceType: c5d.large
+            - InstanceType: c5.large
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5d.xlarge
+            - InstanceType: c5d.large
           MinCount: 1
           MaxCount: 2
       Networking:


### PR DESCRIPTION
### Description of changes
Fix test 'test_update_instance_list' by making use of the expected instance types.
We changed the instance types in https://github.com/aws/aws-parallelcluster/pull/6579, but we missed to fix these files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
