### PR TITLE
[Ubuntu24] Update Validation message that Ubuntu24 is not supported with FSx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Add support for Ubuntu24.
 - Add support for ap-southeast-5 and ap-southeast-7 regions. At the time of this version launch, AWS CodeBuild is not supported in ap-southeast-5 or ap-southeast-7. Therefore, ParallelCluster AWS Batch integration is not supported.
+- Add validator to show Ubuntu2404 and FSX are unsupported in a cluster. Please suppress this validator when you have a Ubuntu2404 CustomAmi which has kernel compatible lustre client.  
 
 **CHANGES**
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -36,7 +36,7 @@ from pcluster.constants import (
     RETAIN_POLICY,
     SCHEDULERS_SUPPORTING_IMDS_SECURED,
     SUPPORTED_OSES,
-    SUPPORTED_SCHEDULERS,
+    SUPPORTED_SCHEDULERS, UNSUPPORTED_OSES_FOR_LUSTRE,
 )
 from pcluster.launch_template_utils import _LaunchTemplateBuilder
 from pcluster.utils import (
@@ -62,8 +62,8 @@ EFS_MESSAGES = {
 }
 
 FSX_SUPPORTED_ARCHITECTURES_OSES = {
-    "x86_64": SUPPORTED_OSES,
-    "arm64": SUPPORTED_OSES,
+    "x86_64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_LUSTRE],
+    "arm64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_LUSTRE],
 }
 
 FSX_MESSAGES = {

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1550,6 +1550,20 @@ def test_fsx_network_validator(
             ),
         ),
         (
+                "x86_64",
+                "ubuntu2404",
+                FSX_MESSAGES["errors"]["unsupported_os"].format(
+                    architecture="x86_64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("x86_64")
+                ),
+        ),
+        (
+                "arm64",
+                "ubuntu2404",
+                FSX_MESSAGES["errors"]["unsupported_os"].format(
+                    architecture="arm64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("arm64")
+                ),
+        ),
+        (
             "UnsupportedArchitecture",
             "alinux2",
             FSX_MESSAGES["errors"]["unsupported_architecture"].format(


### PR DESCRIPTION
### Description of changes
* Add Validation message that Ubuntu24 is not supported with FSx
* release-3.13 https://github.com/aws/aws-parallelcluster/pull/6704

### Tests
Running a dryrun for a cluster-create
```
 {
      "level": "ERROR",
      "type": "FsxArchitectureOsValidator",
      "message": "On x86_64 instance types, FSx Lustre can be used with one of the following operating systems: ['alinux2', 'alinux2023', 'ubuntu2004', 'ubuntu2204', 'rhel8', 'rocky8', 'rhel9', 'rocky9']. Please double check the os configuration."
    }

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
