### PR TITLE
[Test] Execute all Ad integ tests in ap-southeast-1

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -8,11 +8,7 @@ test-suites:
       dimensions:
         - regions: [ "ap-southeast-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ {{ LUSTRE_OS_X86_0 }}, {{ LUSTRE_OS_X86_2 }}]
-          schedulers: ["slurm"]
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [{{ LUSTRE_OS_X86_4 }}, {{ LUSTRE_OS_X86_6 }}]
+          oss: [ {{ LUSTRE_OS_X86_0 }}, {{ LUSTRE_OS_X86_2 }}, {{ LUSTRE_OS_X86_4 }}, {{ LUSTRE_OS_X86_6 }}]
           schedulers: ["slurm"]
   basic:
     test_essential_features.py::test_essential_features:


### PR DESCRIPTION
### Description of changes
Execute all Ad integ tests in ap-southeast-1 where AD creation is apparently more stable. We are ultimately interested in validating the stability of the cluster, not the stability of AD creation.

### Tests
AD test consistently succeeeds in ap-southeast-1 for days, wheres it cnsistently fails in ap-northeast-1 due to AD instability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
