### PR TITLE
[Test] Add HNBootstrap timeout for multi-nic tests

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -1,3 +1,8 @@
+{% if "rocky" in os or "rhel" in os %}
+DevSettings:
+  Timeouts:
+    HeadNodeBootstrapTimeout: 2040
+{% endif %}
 Image:
   Os: {{ os }}
 HeadNode:


### PR DESCRIPTION
### Description of changes
* [Test] Add HNBootstrap timeout for multi-nic tests

### Tests
ONGOING
```
test-suites:
  multiple_nics:
    test_multiple_nics.py::test_multiple_nics:
      dimensions:
        - regions: ["use1-az1"]
          instances: ["c6in.32xlarge"]
          oss: [ "rocky9" ]
          schedulers: ["slurm"].
```
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
