### PR TITLE
[integ-test] Fix test_slurm and run test_pcluster_configure in KUL

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -76,7 +76,7 @@ test-suites:
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: ["ap-southeast-2"]
+        - regions: ["ap-southeast-5"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: [{{ OS_ARM_2 }}]
           schedulers: ["slurm"]
@@ -420,8 +420,8 @@ test-suites:
           schedulers: ["awsbatch"]
     test_slurm.py::test_slurm:
       dimensions:
-        - regions: ["ap-southeast-5"] # c5 instance type is not available in ap-southeast-5
-          instances: ["m6i.xlarge"]
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_from_login_nodes_in_private_network:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -50,7 +50,7 @@ test-suites:
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: ["ap-southeast-2"]
+        - regions: ["ap-southeast-5"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
@@ -191,8 +191,8 @@ test-suites:
           schedulers: ["awsbatch"]
     test_slurm.py::test_slurm:
       dimensions:
-        - regions: ["ap-southeast-5"] # c5 instance type is not available in ap-southeast-5
-          instances: ["m6i.xlarge"]
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2204"]
           schedulers: ["slurm"]
     test_slurm.py::test_error_handling:


### PR DESCRIPTION
test_slurm uses some instance types that are not available in KUL. Therefore, this commit partially reverts https://github.com/aws/aws-parallelcluster/pull/6667.

To make sure there are integration tests running in KUL in the released.yaml, this commit moves test_pcluster_configure to KUL

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
