### PR TITLE
[ActiveDirectory] In AD template, create users without joining the domain

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -437,40 +437,23 @@ Resources:
               yum update -y aws-cfn-bootstrap
               /opt/aws/bin/cfn-init -v --stack "${AWS::StackName}" --resource AdDomainAdminNode --configsets setup --region "${AWS::Region}"
               echo "Domain Name: ${DirectoryDomain}"
+              echo "Domain DNS IP 1: ${DnsIp1}"
+              echo "Domain DNS IP 2: ${DnsIp2}"
               echo "Domain Certificate Secret: ${DomainCertificateSecretArn}"
               echo "Domain Private Key Secret: ${DomainPrivateKeySecretArn}"
               
-              mkdir -p /etc/systemd/resolved.conf.d
-              cat << EOF > /etc/systemd/resolved.conf.d/pcluster-ad-domain-dns-server.conf
-              [Resolve]
-              DNS=${DnsIp1} ${DnsIp2}
-              Domains=~.
-              EOF
-              service systemd-resolved restart
-              
               ADMIN_PW="${AdminPassword}"
-              
-              attempt=0
-              max_attempts=5
-              until [ $attempt -ge $max_attempts ]; do
-                attempt=$((attempt+1))
-                echo "[DEBUG] Checking domain name resolution for ${DirectoryDomain} ..."
-                dig ${DirectoryDomain}
-                echo "Joining domain (attempt $attempt/$max_attempts) ..."
-                echo "$ADMIN_PW" | sudo realm join -U "${Admin}" "${DirectoryDomain}" --verbose && echo "Domain joined" && break
-                sleep 10
-              done
               
               sleep 10
               echo "Registering ReadOnlyUser..."
-              echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain="${DirectoryDomain}" --display-name=ReadOnlyUser ReadOnlyUser
+              echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name=ReadOnlyUser ReadOnlyUser
               sleep 0.5
               echo "Registering Users..."
               USERNAMES="${UserNames}"
               for username in $(echo $USERNAMES | sed "s/,/ /g")
               do
                 echo "Registering user: $username"
-                echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain="${DirectoryDomain}" --display-name="$username" "$username"
+                echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username"
               done
 
               echo "Creating domain certificate..."


### PR DESCRIPTION
### Description of changes
In AD template, create users without joining the domain.

We used to join the domain because we thought it was necessary to create users using adcli.
However, we found out that adcli allows to do it without joining the domain, simply by contacting the Ad domain controllers directly, rather than through the domain.

See option --domain-controller in the general section of https://manpages.ubuntu.com/manpages/trusty/man8/adcli.8.html#name

Also, let the Ad admin node log the controller IPs for troubleshooting.

Further improvement: we can wrap the create-users calls within a retry block.

### Tests
Template used to deploy MsAD in personal account
Manually verified with ldapsearch that the expected users are created.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
