### PR TITLE
[Permissions] Add new parameter 'ParallelClusterFunctionAdditionalPolicies' to the ParallelCluster API stack to add custom permissions for the API Lambda role, on top of the default ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - Add new build image configuration section `Build/Installation` to turn on/off Nvidia software and Lustre client installations. By default, Nvidia software, although included in official ParallelCluster AMIs, is not installed by `build-image`. By default, Lustre client is installed.
 - The CLI commands `export-cluster-logs` and `export-image-logs` can now by default export the logs to the default ParallelCluster bucket or to the CustomS3Bucket if specified in the config.
 - Extend Amazon DCV support to Ubuntu2204 on ARM instances.
+- Add new parameter 'ParallelClusterFunctionAdditionalPolicies' to the ParallelCluster API stack to add custom permissions for the API Lambda role, on top of the default ones.
 
 **CHANGES**
 - Upgrade NVIDIA driver to version 550.127.08 (from 550.90.07). This addresses [a known issue from Nivdia](https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-550-90-07/index.html#known-issues).

--- a/api/infrastructure/deploy-api.sh
+++ b/api/infrastructure/deploy-api.sh
@@ -7,7 +7,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-usage="$(basename "$0") [-h] --s3-bucket bucket-name --region aws-region [--stack-name name] [--enable-iam-admin true|false] [--create-api-user true|false] [--lambda-layer abs_path]"
+usage="$(basename "$0") [-h] --s3-bucket bucket-name --region aws-region [--stack-name name] [--enable-iam-admin true|false] [--create-api-user true|false] [--lambda-layer abs_path] [--additional-iam-policies policy_arn]"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -16,6 +16,7 @@ STACK_NAME="ParallelClusterApi"
 ENABLE_IAM_ADMIN="true"
 CREATE_API_USER="false"
 LAMBDA_LAYER=
+PC_FUNCTION_ADDITIONAL_IAM_POLICIES=
 while [[ $# -gt 0 ]]
 do
 key="$1"
@@ -65,6 +66,11 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --additional-iam-policies)
+    export PC_FUNCTION_ADDITIONAL_IAM_POLICIES=$2
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     echo "$usage" >&2
     exit 1
@@ -104,5 +110,6 @@ aws cloudformation deploy \
     --parameter-overrides ApiDefinitionS3Uri="${S3_UPLOAD_URI}" \
                           PoliciesTemplateUri="${POLICIES_TEMPLATE_URI}" \
                           EnableIamAdminAccess="${ENABLE_IAM_ADMIN}" CreateApiUserRole="${CREATE_API_USER}" \
+                          ParallelClusterFunctionAdditionalPolicies="${PC_FUNCTION_ADDITIONAL_IAM_POLICIES}" \
                           "$([[ -n "${LAMBDA_LAYER}" ]] && echo "CustomBucket=${S3_BUCKET}" || echo " ")" \
     --capabilities CAPABILITY_NAMED_IAM

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -14,6 +14,14 @@ Parameters:
     Type: String
     Default: ''
 
+  ParallelClusterFunctionAdditionalPolicies:
+    Description: |
+      (OPTIONAL) ARN of the additional IAM policy to be attached to the default execution role for the ParallelCluster Lambda function.
+      Only one policy can be specified.
+    Type: String
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+
   ApiDefinitionS3Uri:
     Description: S3 URI of the ParallelCluster API spec
     Type: String
@@ -186,6 +194,7 @@ Resources:
         PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
         IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
         EnableBatchAccess: true
+        AdditionalPolicies: !Ref ParallelClusterFunctionAdditionalPolicies
 
   PclusterLayer:
     Type: AWS::Lambda::LayerVersion

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -62,6 +62,14 @@ Parameters:
     Default: ''
     MaxLength: 10
 
+  AdditionalPolicies:
+    Description: |
+      (OPTIONAL) ARN of the additional IAM policy to be attached to the default execution role for the ParallelCluster Lambda function.
+      Only one policy can be specified.
+    Type: String
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+
 Outputs:
   ParallelClusterLogRetrievalPolicy:
     Value: !Ref ParallelClusterLogRetrievalPolicy
@@ -97,6 +105,7 @@ Conditions:
   EnableFSxS3AccessCondition: !Equals [!Ref EnableFSxS3Access, true]
   EnableBatchAccessCondition: !Equals [!Ref EnableBatchAccess, true]
   EnablePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
+  UseAdditionalPolicies: !Not [!Equals [!Ref AdditionalPolicies, '']]
   UseAllBucketsForFSxS3: !Equals [!Ref FsxS3Buckets, "*"]
   EnableIamPolicy: !Or
     - !Equals [!Ref EnableIamAdminAccess, true]
@@ -202,6 +211,10 @@ Resources:
           - !Ref AWS::NoValue
         - !Ref ParallelClusterImageManagedPolicy
         - !Ref ParallelClusterLogRetrievalPolicy
+        - !If
+          - UseAdditionalPolicies
+          - !Ref AdditionalPolicies
+          - !Ref AWS::NoValue
 
   ### CLUSTER ACTIONS POLICIES
 


### PR DESCRIPTION
### Description of changes
Add new parameter 'ParallelClusterFunctionAdditionalPolicies' to the ParallelCluster API stack to add custom permissions for the API Lambda role, on top of the default ones.

It is intentional to use plural form for the parameter name (ParallelClusterFunctionAdditionalPolicies) even if we currently support just one policy. In this way the parameter will be open to extensions in future.

### Tests
* Deployed PCAPI w/o specifying 'ParallelClusterFunctionAdditionalPolicies' -> the PCAPI Lambda has the default permissions 
* Deployed PCAPI w/ 'ParallelClusterFunctionAdditionalPolicies' -> the PCAPI Lambda has the extra permissions on top of the defualt ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
