### PR TITLE
[Test] In test_fsx_lustre_dra, remove unnecessary update of DRA1 that may cause cluster update failure.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -32,7 +32,9 @@ from pcluster.config.common import (
     DefaultUserHomeType,
 )
 from pcluster.config.common import Imds as TopLevelImds
-from pcluster.config.common import Resource
+from pcluster.config.common import (
+    Resource,
+)
 from pcluster.constants import (
     CIDR_ALL_IPS,
     CW_ALARMS_ENABLED_DEFAULT,

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -210,7 +210,7 @@ def test_fsx_lustre_dra(
 
     check_dra(cluster, region, 1, "test1", mount_dir)
 
-    # Add a second DRA and modify a parameter of the first DRA
+    # Add a second DRA
     cluster_update_config = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
         mount_dir=mount_dir,

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
@@ -43,7 +43,6 @@ SharedStorage:
           FileSystemPath: /test1
           ImportedFileChunkSize: 1024
           AutoExportPolicy: [ NEW, CHANGED, DELETED ]
-          AutoImportPolicy: [ NEW, CHANGED ]
         - Name: dra_2
           BatchImportMetaDataOnCreate: True
           DataRepositoryPath: s3://{{ bucket_name }}/test2


### PR DESCRIPTION
Cherry picked from https://github.com/aws/aws-parallelcluster/pull/6649
Tested in original PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
