### PR TITLE
[unit-tests] Fix unit tests on Python 3.12

### DIFF
--- a/cli/tests/pcluster/cli/test_describe_cluster_instances.py
+++ b/cli/tests/pcluster/cli/test_describe_cluster_instances.py
@@ -5,6 +5,8 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
+
 import pytest
 from assertpy import assert_that
 
@@ -24,8 +26,8 @@ class TestDescribeClusterInstancesCommand:
             (["--cluster-name", "cluster", "--invalid"], "Invalid arguments ['--invalid']"),
             (
                 ["--cluster-name", "cluster", "--node-type", "invalid"],
-                "error: argument --node-type: invalid choice: 'invalid' (choose from 'HeadNode', 'ComputeNode', "
-                "'LoginNode')",
+                r"error: argument --node-type: invalid choice: 'invalid' \(choose from .*HeadNode.*, .*ComputeNode.*, "
+                r".*LoginNode.*\)",
             ),
             (
                 ["--cluster-name", "cluster", "--region", "eu-west-"],
@@ -38,4 +40,4 @@ class TestDescribeClusterInstancesCommand:
         run_cli(command, expect_failure=True)
 
         out, err = capsys.readouterr()
-        assert_that(out + err).contains(error_message)
+        assert_that(re.search(error_message, out + err) or error_message in out + err).is_true()

--- a/cli/tests/pcluster/cli/test_list_images.py
+++ b/cli/tests/pcluster/cli/test_list_images.py
@@ -5,6 +5,8 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
+
 import pytest
 from assertpy import assert_that
 
@@ -33,7 +35,8 @@ class TestListImagesCommand:
             ),
             (
                 ["--image-status", "invalid"],
-                "argument --image-status: invalid choice: 'invalid' (choose from 'AVAILABLE', 'PENDING', 'FAILED')",
+                r"argument --image-status: invalid choice: 'invalid' "
+                r"\(choose from .*AVAILABLE.*, .*PENDING.*, .*FAILED.*\)",
             ),
             (
                 ["--image-status", "AVAILABLE", "--invalid"],
@@ -50,7 +53,7 @@ class TestListImagesCommand:
         run_cli(command, expect_failure=True)
 
         out, err = capsys.readouterr()
-        assert_that(out + err).contains(error_message)
+        assert_that(re.search(error_message, out + err) or error_message in out + err).is_true()
 
     def test_execute(self, mocker):
         response_dict = {


### PR DESCRIPTION
Error output on Python <= 3.11:
```
error: argument --node-type: invalid choice: 'invalid' (choose from 'HeadNode', 'ComputeNode', 'LoginNode')
```

Error output on Python 3.12:
```
error: argument --node-type: invalid choice: 'invalid' (choose from HeadNode, ComputeNode, LoginNode)
```

Therefore, this commit uses regex to add more flexibility to the tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
