### PR TITLE
[integ-test] rotate instance types for some integration tests

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -17,8 +17,8 @@ test-suites:
   basic:
     test_essential_features.py::test_essential_features:
       dimensions:
-        - regions: ["af-south-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        - regions: [{{ US_EAST_1_INSTANCE_TYPE_0_AZ }}]
+          instances: [{{ US_EAST_1_INSTANCE_TYPE_0 }}.xlarge]
           oss: [{{ OS_X86_1 }}]
           schedulers: ["slurm"]
   capacity_reservations:
@@ -288,8 +288,8 @@ test-suites:
   health_checks:
     test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
       dimensions:
-        - regions: ["eu-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        - regions: [{{ EU_WEST_1_GPU_INSTANCE_TYPE_0_AZ }}]
+          instances: [{{ EU_WEST_1_GPU_INSTANCE_TYPE_0 }}.xlarge]
           oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
   iam:

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
@@ -76,7 +76,11 @@ def test_cluster_with_gpu_health_checks(
             ),
         },
     }
-    cluster_config = pcluster_config_reader()
+    if architecture == "x86_64":
+        non_gpu_instance = "c5.xlarge"
+    else:
+        non_gpu_instance = "m6g.xlarge"
+    cluster_config = pcluster_config_reader(non_gpu_instance=non_gpu_instance)
     cluster = clusters_factory(cluster_config)
     assert_head_node_is_running(region, cluster)
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ instance }}
+  InstanceType: {{ non_gpu_instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -18,35 +18,35 @@ Scheduling:
     ComputeResources:
     - Name: compute-resource-1
       Instances:
-        - InstanceType: g4dn.xlarge
+        - InstanceType: {{ instance }}
       HealthChecks:
         Gpu:
           Enabled: false
     - Name: compute-resource-2
       Instances:
-        - InstanceType: g4dn.xlarge
+        - InstanceType: {{ instance }}
       HealthChecks:
         Gpu:
           Enabled: true
     - Name: compute-resource-3
       Instances:
-        - InstanceType: g4dn.xlarge
+        - InstanceType: {{ instance }}
       MinCount: 1
     - Name: compute-resource-4
       Instances:
-        - InstanceType: c5.xlarge
+        - InstanceType: {{ non_gpu_instance }}
       HealthChecks:
         Gpu:
           Enabled: false
     - Name: compute-resource-5
       Instances:
-        - InstanceType: c5.xlarge
+        - InstanceType: {{ non_gpu_instance }}
       HealthChecks:
         Gpu:
           Enabled: true
     - Name: compute-resource-6
       Instances:
-        - InstanceType: c5.xlarge
+        - InstanceType: {{ non_gpu_instance }}
     Networking:
       SubnetIds:
         - {{ private_subnet_id }}
@@ -54,13 +54,13 @@ Scheduling:
     ComputeResources:
     - Name: compute-resource-1
       Instances:
-        - InstanceType: g4dn.xlarge
+        - InstanceType: {{ instance }}
       HealthChecks:
         Gpu:
           Enabled: true
     - Name: compute-resource-2
       Instances:
-        - InstanceType: c5.xlarge
+        - InstanceType: {{ non_gpu_instance }}
       HealthChecks:
         Gpu:
           Enabled: true


### PR DESCRIPTION
1. Unlike rotating OS, instance types are region dependent. Therefore, we cannot use general Jinja variables like `{{ OS_X86_1 }}`. We need to use region specific Jinja variables like `{{ US_EAST_1_INSTANCE_TYPE_0 }}`
2. For code efficiency, this commit only populates three large AWS regions. The code is extendable if more regions should be added.
3. This commit rotates instance types only on `test_essential_features` and `test_cluster_with_gpu_health_checks`. The code is extendable if more tests should be added.
4. Improve `test_cluster_with_gpu_health_checks` to be able to run on both x86 and arm


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
