### PR TITLE
[integ-tests] Relax test condition to allow EBS volume size reporting discrepancy

### DIFF
--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -135,7 +135,11 @@ def _check_shared_home(
 def _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size):
     logging.info(f"Testing ebs {mount_dir} is correctly mounted on login")
     result = remote_command_executor.run_remote_command(f"df -h | grep {mount_dir}")
-    assert_that(result.stdout).matches(r"{size}G.*{mount_dir}".format(size=volume_size, mount_dir=mount_dir))
+    assert_that(result.stdout).matches(
+        r"({size}|{size_minus_one})G.*{mount_dir}".format(
+            size=volume_size, size_minus_one=volume_size - 1, mount_dir=mount_dir
+        )
+    )
 
     result = remote_command_executor.run_remote_command("cat /etc/fstab")
     assert_that(result.stdout).matches(r"{mount_dir}.*_netdev".format(mount_dir=mount_dir))


### PR DESCRIPTION
### Tests
* test_shared_home has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
