### PR TITLE
[Test] In test_efa, when running on Ubuntu 24.04, remove the EXTERNALLY-MANAGED flag of the system installation of Python to unblock installation of Fabtests.

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
@@ -13,6 +13,11 @@ FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
 CUDA_DIR="/usr/local/cuda"
 
+echo "[INFO] Checking OS info"
+. /etc/os-release
+OS="${NAME}-${VERSION_ID}"
+echo "[INFO] OS is ${OS}"
+
 echo "[INFO] Installing Fabtests in $FABTESTS_DIR"
 rm -rf $FABTESTS_DIR
 mkdir -p $FABTESTS_SOURCES_DIR
@@ -20,6 +25,18 @@ cd $FABTESTS_SOURCES_DIR
 git clone --depth 1 --branch v$FABTESTS_VERSION $FABTESTS_REPO
 cd libfabric/fabtests
 ./autogen.sh
+
 ./configure --with-libfabric=$LIBFABRIC_DIR --with-cuda=$CUDA_DIR --prefix=$FABTESTS_DIR && make -j 32 && make install
+
+# On Ubuntu 24.04 we must disable the externally managed flag to unblock installation of custom python packages
+# on the system installation of Python.
+# This is only a workaround to quickly unblock the test.
+# the long term solution is to define a virtualenv to run Fabtests.
+# See https://packaging.python.org/en/latest/specifications/externally-managed-environments/
+if [[ ${OS} == "Ubuntu-24.04" ]]; then
+  PYTHON_STDLIB_DIR=$(python3 -c 'import sysconfig;print(sysconfig.get_path("stdlib", sysconfig.get_default_scheme()))')
+  echo "[INFO] Removing EXTERNALLY-MANAGED flag for system installation of Python at ${PYTHON_STDLIB_DIR}, as a workaround to unblock Fabtests installation on OS ${OS}"
+  sudo rm -rf "${PYTHON_STDLIB_DIR}/EXTERNALLY-MANAGED"
+fi
 python3 -m pip install --user -r $FABTESTS_SOURCES_DIR/libfabric/fabtests/pytest/requirements.txt
 echo "[INFO] Fabtests installed in $FABTESTS_DIR"


### PR DESCRIPTION
### Description of changes
The Fabtest installation script run in test_efa fails the Fasbtest installation on Ubuntu24.04 because on Ubuntu 24.04 the system installation of Python is configured as being externally managed. See https://packaging.python.org/en/latest/specifications/externally-managed-environments/

This setup blocks the installation of custom Python packages on the system.
To unblock the test I applied a workaround, which is to remove the EXTERNALLY-MANAGED flag of the system installation of Python to unblock installation of Fabtests.
This is only a workaround to quickly unblock the test on Ubuntu 24.04. The long term solution is to create a dedicated virtual env for Fabtests.

### Tests
Manually run the fixed installation script on Ubuntu24.04 checking that Fabtest are properly installed.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
