### PR TITLE
[ActiveDirectory] Make AD user creation more robust, wrapping the logic into a retry block.

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -444,16 +444,19 @@ Resources:
               
               ADMIN_PW="${AdminPassword}"
               
-              sleep 10
-              echo "Registering ReadOnlyUser..."
-              echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name=ReadOnlyUser ReadOnlyUser
-              sleep 0.5
-              echo "Registering Users..."
-              USERNAMES="${UserNames}"
+              USERNAMES="ReadOnlyUser,${UserNames}"
+              echo "Registering Users: $USERNAMES ..."
               for username in $(echo $USERNAMES | sed "s/,/ /g")
               do
-                echo "Registering user: $username"
-                echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username"
+                attempt=0
+                max_attempts=5
+                until [ $attempt -ge $max_attempts ]; do
+                  attempt=$((attempt+1))
+                  echo "Registering user $username (attempt $attempt/$max_attempts) ..."
+                  echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  sleep 10
+                done
               done
 
               echo "Creating domain certificate..."

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -462,8 +462,8 @@ Resources:
                 until [ $attempt -ge $max_attempts ]; do
                   attempt=$((attempt+1))
                   echo "Registering user $username (attempt $attempt/$max_attempts) ..."
-                  echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
-                  echo "$ADMIN_PW" | adcli create-user -x -U "${Admin}" --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
                   sleep 10
                 done
               done

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -284,6 +284,7 @@ Resources:
                   physical_resource_id = create_physical_resource_id()
 
                   # provide outputs
+                  response_data['DirectoryId'] = directory_id
                   response_data['DomainName'] = domain
                   response_data['DomainShortName'] = domain.split(".")[0].upper()
                   response_data['VpcId'] = vpc_id
@@ -368,6 +369,8 @@ Resources:
             Statement:
               - Action:
                   - ds:ResetUserPassword
+                  - ds:DescribeDirectories
+                  - ds:DescribeDomainControllers
                 Effect: Allow
                 Resource: !Sub
                   - arn:${AWS::Partition}:ds:${AWS::Region}:${AWS::AccountId}:directory/${DirectoryId}
@@ -445,11 +448,17 @@ Resources:
               exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
               yum update -y aws-cfn-bootstrap
               /opt/aws/bin/cfn-init -v --stack "${AWS::StackName}" --resource AdDomainAdminNode --configsets setup --region "${AWS::Region}"
+              echo "Directory Id: ${DirectoryId}"
               echo "Domain Name: ${DirectoryDomain}"
               echo "Domain DNS IP 1: ${DnsIp1}"
               echo "Domain DNS IP 2: ${DnsIp2}"
               echo "Domain Certificate Secret: ${DomainCertificateSecretArn}"
               echo "Domain Private Key Secret: ${DomainPrivateKeySecretArn}"
+              
+              echo "Describing directory..."
+              aws ds describe-directories --directory-id "${DirectoryId}" --region "${AWS::Region}"
+              echo "Describing domain controllers..."
+              aws ds describe-domain-controllers --directory-id "${DirectoryId}" --region "${AWS::Region}"
               
               ADMIN_PW="${AdminPassword}"
               
@@ -464,6 +473,9 @@ Resources:
                   echo "Registering user $username (attempt $attempt/$max_attempts) ..."
                   echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
                   echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "User creation failed, describing directory and controllers for troubleshooting..."
+                  aws ds describe-directories --directory-id "${DirectoryId}" --region "${AWS::Region}"
+                  aws ds describe-domain-controllers --directory-id "${DirectoryId}" --region "${AWS::Region}"
                   sleep 10
                 done
               done
@@ -484,7 +496,8 @@ Resources:
 
               /opt/aws/bin/cfn-signal -e "$?" --stack "${AWS::StackName}" --region "${AWS::Region}" "${AdDomainAdminNodeWaitConditionHandle}"
 
-            - { DirectoryDomain: !GetAtt Prep.DomainName,
+            - { DirectoryId: !GetAtt Prep.DirectoryId,
+                DirectoryDomain: !GetAtt Prep.DomainName,
                 AdminPassword: !Ref AdminPassword,
                 UserNames: !Ref UserNames,
                 DnsIp1: !GetAtt Prep.DnsIpAddress1,

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -389,11 +389,20 @@ Resources:
       Roles:
         - Ref: JoinRole
 
+  AdDomainAdminNodeWaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+
+  AdDomainAdminNodeWaitCondition:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn:
+      - Prep
+    Properties:
+      Count: 1
+      Handle: !Ref AdDomainAdminNodeWaitConditionHandle
+      Timeout: 900
+
   AdDomainAdminNode:
     Type: AWS::EC2::Instance
-    CreationPolicy:
-      ResourceSignal:
-        Timeout: PT15M
     Metadata:
       "AWS::CloudFormation::Init":
         configSets:
@@ -473,7 +482,7 @@ Resources:
               echo "Deleting private key and certificate from local file system..."
               rm -rf "$PRIVATE_KEY" "$CERTIFICATE"
 
-              /opt/aws/bin/cfn-signal -e "$?" --stack "${AWS::StackName}" --resource AdDomainAdminNode --region "${AWS::Region}"
+              /opt/aws/bin/cfn-signal -e "$?" --stack "${AWS::StackName}" --region "${AWS::Region}" "${AdDomainAdminNodeWaitConditionHandle}"
 
             - { DirectoryDomain: !GetAtt Prep.DomainName,
                 AdminPassword: !Ref AdminPassword,
@@ -482,7 +491,8 @@ Resources:
                 DnsIp2: !GetAtt Prep.DnsIpAddress2,
                 DomainCertificateSecretArn: !Ref DomainCertificateSecret,
                 DomainPrivateKeySecretArn: !Ref DomainPrivateKeySecret,
-                Admin: !If [UseMicrosoftAD, "Admin", "Administrator" ]
+                Admin: !If [UseMicrosoftAD, "Admin", "Administrator" ],
+                AdDomainAdminNodeWaitConditionHandle: !Ref AdDomainAdminNodeWaitConditionHandle
             }
 
   PostRole:


### PR DESCRIPTION
### Description of changes
Improvements to the AD template:
1. user creation is now more fault tolerant as it is wrapped in retry block.
1. AD admin node signaling to external wait condition handle so that the node can be retained in case of failure for troubleshooting.
1. Increased verbosity of adcli commands for troubleshooting.
1. Describe directory and directory controllers in case of failure for better troubleshooting.

### Tests
Template deployed in personal account.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
