### PR TITLE
[Integ tests] Revert "Add wait time to allow time for job state to switch to pending

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -953,7 +953,6 @@ def _test_update_queue_strategy_with_running_job(
         # requeue job in queue2 to launch new instances for nodes
         remote_command_executor.run_remote_command(f"scontrol requeue {queue2_job_id}")
     elif queue_update_strategy == "TERMINATE":
-        time.sleep(60)
         scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
 
     # Be sure the queue2 job is running even after the forced termination: we need the nodes active so that we


### PR DESCRIPTION
Revert "Add wait time to allow time for job state to switch to pending (#6111)"

This reverts commit 531e13c6ce4932cb6f7eac6395f678011988cbd1.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
