### PR TITLE
[integ-tests] Speed up integration tests by reducing GracetimePeriod for login nodes

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 5
 {% endif %}
 HeadNode:
   InstanceType: {{ instance }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 5
 {% endif %}
 HeadNode:
   InstanceType: {{ instance }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_use_login_nodes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_use_login_nodes/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 5
 {% endif %}
 HeadNode:
   InstanceType: {{ instance }}

--- a/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 5
 {% endif %}
 HeadNode:
   SharedStorageType: Efs

--- a/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 3
   {% endif %}
 HeadNode:
   SharedStorageType: {{ shared_storage_type }}

--- a/tests/integration-tests/tests/users/test_default_user_home/test_default_user_local_home/pcluster.config.yaml
+++ b/tests/integration-tests/tests/users/test_default_user_home/test_default_user_local_home/pcluster.config.yaml
@@ -8,7 +8,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 5
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
GracetimePeriod: 60 caused long stack deletion time (1 hour)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
