### PR TITLE
[Bug Fix] Fix ExistingFsxNetworkingValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
 - Ubuntu 20.04 is no longer supported.
 
 **BUG FIXES**
-Fix an issue where Security Group validation failed when a rule contained both IPv4 ranges (IpRanges) and security group references (UserIdGroupPairs).
+- Fix an issue where Security Group validation failed when a rule contained both IPv4 ranges (IpRanges) and security group references (UserIdGroupPairs).
 
 3.13.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.
 
+**BUG FIXES**
+Fix an issue where Security Group validation failed when a rule contained both IPv4 ranges (IpRanges) and security group references (UserIdGroupPairs).
 
 3.13.0
 ------

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -537,6 +537,10 @@ def _populate_allowed_src_or_dst(rule, ip_ranges, allowed_security_groups):
     if rule.get("IpRanges"):
         ip_ranges.extend(rule.get("IpRanges"))
         # Ip Ranges have to be checked later. Return False because the rule allowance is not determined.
+    if rule.get("Ipv4Ranges"):
+        # Currently the describe_security_groups API response syntax contains "IpRanges".
+        # This check is added for future compatibility if API changes to use "Ipv4Ranges"
+        ip_ranges.extend(rule.get("Ipv4Ranges"))
     if rule.get("UserIdGroupPairs"):
         allowed_security_groups.update(
             {user_id_group_pair.get("GroupId") for user_id_group_pair in rule.get("UserIdGroupPairs")}

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -534,15 +534,14 @@ def _populate_allowed_src_or_dst(rule, ip_ranges, allowed_security_groups):
     """
     if rule.get("PrefixListIds"):
         return True  # Always assume prefix list is properly set for code simplicity
-    elif rule.get("IpRanges"):
+    if rule.get("IpRanges"):
         ip_ranges.extend(rule.get("IpRanges"))
-        return False  # Ip Ranges have to be checked later. Return False because the rule allowance is not determined.
-    elif rule.get("UserIdGroupPairs"):
+        # Ip Ranges have to be checked later. Return False because the rule allowance is not determined.
+    if rule.get("UserIdGroupPairs"):
         allowed_security_groups.update(
             {user_id_group_pair.get("GroupId") for user_id_group_pair in rule.get("UserIdGroupPairs")}
         )
         # Security groups have to be checked later. Return False because the rule allowance is not determined.
-        return False
     return False
 
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1306,6 +1306,81 @@ def test_queue_name_validator(name, expected_message):
             r"allows inbound TCP traffic through ports \[111, 2049, 20001, 20002, 20003\]. Missing ports: "
             r"\[2049, 20001, 20002, 20003\]",
         ),
+        (  # working case: The rule has both IpRanges and UserIdGroupPairs. Wrong ip permissions. But SG matches.
+            "LUSTRE",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-12345678"}
+                    ],
+                }
+            ],
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-12345678"}
+                    ],
+                }
+            ],
+            {frozenset({"sg-12345678"}), frozenset({"sg-12345678", "sg-23456789"})},
+            ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
+        (  # not-working case：The rule has both IpRanges and UserIdGroupPairs. Both don't match.
+            "LUSTRE",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
+                    ],
+                }
+            ],
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
+                    ],
+                }
+            ],
+            {frozenset({"sg-12345678"}), frozenset({"sg-12345678", "sg-23456789"})},
+            ["eni-09b9460295ddd4e5f"],
+            r"allows inbound and outbound TCP traffic through ports \[988\]",
+        ),
+        (  # working case：IpRanges covers the subnet, but UserIdGroupPairs do not match
+            "LUSTRE",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.0.0.0/16"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
+                    ],
+                }
+            ],
+            [
+                {
+                    "IpProtocol": "-1",
+                    "IpRanges": [{"CidrIp": "10.0.0.0/16"}],
+                    "UserIdGroupPairs": [
+                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
+                    ],
+                }
+            ],
+            {frozenset({"sg-12345678"})},
+            ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
     ],
 )
 def test_fsx_network_validator(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1313,18 +1313,14 @@ def test_queue_name_validator(name, expected_message):
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-12345678"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}],
                 }
             ],
             [
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-12345678"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}],
                 }
             ],
             {frozenset({"sg-12345678"}), frozenset({"sg-12345678", "sg-23456789"})},
@@ -1338,18 +1334,14 @@ def test_queue_name_validator(name, expected_message):
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-99999999"}],
                 }
             ],
             [
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.1.1.0/25"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-99999999"}],
                 }
             ],
             {frozenset({"sg-12345678"}), frozenset({"sg-12345678", "sg-23456789"})},
@@ -1363,18 +1355,14 @@ def test_queue_name_validator(name, expected_message):
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.0.0.0/16"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-99999999"}],
                 }
             ],
             [
                 {
                     "IpProtocol": "-1",
                     "IpRanges": [{"CidrIp": "10.0.0.0/16"}],
-                    "UserIdGroupPairs": [
-                        {"UserId": "123456789012", "GroupId": "sg-99999999"}
-                    ],
+                    "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-99999999"}],
                 }
             ],
             {frozenset({"sg-12345678"})},


### PR DESCRIPTION
### Description of changes
* The function was using elif, so it IpRanges and UserIdGroupPairsget both exist in a SG rule. It will IpRanges and ignore UserIdGroupPairs. Fixed this bug.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
