### PR TITLE
Add ubuntu24 tags

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -53,6 +53,8 @@ phases:
                 OS='ubuntu2004'
               elif [ $(echo "${RELEASE}" | grep '^ubuntu\.22') ]; then
                 OS='ubuntu2204'
+              elif [ $(echo "${RELEASE}" | grep '^ubuntu\.24') ]; then
+                OS='ubuntu2404'
               elif [ $(echo "${RELEASE}" | grep '^rhel\.8') ]; then
                 OS='rhel8'
               elif [ $(echo "${RELEASE}" | grep '^rocky\.8') ]; then


### PR DESCRIPTION
### Description of changes
* Add the os tag to ubuntu24 amis so that they can be found for kitchen tests

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
