### PR TITLE
[AD] In 1-click template used to deploy AD infrastructure, enforce the desired domain name in adcli commands to prevent connection errors.

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -471,8 +471,8 @@ Resources:
                 until [ $attempt -ge $max_attempts ]; do
                   attempt=$((attempt+1))
                   echo "Registering user $username (attempt $attempt/$max_attempts) ..."
-                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
-                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain ${DirectoryDomain} --domain-controller="${DnsIp1}" --display-name="$username" "$username" && echo "User registered: $username" && break
+                  echo "$ADMIN_PW" | adcli create-user -v -x -U "${Admin}" --domain ${DirectoryDomain} --domain-controller="${DnsIp2}" --display-name="$username" "$username" && echo "User registered: $username" && break
                   echo "User creation failed, describing directory and controllers for troubleshooting..."
                   aws ds describe-directories --directory-id "${DirectoryId}" --region "${AWS::Region}"
                   aws ds describe-domain-controllers --directory-id "${DirectoryId}" --region "${AWS::Region}"


### PR DESCRIPTION
### Description of changes
In 1-click template used to deploy AD infrastructure, enforce the desired domain name in adcli commands to prevent connection errors.

Without this change it may happen that the adcli request fail with a timeout because they are querying the domain controller for the default EC2 domain. It is still unclear why such failure is intermittent, but this mitigation seems reasonable and suggested by Directory Service team as well.

### Tests
* 1-click template deployed successfully

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
