### PR TITLE
[Ubuntu24] Update Validation message that Ubuntu24 is not supported with Fsx

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1720,7 +1720,10 @@ class BaseClusterConfig(Resource):
                         new_storage_count["fsx"] += 1
                     self._register_validator(FeatureRegionValidator, feature=Feature.FSX_LUSTRE, region=self.region)
                     self._register_validator(
-                        FsxArchitectureOsValidator, architecture=self.head_node.architecture, os=self.image.os
+                        FsxArchitectureOsValidator,
+                        architecture=self.head_node.architecture,
+                        os=self.image.os,
+                        custom_ami=self.image.custom_ami,
                     )
                 elif isinstance(storage, ExistingFsxOpenZfs):
                     existing_storage_count["fsx"] += 1

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -37,6 +37,7 @@ from pcluster.constants import (
     SCHEDULERS_SUPPORTING_IMDS_SECURED,
     SUPPORTED_OSES,
     SUPPORTED_SCHEDULERS,
+    UNSUPPORTED_OSES_FOR_LUSTRE,
 )
 from pcluster.launch_template_utils import _LaunchTemplateBuilder
 from pcluster.utils import (
@@ -62,8 +63,8 @@ EFS_MESSAGES = {
 }
 
 FSX_SUPPORTED_ARCHITECTURES_OSES = {
-    "x86_64": SUPPORTED_OSES,
-    "arm64": SUPPORTED_OSES,
+    "x86_64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_LUSTRE],
+    "arm64": [os for os in SUPPORTED_OSES if os not in UNSUPPORTED_OSES_FOR_LUSTRE],
 }
 
 FSX_MESSAGES = {
@@ -712,7 +713,7 @@ class FsxArchitectureOsValidator(Validator):
     Validate that OS and architecture are compatible with FSx.
     """
 
-    def _validate(self, architecture: str, os):
+    def _validate(self, architecture: str, os, custom_ami):
         if architecture not in FSX_SUPPORTED_ARCHITECTURES_OSES:
             self._add_failure(
                 FSX_MESSAGES["errors"]["unsupported_architecture"].format(
@@ -721,12 +722,15 @@ class FsxArchitectureOsValidator(Validator):
                 FailureLevel.ERROR,
             )
         elif os not in FSX_SUPPORTED_ARCHITECTURES_OSES.get(architecture):
-            self._add_failure(
-                FSX_MESSAGES["errors"]["unsupported_os"].format(
-                    architecture=architecture, supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get(architecture)
-                ),
-                FailureLevel.ERROR,
-            )
+            if os in ["ubuntu2404"] and custom_ami:
+                pass
+            else:
+                self._add_failure(
+                    FSX_MESSAGES["errors"]["unsupported_os"].format(
+                        architecture=architecture, supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get(architecture)
+                    ),
+                    FailureLevel.ERROR,
+                )
 
 
 def _find_duplicate_params(param_list):

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1525,19 +1525,20 @@ def test_fsx_network_validator(
 
 
 @pytest.mark.parametrize(
-    "architecture, os, expected_message",
+    "architecture, os, custom_ami, expected_message",
     [
         # Supported combinations
-        ("x86_64", "alinux2", None),
-        ("x86_64", "rhel8", None),
-        ("x86_64", "ubuntu2004", None),
-        ("arm64", "ubuntu2004", None),
-        ("arm64", "rhel8", None),
-        ("arm64", "alinux2", None),
+        ("x86_64", "alinux2", None, None),
+        ("x86_64", "rhel8", None, None),
+        ("x86_64", "ubuntu2004", None, None),
+        ("arm64", "ubuntu2004", None, None),
+        ("arm64", "rhel8", None, None),
+        ("arm64", "alinux2", None, None),
         # Unsupported combinations
         (
             "x86_64",
             "ubuntu1804",
+            None,
             FSX_MESSAGES["errors"]["unsupported_os"].format(
                 architecture="x86_64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("x86_64")
             ),
@@ -1545,6 +1546,24 @@ def test_fsx_network_validator(
         (
             "arm64",
             "ubuntu1804",
+            None,
+            FSX_MESSAGES["errors"]["unsupported_os"].format(
+                architecture="arm64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("arm64")
+            ),
+        ),
+        (
+            "x86_64",
+            "ubuntu2404",
+            None,
+            FSX_MESSAGES["errors"]["unsupported_os"].format(
+                architecture="x86_64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("x86_64")
+            ),
+        ),
+        ("x86_64", "ubuntu2404", "ami-1234567890", None),
+        (
+            "arm64",
+            "ubuntu2404",
+            None,
             FSX_MESSAGES["errors"]["unsupported_os"].format(
                 architecture="arm64", supported_oses=FSX_SUPPORTED_ARCHITECTURES_OSES.get("arm64")
             ),
@@ -1552,14 +1571,15 @@ def test_fsx_network_validator(
         (
             "UnsupportedArchitecture",
             "alinux2",
+            None,
             FSX_MESSAGES["errors"]["unsupported_architecture"].format(
                 supported_architectures=list(FSX_SUPPORTED_ARCHITECTURES_OSES.keys())
             ),
         ),
     ],
 )
-def test_fsx_architecture_os_validator(architecture, os, expected_message):
-    actual_failures = FsxArchitectureOsValidator().execute(architecture, os)
+def test_fsx_architecture_os_validator(architecture, os, custom_ami, expected_message):
+    actual_failures = FsxArchitectureOsValidator().execute(architecture, os, custom_ami)
     assert_failure_messages(actual_failures, expected_message)
 
 


### PR DESCRIPTION

### Description of changes

develop - https://github.com/aws/aws-parallelcluster/pull/6703
* Add Validation message that Ubuntu24 is not supported with FSx

### Tests
Running a dryrun for a cluster-create
```
 {
      "level": "ERROR",
      "type": "FsxArchitectureOsValidator",
      "message": "On x86_64 instance types, FSx Lustre can be used with one of the following operating systems: ['alinux2', 'alinux2023', 'ubuntu2004', 'ubuntu2204', 'rhel8', 'rocky8', 'rhel9', 'rocky9']. Please double check the os configuration."
    }

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
