### PR TITLE
Only have EFS shared storage type if the scheduler is slurm

### DIFF
--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -2,7 +2,9 @@ Image:
   Os: {{ os }}
 HeadNode:
   InstanceType: {{ instance }}
+  {% if scheduler == "slurm" %}
   SharedStorageType: {{ shared_headnode_storage_type }}
+  {% endif %}
   Networking:
     SubnetId: {{ public_subnet_ids[0] }}
   Ssh:


### PR DESCRIPTION
### Description of changes
* Fix `test_multiple_efs` failure with awsbatch that occured due to have an EFS shared storage type

### Tests
* Ran `test_multiple_efs[us-east-2-c5.xlarge-alinux2-awsbatch-None]` integ test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
