### PR TITLE
[Test] Use larger head nodes to manage large cluster size

### DIFF
--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create/pcluster.config.yaml
@@ -6,7 +6,7 @@ Tags:
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
 Scheduling:

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update/pcluster.config.yaml
@@ -6,7 +6,7 @@ Tags:
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
 Scheduling:

--- a/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_job_level_scaling/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -2,7 +2,7 @@ Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -2,7 +2,7 @@ Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -2,7 +2,7 @@ Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: "c5.2xlarge"
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:


### PR DESCRIPTION
These tests started to fail after https://github.com/aws/aws-parallelcluster/pull/6623. The tests didn't encounter scaling issue because the tests were not launching many compute nodes to use the full capacity of the cluster.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
