### PR TITLE
Pin minor version only if it has not already been pinned

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -195,8 +195,11 @@ phases:
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 if [[ ${!OS} == rhel9 ]] || [[ ${!OS} == rocky9 ]]; then
-                  echo ${!VERSION} > /etc/yum/vars/releasever
-                  yum clean all
+                  if [[ ! -f /etc/yum/vars/releasever ]]; then
+                    echo "yes" > /opt/parallelcluster/pin_releasesever
+                    echo ${!VERSION} > /etc/yum/vars/releasever
+                    yum clean all
+                  fi
                 fi
                 yum -y update krb5-libs
                 yum -y groupinstall development && sudo yum -y install curl wget jq

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -194,7 +194,7 @@ phases:
               VERSION='{{ build.OperatingSystemVersion.outputs.stdout }}'
 
               if [[ ${!PLATFORM} == RHEL ]]; then
-                if [[ ${!OS} == rhel9 ]]; then
+                if [[ ${!OS} == rhel9 ]] || [[ ${!OS} == rocky9 ]]; then
                   echo ${!VERSION} > /etc/yum/vars/releasever
                   yum clean all
                 fi

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -167,7 +167,7 @@ phases:
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               VERSION='{{ build.OperatingSystemVersion.outputs.stdout }}'
-              if [[ ${!OS} == rhel9 ]]; then
+              if [[ ${!OS} == rhel9 ]] || [[ ${!OS} == rocky9 ]]; then
                   echo ${!VERSION} > /etc/yum/vars/releasever
                   yum clean all
                 fi

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -57,21 +57,6 @@ phases:
               fi
 
               echo ${!OS}
-      - name: OperatingSystemVersion
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              FILE=/etc/os-release
-              if [ -e ${!FILE} ]; then
-                . ${!FILE}
-                echo "${!VERSION_ID}"
-              else
-                echo "The file '${!FILE}' does not exist. Failing build."
-                exit {{ FailExitCode }}
-              fi
-
 
       # Get platform name
       - name: PlatformName
@@ -166,14 +151,6 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-              VERSION='{{ build.OperatingSystemVersion.outputs.stdout }}'
-              if [[ ${!OS} == rhel9 ]] || [[ ${!OS} == rocky9 ]]; then
-                if [[ ! -f /etc/yum/vars/releasever ]]; then
-                  echo "yes" > /opt/parallelcluster/pin_releasesever
-                  echo ${!VERSION} > /etc/yum/vars/releasever
-                  yum clean all
-                fi
-              fi
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y install jq

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -168,9 +168,12 @@ phases:
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               VERSION='{{ build.OperatingSystemVersion.outputs.stdout }}'
               if [[ ${!OS} == rhel9 ]] || [[ ${!OS} == rocky9 ]]; then
+                if [[ ! -f /etc/yum/vars/releasever ]]; then
+                  echo "yes" > /opt/parallelcluster/pin_releasesever
                   echo ${!VERSION} > /etc/yum/vars/releasever
                   yum clean all
                 fi
+              fi
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y install jq


### PR DESCRIPTION
### Description of changes
* Pin minor version only if it has not already been pinned
* Do not pin the minor version during the first stage build or in the update_and_reboot component

### Tests
* Running first and second stage build pipelines

### References
* Works in tandem with this cookbook change: https://github.com/aws/aws-parallelcluster-cookbook/pull/2854

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
