### PR TITLE
[build-image] Add internal parameter to distinguish official AMI build

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -329,7 +329,7 @@ phases:
           commands:
             - |
               set -v
-              /usr/local/sbin/ami_cleanup.sh
+              /usr/local/sbin/ami_cleanup.sh "${CfnParamIsOfficialAmiBuild}"
 
   - name: validate
     steps:

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -213,6 +213,25 @@ class ImageBuilderCdkStack(Stack):
             ),
             description="UpdateOsAndReboot",
         )
+        CfnParameter(
+            self,
+            "CfnParamIsOfficialAmiBuild",
+            type="String",
+            default=(
+                json.loads(self.config.dev_settings.cookbook.extra_chef_attributes)
+                .get("cluster")
+                .get("is_official_ami_build")
+                if self.config.dev_settings
+                and self.config.dev_settings.cookbook
+                and self.config.dev_settings.cookbook.extra_chef_attributes
+                and json.loads(self.config.dev_settings.cookbook.extra_chef_attributes).get("cluster")
+                and json.loads(self.config.dev_settings.cookbook.extra_chef_attributes)
+                .get("cluster")
+                .get("is_official_ami_build")
+                else "false"
+            ),
+            description="IsOfficialAmiBuild",
+        )
 
     # -- Resources --------------------------------------------------------------------------------------------------- #
 

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -61,6 +61,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -112,6 +113,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -162,6 +164,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -210,6 +213,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceProfile": {},
@@ -260,6 +264,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InfrastructureConfiguration": {},
@@ -309,6 +314,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -357,6 +363,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -407,6 +414,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -456,6 +464,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -513,6 +522,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -563,6 +573,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -612,6 +623,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},
@@ -661,6 +673,7 @@ from tests.pcluster.utils import assert_lambdas_have_expected_vpc_config_and_man
                     "CfnParamCincInstaller": {},
                     "CfnParamCookbookVersion": {},
                     "CfnParamUpdateOsAndReboot": {},
+                    "CfnParamIsOfficialAmiBuild": {},
                 },
                 "Resources": {
                     "InstanceRole": {},


### PR DESCRIPTION
This allows more complete AMI cleanup when build official AMIs

### Tests
* AMI builds on all OS are successful

### References
* Cookbook https://github.com/aws/aws-parallelcluster-cookbook/pull/2920

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
