### PR TITLE
[Test] In test_pyxis, when run on Ubuntu24.04, disable kernel setting 'apparmor_restrict_unprivileged_userns'

### DIFF
--- a/tests/integration-tests/tests/pyxis/test_pyxis/test_pyxis/compute_node_start.sh
+++ b/tests/integration-tests/tests/pyxis/test_pyxis/test_pyxis/compute_node_start.sh
@@ -22,3 +22,12 @@ PYXIS_RUNTIME_DIR="/run/pyxis"
 
 sudo mkdir -p $PYXIS_RUNTIME_DIR
 sudo chmod 1777 $PYXIS_RUNTIME_DIR
+
+# In Ubuntu24.04 Apparmor blocks the creation of unprivileged user namespaces,
+# which is required by Enroot. So to run Enroot, it is required to disable this restriction.
+# See https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+source /etc/os-release
+if [ "${ID}${VERSION_ID}" == "ubuntu24.04" ]; then
+    echo "kernel.apparmor_restrict_unprivileged_userns = 0" | sudo tee /etc/sysctl.d/99-pcluster-disable-apparmor-restrict-unprivileged-userns.conf
+    sudo sysctl --system
+fi


### PR DESCRIPTION
### Description of changes
[Test] In test_pyxis, when run on Ubuntu24.04, disable kernel setting 'apparmor_restrict_unprivileged_userns' to prevent permission denied errors blocking Enroot execution. 

This is required only on Ubuntu24.04 as the restriction was introduced in Ubuntu23.

See https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces

### Tests
Ongoing 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
