### PR TITLE
[integ-tests] Add ap-southeast-5 ap-southeast-7 regions to common.jinja2

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -1,4 +1,4 @@
-{%- set REGIONS_COMMERCIAL = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "eu-north-1", "me-south-1", "af-south-1", "eu-south-1", "il-central-1"] -%}
+{%- set REGIONS_COMMERCIAL = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-5", "ap-southeast-7", "eu-north-1", "me-south-1", "af-south-1", "eu-south-1", "il-central-1"] -%}
 {%- set REGIONS_CHINA = ["cn-north-1", "cn-northwest-1"] -%}
 {%- set REGIONS_GOVCLOUD = ["us-gov-west-1", "us-gov-east-1"] -%}
 {%- set REGIONS_ALL = REGIONS_COMMERCIAL + REGIONS_CHINA + REGIONS_GOVCLOUD -%}


### PR DESCRIPTION
The REGIONS_COMMERCIAL variable is not really used anywhere

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
