### PR TITLE
[Test] Fix test 'test_update_slurm' adapting the constraint in the sbatch command to the flexible instance types used in the config

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -334,8 +334,8 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     _check_volume(cluster, updated_config, region)
 
     # Launch a new instance for queue1 and test updated pre/post install script execution and extra json update
-    # Add a new dynamic node t3.small to queue1-i3
-    new_compute_node = _add_compute_nodes(slurm_commands, "queue1", "t3.small")
+    # Add a new dynamic node to queue1-i3
+    new_compute_node = _add_compute_nodes(slurm_commands, "queue1", "queue1-i3&dynamic")
 
     logging.info(f"New compute node: {new_compute_node}")
 


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/6592

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.