### PR TITLE
[Integ-Test] Fix test_queue_parameters_update

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -939,7 +939,8 @@ def _test_update_queue_strategy_with_running_job(
     queue1_nodes = scheduler_commands.get_compute_nodes("queue1")
     assert_compute_node_states(scheduler_commands, queue1_nodes, expected_states=["mixed", "allocated"])
     if queue_update_strategy == "TERMINATE":
-        scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
+        time.sleep(10)
+        scheduler_commands.assert_job_state(queue2_job_id, "CONFIGURING")
     # check queue1 AMIs are not replaced
     _check_queue_ami(cluster, ec2, pcluster_ami_id, "queue1")
 


### PR DESCRIPTION
### Description of changes
* Replace PENDING assertion to CONFIGURING.
* The PENDING assertion makes non-sense. The compute node started to be waked up the same time as cluster update succeeded and the job enter CF state immediately.

### Tests
* Test re-run succeeded in Jenkins.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
