### PR TITLE
[integ-tests] Improve integration tests to prevent tests hanging forever

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -23,6 +23,7 @@ pytest-html
 pytest-rerunfailures
 pytest-sugar
 pytest-xdist
+pytest-timeout
 PyYAML
 requests
 retrying

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -557,6 +557,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
 
     pytest_args.append("--tests-log-file={0}/{1}".format(args.output_dir, log_file))
     pytest_args.append("--output-dir={0}/{1}".format(args.output_dir, out_dir))
+    pytest_args.append("--timeout=25200")
     pytest_args.append(f"--key-name={args.key_name}")
     pytest_args.append(f"--key-path={args.key_path}")
     pytest_args.extend(["--stackname-suffix", args.stackname_suffix])

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -315,7 +315,7 @@ def _test_s3_access(remote_command_executor, region):
 def _test_batch_access(remote_command_executor, region):
     logging.info("Testing AWS Batch Access")
     result = remote_command_executor.run_remote_command(
-        f"aws batch describe-compute-environments --region {region}"
+        f"aws batch describe-compute-environments --region {region}", timeout=60
     ).stdout
     # An error occurred (AccessDeniedException) when calling the DescribeComputeEnvironments operation: ...
     assert_that(result).does_not_contain("AccessDeniedException")


### PR DESCRIPTION
### Tests
* `test_iam_policies` is timing out properly. I will look into why the command in `test_iam_policies` is timing out

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
