### PR TITLE
Using Pseudo Function to get Service URL Domain

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -358,7 +358,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: "2012-10-17"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -170,7 +170,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: 2012-10-17
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
@@ -189,7 +189,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: 2012-10-17
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -59,7 +59,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:
@@ -105,7 +105,7 @@ Resources:
                 Condition:
                   StringEquals:
                     iam:PassedToService:
-                      - !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
+                      - !Sub ec2.${AWS::URLSuffix}
               - Action:
                   - ec2:DescribeInstances
                   - ec2:DescribeInstanceStatus
@@ -147,7 +147,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:
@@ -235,7 +235,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
@@ -73,7 +73,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              Service: !Sub ec2.${AWS::URLSuffix}
         Version: "2012-10-17"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore


### PR DESCRIPTION
### Description of changes
* Using cfn pseudo function `${AWS::URLSuffix}` for getting URL domain

Keeping some hardcoded for EC2 SP's based on https://github.com/aws/aws-parallelcluster/pull/3157

### Tests
* Manually Deployed the Templates

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
