### PR TITLE
[perf test] Use the right placement group for capacity reservation

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
@@ -33,7 +33,7 @@ Scheduling:
           - {{ private_subnet_id }}
         PlacementGroup:
           Enabled: true
-          {% if instance == "c5n.18xlarge" %}Name: c5n_capacity_reservation{% endif %}
+          {% if instance == "c5n.18xlarge" %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status

--- a/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
       Networking:
         PlacementGroup:
           Enabled: true
-          Name: c5n_capacity_reservation
+          Name: {{ capacity_reservation_framework_placement_group }}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -39,7 +39,7 @@ Scheduling:
           - {{ private_subnet_id }}
         PlacementGroup:
           Enabled: true
-          {% if instance == "c5n.18xlarge" %}Name: c5n_capacity_reservation{% endif %}
+          {% if instance == "c5n.18xlarge" %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status


### PR DESCRIPTION
Prior to this commit, c5n_capacity_reservation was the placement group name we used to a manual capacity reservation. After https://github.com/aws/aws-parallelcluster/pull/6783, the name should be changed accordingly

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
