### PR TITLE
[Test] Fix script used to run OSU benchmark with IntelMPI.

### DIFF
--- a/tests/integration-tests/tests/common/data/osu/osu_pt2pt_submit_intelmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_pt2pt_submit_intelmpi.sh
@@ -9,4 +9,4 @@ export I_MPI_DEBUG=10
 
 env
 
-mpirun -bootstrap=slurm  -np 2 --map-by ppr:1:node /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out
+mpirun -bootstrap=slurm -np 2 -ppn 1 /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out


### PR DESCRIPTION
### Description of changes
Fix script used to run OSU benchmark with IntelMPI.

`--map-by` is an OpenMPI option, which is not supported by IntelMPI.
To achieve the equivalent node mapping IntelMPI exposes the option `--ppn` (processes per node).

### Tests
Manually verified that simply replacing the option makes the job succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
