### PR TITLE
[Test] Add Ubuntu24, RHEL9 and Rocky9 to OpenFOAM performance tests.

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "ubuntu2004"] # Ubuntu22.04, RHEL8 and Rocky8 are not supported
+          oss: ["alinux2", "alinux2023", "ubuntu2004"] # Ubuntu22.04, RHEL8 and Rocky8 are not supported
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -12,12 +12,16 @@ OPENFOAM_JOB_TIMEOUT = 5400  # Takes long time because during the first time, it
 # builds and installs many things
 TASK_VCPUS = 36  # vCPUs are cut in a half because multithreading is disabled
 BASELINE_CLUSTER_SIZE_ELAPSED_SECONDS = {
+    "alinux2023": {8: 754, 16: 366, 32: 182},  # v3.10.0
     "alinux2": {8: 754, 16: 366, 32: 182},  # v3.1.3
+    "ubuntu2404": {8: 742, 16: 376, 32: 185},  # v3.13.0 just a placeholder, Ubuntu24.04 not supported
     "ubuntu2204": {8: 742, 16: 376, 32: 185},  # v3.7.0 just a placeholder, Ubuntu22.04 not supported
     "ubuntu2004": {8: 750, 16: 382, 32: 187},  # v3.1.3
     "centos7": {8: 755, 16: 371, 32: 190},  # v3.1.3
     "rhel8": {8: 742, 16: 376, 32: 185},  # v3.6.0 just a placeholder, RHEL8 not supported
+    "rhel9": {8: 742, 16: 376, 32: 185},  # v3.9.0 just a placeholder, RHEL9 not supported
     "rocky8": {8: 742, 16: 376, 32: 185},  # v3.8.0 just a placeholder, Rocky8 not supported
+    "rocky9": {8: 742, 16: 376, 32: 185},  # v3.9.0 just a placeholder, Rocky9 not supported
 }
 
 


### PR DESCRIPTION
Cherry picked from https://github.com/aws/aws-parallelcluster/pull/6713

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
