### PR TITLE
[Integ-Test] Move test_trainium to use2-az3 as there are more trn1.32xlarge instances

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -748,7 +748,7 @@ test-suites:
   trainium:
     test_trainium.py::test_trainium:
       dimensions:
-        - regions: ["usw2-az4"]  # do not move, unless instance type support is moved as well
+        - regions: ["use2-az3"]  # do not move, unless instance type support is moved as well
           schedulers: ["slurm"]
           oss: ["ubuntu2004"]
           instances: ["trn1.32xlarge"]


### PR DESCRIPTION
### Description of changes
* Fix test_trainium ICE issue.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
