### PR TITLE
Install cmake using cookbook_virtual_env for validating Cuda

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -309,32 +309,44 @@ phases:
               echo "Correctly installed CUDA ${cuda_output}"
 
               echo "Testing CUDA with deviceQuery..."
-              if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'ubuntu2004' ]; then
-                echo "Skipping CUDA deviceQuery test on Ubuntu 20.04"
+              if [ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]; then
+                /usr/local/cuda-${cuda_ver}/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
+                [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
               else
-                if [ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]; then
-                  /usr/local/cuda-${cuda_ver}/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
-                  [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
-                else
-                   cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
-                   if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'alinux2' ]; then
-                     make
-                     /usr/local/{{ validate.CudaSamplesBinDir.outputs.stdout }}/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
-                   else
-                     mkdir build
-                     cd build
-                     cmake .. \
-                      -DCMAKE_CUDA_ARCHITECTURES="75;80;86" \
-                      -DCMAKE_CUDA_COMPILER=/usr/local/cuda-${cuda_ver}/bin/nvcc \
-                      -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-${cuda_ver} \
-                      -DCMAKE_PREFIX_PATH=/usr/local/cuda-cuda-${cuda_ver}
-                     make
-                     ./deviceQuery | grep -o "Result = PASS"
+                 cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
+                 if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'alinux2' ]; then
+                   make
+                   /usr/local/{{ validate.CudaSamplesBinDir.outputs.stdout }}/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
+                 else
+                   if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'ubuntu2004' ]; then
+                     MINI_CMAKE_VER_REQ=$(sed -n 's/cmake_minimum_required(\(VERSION \)\?\([0-9.]*\)).*/\2/p' CMakeLists.txt)
+                     COOKBOOK_ENV=$(jq '.default.cluster.cookbook_virtualenv_path' {{ CookbookDefaultFile }})
+                     COOKBOOK_ENV_PATH=$(echo ${COOKBOOK_ENV} | tr -d '\n' | cut -d = -f 2 | xargs)
+                     echo "Installing Cmake >= ${MINI_CMAKE_VER_REQ} in $COOKBOOK_ENV_PATH/bin"
+                     . $COOKBOOK_ENV_PATH/bin/activate
+                     $COOKBOOK_ENV_PATH/bin/pip3 install cmake>=$MINI_CMAKE_VER_REQ
+                     CMAKE_ARGS=""
+                     if [ -e $COOKBOOK_ENV_PATH/bin/cmake ]; then
+                       CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=$COOKBOOK_ENV_PATH/bin/cmake ${CMAKE_ARGS}"
+                     fi
                    fi
-                   [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
-                fi
-                echo "CUDA deviceQuery test passed"
+                   mkdir build && cd build
+                   cmake .. \
+                    -DCMAKE_CUDA_ARCHITECTURES="75;80;86" \
+                    -DCMAKE_CUDA_COMPILER=/usr/local/cuda-${cuda_ver}/bin/nvcc \
+                    -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-${cuda_ver} \
+                    -DCMAKE_PREFIX_PATH=/usr/local/cuda-cuda-${cuda_ver} \
+                     ${CMAKE_ARGS}
+                   make
+                   ./deviceQuery | grep -o "Result = PASS"
+                   if [ "${OS}" == 'ubuntu2004' ]; then
+                     $COOKBOOK_ENV_PATH/bin/pip3 uninstall cmake -y
+                     deactivate
+                   fi
+                 fi
+                 [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
               fi
+              echo "CUDA deviceQuery test passed"
 
       - name: FSxLustre
         action: ExecuteBash

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -169,7 +169,7 @@ phases:
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
-      - name: CudaSamplesSrcDir
+      - name: CudaSamplesDir
         action: ExecuteBash
         inputs:
           commands:
@@ -179,24 +179,9 @@ phases:
               if [ ${cuda_ver} \> '11.4' ]; then
                 PATTERN=$(jq '.default.cluster.nvidia.cuda_samples_version' {{ CookbookDefaultFile }})
                 VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-                echo cuda-samples-${VERSION}/Samples
+                echo cuda-samples-${VERSION}
               else
-                echo cuda-${cuda_ver}/samples
-              fi
-
-      - name: CudaSamplesBinDir
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              cuda_ver="{{ validate.CudaVersion.outputs.stdout }}"
-              if [ ${cuda_ver} \> '11.4' ]; then
-                PATTERN=$(jq '.default.cluster.nvidia.cuda_samples_version' {{ CookbookDefaultFile }})
-                VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-                echo cuda-samples-${VERSION}/bin
-              else
-                echo cuda-${cuda_ver}/samples/bin
+                echo cuda-${cuda_ver}
               fi
 
       ### utils ###
@@ -313,10 +298,10 @@ phases:
                 /usr/local/cuda-${cuda_ver}/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
                 [[ $? -ne 0 ]] && echo "CUDA deviceQuery test failed" && exit 1
               else
-                 cd /usr/local/{{ validate.CudaSamplesSrcDir.outputs.stdout }}/1_Utilities/deviceQuery
+                 cd /usr/local/{{ validate.CudaSamplesDir.outputs.stdout }}//Samples/1_Utilities/deviceQuery
                  if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'alinux2' ]; then
                    make
-                   /usr/local/{{ validate.CudaSamplesBinDir.outputs.stdout }}/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
+                   /usr/local/{{ validate.CudaSamplesDir.outputs.stdout }}/bin/sbsa/linux/release/deviceQuery | grep -o "Result = PASS"
                  else
                    if [ {{ validate.OperatingSystemName.outputs.stdout }} == 'ubuntu2004' ]; then
                      MINI_CMAKE_VER_REQ=$(sed -n 's/cmake_minimum_required(\(VERSION \)\?\([0-9.]*\)).*/\2/p' CMakeLists.txt)


### PR DESCRIPTION
### Description of changes
*  Install cmake using cookbook_virtual_env and later uninstalling cmake
The latest version of cmake available in repo for U20 is 3.16 and we need version > 3.20 as per cuda samples. 
Uninstalling the cmake package affects EFA packages and other libraries in OS.

* Removed CudaSamplesBinDir as its similar to CudaSamplesSrcDir and the size of the Component was over the limit


### Tests
Build AMI

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
