### PR TITLE
Wait for update to complete in test_api

### DIFF
--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -302,6 +302,7 @@ def _test_cluster_workflow(
     with open(updated_config_file, encoding="utf-8") as config_file:
         updated_cluster_config = config_file.read()
     _test_update_cluster(region, cluster_operations_client, cluster_name, updated_cluster_config)
+    cluster.wait_cluster_status("UPDATE_COMPLETE")
 
     head_node = _test_describe_cluster_head_node(region, cluster_instances_client, cluster_name)
     compute_node_map = _test_describe_cluster_compute_nodes(region, cluster_instances_client, cluster_name)


### PR DESCRIPTION
### Description of changes
* Fix test_api integration test error:
`Bad Request: Failed when stopping compute fleet with error: Cannot stop/disable compute fleet while stack is in UPDATE_IN_PROGRESS status.`

### Tests
* Ran `test_cluster_slurm[us-east-1-c5.xlarge-alinux2-slurm-None]`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
