### PR TITLE
[Test] Fix test 'test_update_slurm' adapting the constraint in the sbatch command to the flexible instance types used in the config

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -335,8 +335,8 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     _check_volume(cluster, updated_config, region)
 
     # Launch a new instance for queue1 and test updated pre/post install script execution and extra json update
-    # Add a new dynamic node t3.small to queue1-i3
-    new_compute_node = _add_compute_nodes(slurm_commands, "queue1", "t3.small")
+    # Add a new dynamic node to queue1-i3
+    new_compute_node = _add_compute_nodes(slurm_commands, "queue1", "queue1-i3&dynamic")
 
     logging.info(f"New compute node: {new_compute_node}")
 


### PR DESCRIPTION
### Description of changes
Fix test 'test_update_slurm' adapting the constraint in the sbatch command so that it can work when flexibleinstance types are used. In https://github.com/aws/aws-parallelcluster/commit/1360e741541e4ab58a6f8ea5cb9a535b15686a3e we introduced the use of flexible instance types in the test to reduce the risk of ICEs, but the sbatch command should have been adapted accordingly. Notiuce that you cannot use instance typoes as constraints when flexible instance types are used because in that case, the instance type is not listed in CR features.

### Tests
1. Succeeded `test_update_slurm`.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
