### PR TITLE
[Build Image] Manage Kernel consistency through version locking

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -182,23 +182,6 @@ phases:
                 fi
               fi
 
-      - name: CreatingJsonFile
-        action: CreateFile
-        inputs:
-          - path: /etc/parallelcluster/image_dna.json
-            content: |
-              ${CfnParamChefDnaJson}
-            overwrite: true
-
-      - name: DisableKernelUpdate
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              DISABLE_KERNEL_UPDATE=$(cat /etc/parallelcluster/image_dna.json | jq -r '.cluster.disable_kernel_update.enabled')
-              echo "${!DISABLE_KERNEL_UPDATE}"
-
       - name: PinKernelVersion
         action: ExecuteBash
         inputs:
@@ -207,27 +190,24 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
 
-              if [[ ${!DISABLE_KERNEL_UPDATE} == true ]]; then
-                if [[ ${!PLATFORM} == RHEL ]]; then
-                  yum install -y yum-plugin-versionlock
-                  # listing all the packages because wildcard does not work as expected
-                  yum versionlock kernel kernel-core kernel-modules
+              if [[ ${!PLATFORM} == RHEL ]]; then
+                yum install -y yum-plugin-versionlock
+                # listing all the packages because wildcard does not work as expected
+                yum versionlock kernel kernel-core kernel-modules
 
-                  if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
-                    yum versionlock kernel-abi-whitelists
-                  else
-                    yum versionlock kernel-abi-stablelists
-                  fi
-
-                  if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
-                    yum versionlock rocky-release rocky-repos
-                  elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
-                    yum versionlock redhat-release
-                  fi
-                  echo "Kernel version locked"
+                if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
+                  yum versionlock kernel-abi-whitelists
+                else
+                  yum versionlock kernel-abi-stablelists
                 fi
+
+                if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
+                  yum versionlock rocky-release rocky-repos
+                elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
+                  yum versionlock redhat-release
+                fi
+                echo "Kernel version locked"
               fi
 
       # Install prerequisite OS packages
@@ -324,6 +304,14 @@ phases:
               cookbook_path ['/etc/chef/cookbooks']
             overwrite: true
 
+      - name: CreatingJsonFile
+        action: CreateFile
+        inputs:
+          - path: /etc/parallelcluster/image_dna.json
+            content: |
+              ${CfnParamChefDnaJson}
+            overwrite: true
+
       - name: InstallPClusterPackages
         action: ExecuteBash
         inputs:
@@ -350,10 +338,9 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
 
               # Remove kernel version lock
-              if [[ ${!DISABLE_KERNEL_UPDATE} == true ]] && [[ ${!PLATFORM} == RHEL ]]; then
+              if [[ ${!PLATFORM} == RHEL ]]; then
                 yum versionlock delete kernel kernel-core kernel-modules
 
                 if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -182,6 +182,54 @@ phases:
                 fi
               fi
 
+      - name: CreatingJsonFile
+        action: CreateFile
+        inputs:
+          - path: /etc/parallelcluster/image_dna.json
+            content: |
+              ${CfnParamChefDnaJson}
+            overwrite: true
+
+      - name: DisableKernelUpdate
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              DISABLE_KERNEL_UPDATE=$(cat /etc/parallelcluster/image_dna.json | jq -r '.cluster.disable_kernel_update.enabled')
+              echo "${!DISABLE_KERNEL_UPDATE}"
+
+      - name: PinKernelVersion
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+
+              if [[ ${!DISABLE_KERNEL_UPDATE} == true ]]; then
+                if [[ ${!PLATFORM} == RHEL ]]; then
+                  yum install -y yum-plugin-versionlock
+                  # listing all the packages because wildcard does not work as expected
+                  yum versionlock kernel kernel-core kernel-modules
+
+                  if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
+                    yum versionlock kernel-abi-whitelists
+                  else
+                    yum versionlock kernel-abi-stablelists
+                  fi
+
+                  if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
+                    yum versionlock rocky-release rocky-repos
+                  elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
+                    yum versionlock redhat-release
+                  fi
+                  echo "Kernel version locked"
+                fi
+              fi
+
       # Install prerequisite OS packages
       - name: InstallPrerequisite
         action: ExecuteBash
@@ -282,14 +330,6 @@ phases:
               cookbook_path ['/etc/chef/cookbooks']
             overwrite: true
 
-      - name: CreatingJsonFile
-        action: CreateFile
-        inputs:
-          - path: /etc/parallelcluster/image_dna.json
-            content: |
-              ${CfnParamChefDnaJson}
-            overwrite: true
-
       - name: InstallPClusterPackages
         action: ExecuteBash
         inputs:
@@ -307,6 +347,34 @@ phases:
             content: |
               {{ build.PClusterCookbookVersionName.outputs.stdout }}
             overwrite: true
+
+      - name: RemoveKernelPin
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+
+              # Remove kernel version lock
+              if [[ ${!DISABLE_KERNEL_UPDATE} == true ]] && [[ ${!PLATFORM} == RHEL ]]; then
+                yum versionlock delete kernel kernel-core kernel-modules
+
+                if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
+                  yum versionlock delete kernel-abi-whitelists
+                else
+                  yum versionlock delete kernel-abi-stablelists
+                fi
+
+                if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
+                  yum versionlock delete rocky-release
+                elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
+                  yum versionlock delete redhat-release
+                fi
+                echo "Kernel version unlocked"
+              fi
 
       - name: KeepSSM
         action: ExecuteBash

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -129,7 +129,7 @@ phases:
                set -v
                OS='{{ build.OperatingSystemName.outputs.stdout }}'
 
-               if [ `echo "${!OS}" | grep -E '^(alinux|centos|rhel|rocky)'` ]; then
+               if [ `echo "${!OS}" | grep -E '^(alinux|rhel|rocky)'` ]; then
                  PLATFORM='RHEL'
                elif [ `echo "${!OS}" | grep -E '^ubuntu'` ]; then
                  PLATFORM='DEBIAN'
@@ -167,7 +167,7 @@ phases:
               set -v
               if [ ${CfnParamUpdateOsAndReboot} == false ]; then
                 RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
-                if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|centos|ubuntu|rhel|rocky)'` ]; then
+                if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|ubuntu|rhel|rocky)'` ]; then
                   echo "This component does not support '${!RELEASE}'. Failing build."
                   exit {{ FailExitCode }}
                 fi
@@ -251,12 +251,6 @@ phases:
                 fi
                 yum -y update krb5-libs
                 yum -y groupinstall development && sudo yum -y install curl wget jq
-              
-
-                if [[ ${!OS} =~ ^centos ]]; then
-                  /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
-                  grub2-mkconfig -o /boot/grub2/grub.cfg
-                fi
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 if [[ "${CfnParamUpdateOsAndReboot}" == "false" ]]; then
                   # disable apt-daily.timer to avoid dpkg lock

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -190,7 +190,7 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-
+              KERNEL_VERSION=$(uname -a)
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum install -y yum-plugin-versionlock
                 # listing all the packages because wildcard does not work as expected
@@ -207,8 +207,10 @@ phases:
                 elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
                   yum versionlock redhat-release
                 fi
-                echo "Kernel version locked"
+              else
+                apt-mark hold linux-aws* linux-base* linux-headers* linux-image* 
               fi
+              echo "Kernel version is ${!KERNEL_VERSION}"     
 
       # Install prerequisite OS packages
       - name: InstallPrerequisite
@@ -338,7 +340,7 @@ phases:
               set -v
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
-
+              BEFORE_KERNEL_VERSION='{{ build.PinKernelVersion.output.stdout }}'
               # Remove kernel version lock
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum versionlock delete kernel kernel-core kernel-modules
@@ -350,12 +352,17 @@ phases:
                 fi
 
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
-                  yum versionlock delete rocky-release
+                  yum versionlock delete rocky-release rocky-repos
                 elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
                   yum versionlock delete redhat-release
                 fi
-                echo "Kernel version unlocked"
+              else
+                apt-mark unhold linux-aws* linux-base* linux-headers* linux-image* 
               fi
+              if [[ "$(uname -a)" != ${!BEFORE_KERNEL_VERSION} ]] ; then
+                echo "Kernel was upgraded from ${!BEFORE_KERNEL_VERSION} to $(uname -a)"
+              fi
+              echo "Kernel version unlocked"
 
       - name: KeepSSM
         action: ExecuteBash

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -67,7 +67,7 @@ phases:
                set -v
                OS='{{ build.OperatingSystemName.outputs.stdout }}'
 
-               if [ `echo "${!OS}" | grep -E '^(alinux|centos|rhel|rocky)'` ]; then
+               if [ `echo "${!OS}" | grep -E '^(alinux|rhel|rocky)'` ]; then
                  PLATFORM='RHEL'
                elif [ `echo "${!OS}" | grep -E '^ubuntu'` ]; then
                  PLATFORM='DEBIAN'
@@ -83,7 +83,7 @@ phases:
             - |
               set -v
               RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
-              if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|centos|ubuntu|rhel|rocky)'` ]; then
+              if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|ubuntu|rhel|rocky)'` ]; then
                 echo "This component does not support '${!RELEASE}'. Failing build."
                 exit {{ FailExitCode }}
               fi


### PR DESCRIPTION
### Description of changes
* Pin Kernel in parallelcluster.yaml before we install any packages and unpin the kernel so that CX can update it on the AMI which is generated.


### Tests
rhel8 ami 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
