### PR TITLE
[integ-tests-framework] Create capacity reservation before test execution

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -256,7 +256,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS }}]
           instances: ["c5n.18xlarge"]
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
@@ -744,7 +744,7 @@ test-suites:
   trainium:
     test_trainium.py::test_trainium:
       dimensions:
-        - regions: ["use2-az3"]  # do not move, unless instance type support is moved as well
+        - regions: [{{ trn1_32xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS }}]
           schedulers: ["slurm"]
           oss: ["ubuntu2404"]
           instances: ["trn1.32xlarge"]

--- a/tests/integration-tests/configs/openfoam.yaml
+++ b/tests/integration-tests/configs/openfoam.yaml
@@ -2,7 +2,7 @@ test-suites:
   performance_tests:
     test_openfoam.py::test_openfoam:
       dimensions:
-        - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_6_HOURS }}]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2", "ubuntu2404"] # Amazon Linux 2023, Ubuntu22.04, RHEL8 and Rocky8 are not supported
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/osu.yaml
+++ b/tests/integration-tests/configs/osu.yaml
@@ -3,7 +3,7 @@ test-suites:
   performance_tests:
     test_osu.py::test_osu:
       dimensions:
-        - regions: [ "euw1-az1" ]  # do not move, unless capacity reservation is moved as well
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_6_HOURS }}]
           instances: [ "c5n.18xlarge" ]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: [ "slurm" ]

--- a/tests/integration-tests/configs/starccm.yaml
+++ b/tests/integration-tests/configs/starccm.yaml
@@ -2,7 +2,7 @@ test-suites:
   performance_tests:
     test_starccm.py::test_starccm:
       dimensions:
-        - regions: ["euw1-az1"]  # do not move, unless capacity reservation is moved as well
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_6_HOURS }}]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2", "alinux2023", "ubuntu2404", "ubuntu2204", "rhel8", "rhel9", "rocky8", "rocky9"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -580,7 +580,7 @@ def test_datadir(request, datadir):
 
 
 @pytest.fixture()
-def pcluster_config_reader(test_datadir, vpc_stack, request, region, architecture):
+def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, architecture):
     """
     Define a fixture to render pcluster config templates associated to the running test.
 
@@ -602,7 +602,8 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, architectur
             raise FileNotFoundError(f"Cluster config file not found in the expected dir {config_file_path}")
         output_file_path = test_datadir / output_file if output_file else config_file_path
         default_values = _get_default_template_values(vpc_stack, request)
-        kwargs = inject_internal_storage_settings(**kwargs)
+        inject_internal_storage_settings(kwargs)
+        inject_placement_group_settings(vpc_stack, instance, kwargs)
         file_loader = FileSystemLoader(str(test_datadir))
         env = SandboxedEnvironment(loader=file_loader)
         rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
@@ -616,10 +617,14 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, architectur
     return _config_renderer
 
 
-def inject_internal_storage_settings(**kwargs):
+def inject_internal_storage_settings(kwargs):
     if not kwargs.get("shared_headnode_storage_type"):
         kwargs["shared_headnode_storage_type"] = "Efs"
-    return kwargs
+
+
+def inject_placement_group_settings(vpc_stack, instance, kwargs):
+    if vpc_stack.az_override:
+        kwargs["capacity_reservation_framework_placement_group"] = f"{instance}_placement_group_{vpc_stack.az_override}"
 
 
 def inject_additional_image_configs_settings(image_config, request):

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -11,11 +11,11 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 import boto3
 import yaml
-from jinja2 import FileSystemLoader
+from jinja2 import FileSystemLoader, meta
 from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
@@ -207,7 +207,11 @@ def read_config_file(config_file, print_rendered=False, config=None, args=None, 
     """
     logging.info("Parsing config file: %s", config_file)
     rendered_config = _render_config_file(
-        config_file, **kwargs, **_get_os_parameters(config=config, args=args), **_get_instance_type_parameters()
+        config_file,
+        **kwargs,
+        **_get_os_parameters(config=config, args=args),
+        **_get_instance_type_parameters(),
+        **_check_or_create_capacity_reservations(config_file),
     )
     try:
         return yaml.safe_load(rendered_config)
@@ -243,3 +247,158 @@ def _render_config_file(config_file, **kwargs):
     except Exception as e:
         logging.error("Failed when rendering config file %s with error: %s", config_file, e)
         raise
+
+
+def _get_all_jinja_variables(config_file):
+    """Get all jinja variables from config file."""
+    config_dir = os.path.dirname(config_file)
+    config_name = os.path.basename(config_file)
+    file_loader = FileSystemLoader(config_dir)
+    env = SandboxedEnvironment(loader=file_loader)
+    template_source = env.loader.get_source(env, config_name)[0]
+    parsed_content = env.parse(template_source)
+    return meta.find_undeclared_variables(parsed_content)
+
+
+def _check_or_create_capacity_reservations(config_file):
+    """Check/Create capacity reservations for all the instances in the config file."""
+    variables = _get_all_jinja_variables(config_file)
+    az_for_capacity_reservation = {}
+    for var in variables:
+        if "CAPACITY_RESERVATION" in var:
+            logging.info("Checking capacity reservation for %s", var)
+            parts = var.split("_")
+            instance_type = f"{parts[0]}.{parts[1]}"
+            count = int(parts[4])
+            hours = int(parts[6])
+            end_date = datetime.now(timezone.utc) + timedelta(hours=hours)
+            candidate_regions = ["us-east-1", "us-west-2", "eu-west-1"]
+            if _find_and_modify_existing_capacity_reservation(
+                az_for_capacity_reservation, candidate_regions, count, end_date, instance_type, var
+            ):
+                break
+            capacity_reservation_created = False
+            try:
+                for region in candidate_regions:
+                    ec2_client = boto3.client("ec2", region_name=region)
+                    capacity_reservation_created = _create_capacity_reservation(
+                        az_for_capacity_reservation, count, ec2_client, end_date, instance_type, var
+                    )
+                    if capacity_reservation_created:
+                        break
+            except Exception:
+                az_for_capacity_reservation[var] = "use1-az6"
+            if not capacity_reservation_created:
+                # Assign arbitrary zone if no reservations can be made
+                az_for_capacity_reservation[var] = "use1-az6"
+    return az_for_capacity_reservation
+
+
+def _create_capacity_reservation(az_for_capacity_reservation, count, ec2_client, end_date, instance_type, var):
+    capacity_reservation_created = False
+    for availability_zone in ec2_client.describe_availability_zones()["AvailabilityZones"]:
+        if availability_zone["ZoneType"] == "availability-zone":
+            try:
+                zone_id = availability_zone["ZoneId"]
+                placement_group_name = f"{instance_type}_placement_group_{zone_id}"
+                try:
+                    placement_group_arn = ec2_client.describe_placement_groups(GroupNames=[placement_group_name])[
+                        "PlacementGroups"
+                    ][0]["GroupArn"]
+                except Exception:
+                    placement_group_arn = ec2_client.create_placement_group(
+                        GroupName=placement_group_name, Strategy="cluster"
+                    )["PlacementGroup"]["GroupArn"]
+                ec2_client.create_capacity_reservation(
+                    InstanceType=instance_type,
+                    InstancePlatform="Linux/UNIX",
+                    AvailabilityZoneId=zone_id,
+                    InstanceCount=count,
+                    EndDateType="limited",
+                    EndDate=end_date,
+                    Tenancy="default",
+                    PlacementGroupArn=placement_group_arn,
+                )
+                logging.info("Capacity reservation for %s %s created in %s", count, instance_type, zone_id)
+                capacity_reservation_created = True
+                az_for_capacity_reservation[var] = zone_id
+                break
+            except Exception as e:
+                logging.info(
+                    "Capacity reservation for %s %s failed to create in %s",
+                    count,
+                    instance_type,
+                    zone_id,
+                )
+                logging.info(e)
+    return capacity_reservation_created
+
+
+def _find_and_modify_existing_capacity_reservation(  # noqa: C901
+    az_for_capacity_reservation, candidate_regions, count, end_date, instance_type, var
+):
+    """Find existing capacity reservation. Modify the reservation if more capacity or time is needed."""
+    found_existing_capacity_reservation = False
+    for region in candidate_regions:
+        try:
+            ec2_client = boto3.client("ec2", region_name=region)
+            paginator = ec2_client.get_paginator("describe_capacity_reservations")
+            page_iterator = paginator.paginate(
+                Filters=[
+                    {"Name": "instance-type", "Values": [instance_type]},
+                    {"Name": "state", "Values": ["active", "pending"]},
+                ]
+            )
+            for page in page_iterator:
+                for capacity_reservation in page["CapacityReservations"]:
+                    if capacity_reservation["TotalInstanceCount"] >= count and (
+                        capacity_reservation["EndDateType"] == "unlimited" or capacity_reservation["EndDate"] > end_date
+                    ):
+                        az_for_capacity_reservation[var] = capacity_reservation["AvailabilityZoneId"]
+                        found_existing_capacity_reservation = True
+                        logging.info(
+                            "Found existing capacity reservation for %s %s in %s",
+                            count,
+                            instance_type,
+                            capacity_reservation["AvailabilityZoneId"],
+                        )
+                        break
+                    else:
+                        logging.info(
+                            "Found existing capacity reservation for %s %s in %s. "
+                            "Modifing the capacity reservation for more instances/time",
+                            count,
+                            instance_type,
+                            capacity_reservation["AvailabilityZoneId"],
+                        )
+                        try:
+                            if capacity_reservation["EndDateType"] == "unlimited":
+                                new_end_date = None
+                            else:
+                                new_end_date = (
+                                    end_date
+                                    if end_date > capacity_reservation["EndDate"]
+                                    else capacity_reservation["EndDate"]
+                                )
+                            ec2_client.modify_capacity_reservation(
+                                CapacityReservationId=capacity_reservation["CapacityReservationId"],
+                                EndDate=new_end_date,
+                                EndDateType=capacity_reservation["EndDateType"],
+                                InstanceCount=max(count, capacity_reservation["TotalInstanceCount"]),
+                            )
+                            az_for_capacity_reservation[var] = capacity_reservation["AvailabilityZoneId"]
+                            found_existing_capacity_reservation = True
+                            logging.info(
+                                "Modified capacity reservation for %s %s in %s",
+                                count,
+                                instance_type,
+                                capacity_reservation["AvailabilityZoneId"],
+                            )
+                            break
+                        except Exception as e:
+                            logging.info("Failed to modify capacity reservation %s", e)
+            if found_existing_capacity_reservation:
+                break
+        except Exception as e:
+            logging.info("Failed to find existing capacity reservation %s", e)
+    return found_existing_capacity_reservation

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
       Networking:
         PlacementGroup:
           Enabled: {% if instance not in ["p4d.24xlarge", "c6gn.16xlarge"] %}true{% else %}false{% endif %}
-          {% if instance == "c5n.18xlarge" %}Name: c5n_capacity_reservation{% endif %}
+          {% if instance == "c5n.18xlarge" %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
@@ -29,7 +29,7 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
         PlacementGroup:
-          Enabled: false
+          Name: {{ capacity_reservation_framework_placement_group }}
       CustomActions:
         OnNodeConfigured:
           Script: s3://{{ bucket_name }}/neuron-installation.sh


### PR DESCRIPTION
1. This commit checks/creates capacity reservation according to instruction in the test definition YAML file. For example, `c5n_18xlarge_CAPACITY_RESERVATION_1_INSTANCES_2_HOURS` can be specified in the `region` of a test in the test definition file. The parameter will be replaced by the availability zone ID, where c5n.18xlarge 1 instance reservation is made for 2 hours.
2. This commit checks existing capacity reservations before creating new reservations. This commit assumes capacity reservation re-usage for the same instance types. This is mainly driven by the simplicity of implementation and robustness of the logic (e.g. we wouldn't end up with a bunch of reservations if the tests somehow rerun many times). We can improve in the future to disallow re-usage, so that tests with reservations can run in parallel. For now, tests with reservations have to be run in sequential.
3. This commit adjusts some tests to use this new feature.
4. This commit contains minor code improvements.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
