### PR TITLE
[Test] In test_fsx_lustre_dra, remove unnecessary update of DRA1 that may cause cluster update failure.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -32,7 +32,9 @@ from pcluster.config.common import (
     DefaultUserHomeType,
 )
 from pcluster.config.common import Imds as TopLevelImds
-from pcluster.config.common import Resource
+from pcluster.config.common import (
+    Resource,
+)
 from pcluster.constants import (
     CIDR_ALL_IPS,
     CW_ALARMS_ENABLED_DEFAULT,

--- a/cli/tests/pcluster/cli/test_describe_cluster_instances.py
+++ b/cli/tests/pcluster/cli/test_describe_cluster_instances.py
@@ -5,6 +5,8 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
+
 import pytest
 from assertpy import assert_that
 
@@ -24,8 +26,8 @@ class TestDescribeClusterInstancesCommand:
             (["--cluster-name", "cluster", "--invalid"], "Invalid arguments ['--invalid']"),
             (
                 ["--cluster-name", "cluster", "--node-type", "invalid"],
-                "error: argument --node-type: invalid choice: 'invalid' (choose from 'HeadNode', 'ComputeNode', "
-                "'LoginNode')",
+                r"error: argument --node-type: invalid choice: 'invalid' \(choose from .*HeadNode.*, .*ComputeNode.*, "
+                r".*LoginNode.*\)",
             ),
             (
                 ["--cluster-name", "cluster", "--region", "eu-west-"],
@@ -38,4 +40,4 @@ class TestDescribeClusterInstancesCommand:
         run_cli(command, expect_failure=True)
 
         out, err = capsys.readouterr()
-        assert_that(out + err).contains(error_message)
+        assert_that(re.search(error_message, out + err) or error_message in out + err).is_true()

--- a/cli/tests/pcluster/cli/test_list_images.py
+++ b/cli/tests/pcluster/cli/test_list_images.py
@@ -5,6 +5,8 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
+
 import pytest
 from assertpy import assert_that
 
@@ -33,7 +35,8 @@ class TestListImagesCommand:
             ),
             (
                 ["--image-status", "invalid"],
-                "argument --image-status: invalid choice: 'invalid' (choose from 'AVAILABLE', 'PENDING', 'FAILED')",
+                r"argument --image-status: invalid choice: 'invalid' "
+                r"\(choose from .*AVAILABLE.*, .*PENDING.*, .*FAILED.*\)",
             ),
             (
                 ["--image-status", "AVAILABLE", "--invalid"],
@@ -50,7 +53,7 @@ class TestListImagesCommand:
         run_cli(command, expect_failure=True)
 
         out, err = capsys.readouterr()
-        assert_that(out + err).contains(error_message)
+        assert_that(re.search(error_message, out + err) or error_message in out + err).is_true()
 
     def test_execute(self, mocker):
         response_dict = {

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -210,7 +210,7 @@ def test_fsx_lustre_dra(
 
     check_dra(cluster, region, 1, "test1", mount_dir)
 
-    # Add a second DRA and modify a parameter of the first DRA
+    # Add a second DRA
     cluster_update_config = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
         mount_dir=mount_dir,

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
@@ -43,7 +43,6 @@ SharedStorage:
           FileSystemPath: /test1
           ImportedFileChunkSize: 1024
           AutoExportPolicy: [ NEW, CHANGED, DELETED ]
-          AutoImportPolicy: [ NEW, CHANGED ]
         - Name: dra_2
           BatchImportMetaDataOnCreate: True
           DataRepositoryPath: s3://{{ bucket_name }}/test2


### PR DESCRIPTION
### Description of changes
[Test] In test_fsx_lustre_dra, remove unnecessary update of DRA1 that may cause cluster update failure.
In fact, there is a known FSx limitation that can cause FSx timeout when multiple DRAs are updated concurrently.

### Tests
* `test_fsx_lustre_dra` succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
