### PR TITLE
[Integ test] Moving check of Job state after cluster update

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -938,6 +938,8 @@ def _test_update_queue_strategy_with_running_job(
     scheduler_commands.assert_job_state(queue1_job_id, "RUNNING")
     queue1_nodes = scheduler_commands.get_compute_nodes("queue1")
     assert_compute_node_states(scheduler_commands, queue1_nodes, expected_states=["mixed", "allocated"])
+    if queue_update_strategy == "TERMINATE":
+        scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
     # check queue1 AMIs are not replaced
     _check_queue_ami(cluster, ec2, pcluster_ami_id, "queue1")
 
@@ -952,8 +954,6 @@ def _test_update_queue_strategy_with_running_job(
         assert_compute_node_states(scheduler_commands, queue2_nodes, expected_states=["draining", "draining!"])
         # requeue job in queue2 to launch new instances for nodes
         remote_command_executor.run_remote_command(f"scontrol requeue {queue2_job_id}")
-    elif queue_update_strategy == "TERMINATE":
-        scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
 
     # Be sure the queue2 job is running even after the forced termination: we need the nodes active so that we
     # can check the AMI id on the instances


### PR DESCRIPTION
### Description of changes
Adding check for compute node state quickly after an update as nodes are moving from Pending to Configuring


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
