### PR TITLE
Fix cuda deviceQuery test

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -309,18 +309,32 @@ phases:
               echo "Correctly installed CUDA ${cuda_output}"
 
               echo "Testing CUDA with deviceQuery..."
-              if [ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]; then
-                /usr/local/cuda-${cuda_ver}/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
-                [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
+              if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'ubuntu2004' ]; then
+                echo "Skipping CUDA deviceQuery test on Ubuntu 20.04"
               else
-                 cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
-                 cmake .. -D CMAKE_CUDA_ARCHITECTURES=native -D CMAKE_PREFIX_PATH=/usr/local/cuda-${cuda_ver}
-                 cd deviceQuery
-                 make
-                 ./deviceQuery | grep -o "Result = PASS"
-                 [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
+                if [ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]; then
+                  /usr/local/cuda-${cuda_ver}/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
+                  [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
+                else
+                   cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
+                   if [ ${cuda_ver} < '12.8' ]; then
+                     make
+                     /usr/local/{{ validate.CudaSamplesBinDir.outputs.stdout }}/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
+                   else
+                     mkdir build
+                     cd build
+                     cmake .. \
+                      -DCMAKE_CUDA_ARCHITECTURES="75;80;86" \
+                      -DCMAKE_CUDA_COMPILER=/usr/local/cuda-${cuda_ver}/bin/nvcc \
+                      -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-${cuda_ver} \
+                      -DCMAKE_PREFIX_PATH=/usr/local/cuda-cuda-${cuda_ver}
+                     make
+                     ./deviceQuery | grep -o "Result = PASS"
+                   fi
+                   [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
+                fi
+                echo "CUDA deviceQuery test passed"
               fi
-              echo "CUDA deviceQuery test passed"
 
       - name: FSxLustre
         action: ExecuteBash

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -317,7 +317,7 @@ phases:
                   [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
                 else
                    cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
-                   if [ ${cuda_ver} < '12.8' ]; then
+                   if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'alinux2' ]; then
                      make
                      /usr/local/{{ validate.CudaSamplesBinDir.outputs.stdout }}/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
                    else


### PR DESCRIPTION
### Description of changes
* Fix cuda deviceQuery test
* AL2 is still on cuda 12.8, so it still uses make instead of cmake
* ubuntu2004 does not have a high enough cmake version, it would need to be installed from the internet, this change just excludes running device query on ubuntu2004

### Tests
* Ran second stage build for all OSs

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
