### PR TITLE
[Test] Fix test shared home by setting the expected size for the shared ebs volume.

### DIFF
--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -123,8 +123,8 @@ def _check_shared_home(
             scheduler_commands, remote_command_executor, f"{mount_dir}/{get_username_for_os(os)}"
         )
     elif storage_type == "Ebs":
-        _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size=40)
-        _test_ebs_correctly_mounted(remote_command_executor_login_node, mount_dir, volume_size=40)
+        _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size=45)
+        _test_ebs_correctly_mounted(remote_command_executor_login_node, mount_dir, volume_size=45)
         # Test ebs correctly shared between HeadNode and ComputeNodes
         logging.info("Testing ebs correctly mounted on compute nodes")
         verify_directory_correctly_shared(


### PR DESCRIPTION
### Description of changes
Fix test shared home by setting the expected size for the shared ebs volume.

We must match the value of 45Gb set in the cluster config:

```
    EbsSettings:
      Raid:
        Type: 1
      Size: 45
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
