### PR TITLE
[Test] In test_essential_features, increase the max time to wait for the failing instance to be terminated from 5min to 6min.

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -30,7 +30,7 @@ from tests.common.scaling_common import get_compute_nodes_allocation
 from tests.common.utils import get_ddb_item
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(6))
 def wait_instance_replaced_or_terminating(instance_id, region):
     assert_instance_replaced_or_terminating(instance_id, region)
 


### PR DESCRIPTION
### Description of changes
In test_essential_features, increase the max time to wait for the failing instance to be terminated from 5min to 6min.
This is required to give the init recipe the time to complete.
We observed this need of this relaxation on Rocky and RHEL.

### Tests
Verified that this fix unblocks the test, which is failing for other reasons.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
