### PR TITLE
Add "ap-southeast-5", "ap-southeast-7" to unsupported AWS Batch validator

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -254,7 +254,7 @@ class Feature(Enum):
 
 
 UNSUPPORTED_FEATURES_MAP = {
-    Feature.BATCH: ["ap-northeast-3", "us-iso"],
+    Feature.BATCH: ["ap-northeast-3", "ap-southeast-5", "ap-southeast-7", "us-iso"],
     Feature.DCV: ["us-iso"],
     Feature.FSX_LUSTRE: ["us-isob"],
     Feature.FILE_CACHE: ["us-iso"],


### PR DESCRIPTION
Although AWS Batch is available in those regions. But AWS CodeBuild is not available. ParallelCluster relies on CodeBuild to integration with AWS Batch


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
