### PR TITLE
[Test] Remove AL23 from test OpenFOAM as it is not supported

### DIFF
--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -4,5 +4,5 @@ test-suites:
       dimensions:
         - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2", "alinux2023", "ubuntu2004"] # Ubuntu22.04, RHEL8 and Rocky8 are not supported
+          oss: ["alinux2", "ubuntu2004"] # Amazon Linux 2023, Ubuntu22.04, RHEL8 and Rocky8 are not supported
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
Remove AL23 from test OpenFOAM as it is not supported

### Tests
OpenFOAM  explicitly says it's not supported.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
