### PR TITLE
[integ-tests-framework] Fix capacity reservation creation logic

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -276,7 +276,7 @@ def _check_or_create_capacity_reservations(config_file):
             if _find_and_modify_existing_capacity_reservation(
                 az_for_capacity_reservation, candidate_regions, count, end_date, instance_type, var
             ):
-                break
+                continue
             capacity_reservation_created = False
             try:
                 for region in candidate_regions:


### PR DESCRIPTION
The logic failed when there are more than one test using capacity reservation jinja variable

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
