### PR TITLE
[integ-tests-framework] Fix CloudWatch name retrieval

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -505,7 +505,7 @@ class ClustersFactory:
                     end_time = time.time()
                     request.node.user_properties.append(("cluster_creation_time", end_time - start_time))
                     request.node.user_properties.append(
-                        ("cw_log_group_name", cluster.cfn_resources["CloudWatchLogGroup"])
+                        ("cw_log_group_name", cluster.cfn_resources.get("CloudWatchLogGroup"))
                     )
                     cluster.mark_as_created()
             else:


### PR DESCRIPTION
Some integration tests have CloudWatch log disabled. Using `get()` to suppress exceptions

### References
* This fixes bug from https://github.com/aws/aws-parallelcluster/pull/6798

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
