### PR TITLE
[integ-test] Run test_cluster_with_gpu_health_checks in us-west-2 instead of eu-west-1 to test more instance types

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -288,8 +288,8 @@ test-suites:
   health_checks:
     test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
       dimensions:
-        - regions: [{{ EU_WEST_1_GPU_INSTANCE_TYPE_0_AZ }}]
-          instances: [{{ EU_WEST_1_GPU_INSTANCE_TYPE_0 }}.xlarge]
+        - regions: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0_AZ }}]
+          instances: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0 }}.xlarge]
           oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
   iam:


### PR DESCRIPTION
g5g and g6 are not available in eu-west-1

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
