### PR TITLE
[Integ Test] Increase stop_max_delay to fix test_error_handling

### DIFF
--- a/tests/integration-tests/tests/common/hit_common.py
+++ b/tests/integration-tests/tests/common/hit_common.py
@@ -85,7 +85,7 @@ def assert_compute_node_reasons(scheduler_commands, compute_nodes, expected_reas
         assert_that(node_info).contains(f"Reason={expected_reason}")
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(8))
 def wait_for_num_nodes_in_scheduler(scheduler_commands, desired, filter_by_partition=None):
     assert_num_nodes_in_scheduler(scheduler_commands, desired, filter_by_partition)
 


### PR DESCRIPTION
### Description of changes
* The test_error_handling is failed because compute node launch time is longer than 5 minutes. But eventually it became fully functional. In our observation, the compute node is responded just 1 second after the timeout. So increase the timeout to 8 minutes to ensure will not cause a test failure.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
