### PR TITLE
[Test] Adding sleep before we start-stop compute fleet to avoid sporadic failure

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -15,6 +15,7 @@ import logging
 import re
 import tarfile
 import tempfile
+import time
 
 import boto3
 import botocore
@@ -272,8 +273,11 @@ def _test_pcluster_compute_fleet(cluster, expected_num_nodes):
     logging.info("Testing pcluster start functionalities")
     # Do a complicated sequence of start and stop and see if commands will still work
     cluster.start()
+    time.sleep(15)
     cluster.stop()
+    time.sleep(15)
     cluster.stop()
+    time.sleep(30)
     cluster.start()
     compute_fleet = cluster.describe_compute_fleet()
     last_start_time = compute_fleet["lastStatusUpdatedTime"]


### PR DESCRIPTION
### Description of changes
* Adding sleep to avoid
 ```
 {
  "message": "Bad Request: Failed when starting compute fleet due to a concurrent update of the status. Please retry the operation."
}
```

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
