### PR TITLE
[Test] In test_scontrol_reboot, increase the timeout to wait for compute nodes to reboot from 400s to 500s in Rocky and RHEL as we observed an increase in bootstrap time.

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -330,11 +330,11 @@ def pytest_collection_finish(session):
         region = [unmarshal_az_override(az) for az in region]
         # Use the first element of the list of regions, since there must be at least one
         reporting_region = get_reporting_region(region[0])
-        logging.info(f"Metadata reporting region {reporting_region}")
+        logging.debug(f"Metadata reporting region {reporting_region}")
         # Setup the metadata table in case it doesn't exist
         MetadataTableManager(reporting_region, METADATA_TABLE).create_metadata_table()
     except Exception as exc:
-        logging.info(f"There was a '{type(exc)}' error with '{exc}' when creating the table!")
+        logging.error(f"There was a '{type(exc)}' error with '{exc}' when creating the table!")
 
 
 def _log_collected_tests(session):

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -782,6 +782,7 @@ def test_scontrol_reboot(
     clusters_factory,
     test_datadir,
     scheduler_commands_factory,
+    os,
 ):
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
@@ -798,11 +799,14 @@ def test_scontrol_reboot(
         slots=2,
         constraint="dynamic",
     )
+    # TOFIX We observe in 3.13.0 an increase in the bootstrap time for AL2023, Rocky and RHEL.
+    # We must address it and restore the default wait time to 400s.
+    stop_max_delay_secs = 500 if (os == "alinux2023" or os.startswith("rocky") or os.startswith("rhel")) else 400
     wait_for_compute_nodes_states(
         slurm_commands,
         ["queue1-dy-cr1-1", "queue1-dy-cr1-2"],
         "idle",
-        stop_max_delay_secs=400,
+        stop_max_delay_secs=stop_max_delay_secs,
     )
 
     # Test that idle static and dynamic nodes can be rebooted


### PR DESCRIPTION
### Description of changes
[Test] In test_scontrol_reboot, increase the timeout to wait for compute nodes to reboot from 400s to 500s in Rocky and RHEL as we observed an increase in bootstrap time.

### Tests
test_scontrol_reboot succeeded on all OSes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
