### PR TITLE
[Test][ActiveDirectory] In test AD, replace the use of service command with systemctl to prevent failures on Rocky9 where service command is not found.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -544,7 +544,7 @@ def test_ad_integration(  # noqa: C901
 
     remote_command_executor = RemoteCommandExecutor(cluster)
     remote_command_executor.run_remote_command(
-        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo service sssd restart",
+        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i systemctl restart sssd",
         additional_files=[test_datadir / "certificate.crt"],
     )
     if directory_certificate_verification:
@@ -670,7 +670,7 @@ def test_ad_integration_on_login_nodes(
     # Publish compute node count metric every minute via cron job
     remote_command_executor = RemoteCommandExecutor(cluster)
     remote_command_executor.run_remote_command(
-        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo service sssd restart",
+        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i service sssd restart",
         additional_files=[test_datadir / "certificate.crt"],
     )
     if directory_certificate_verification:


### PR DESCRIPTION
### Description of changes
In test AD, replace the use of service command with systemctl to prevent failures on Rocky9 where service command is not found. systemctl is available on all other OSes so it's ok to make this change across all OSes.

### Tests
* test_ad_integration on Rocky9

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
