### PR TITLE
[integ-tests-framework] Add --pcluster-installer-path and run test_slurm_cli_commands with installer

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -139,6 +139,7 @@ def pytest_addoption(parser):
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")
     parser.addoption("--cw-dashboard-template-url", help="url to a custom Dashboard cfn template")
     parser.addoption("--custom-awsbatchcli-package", help="url to a custom awsbatch cli package")
+    parser.addoption("--pcluster-installer-path", help="Path to ParallelCluster installer")
     parser.addoption("--custom-node-package", help="url to a custom node package")
     parser.addoption("--custom-ami", help="custom AMI to use in the tests")
     parser.addoption("--pre-install", help="url to pre install script")

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -65,6 +65,7 @@ TEST_DEFAULTS = {
     "available_amis_oss_arm": [],
     "createami_custom_node_url": None,
     "custom_awsbatchcli_url": None,
+    "pcluster_installer_path": None,
     "custom_ami": None,
     "pre_install": None,
     "post_install": None,
@@ -266,6 +267,11 @@ def _init_argparser():
         help="URL to a custom awsbatch cli package.",
         default=TEST_DEFAULTS.get("custom_awsbatchcli_url"),
         type=_is_url,
+    )
+    custom_group.add_argument(
+        "--pcluster-installer-path",
+        help="Path to ParallelCluster installer.",
+        default=TEST_DEFAULTS.get("pcluster_installer_path"),
     )
     custom_group.add_argument(
         "--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install")
@@ -650,6 +656,9 @@ def _set_custom_packages_args(args, pytest_args):  # noqa: C901
 
     if args.custom_awsbatchcli_url:
         pytest_args.extend(["--custom-awsbatchcli-package", args.custom_awsbatchcli_url])
+
+    if args.pcluster_installer_path:
+        pytest_args.extend(["--pcluster-installer-path", args.pcluster_installer_path])
 
     if args.pre_install:
         pytest_args.extend(["--pre-install", args.pre_install])

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -12,6 +12,7 @@
 import datetime
 import json
 import logging
+import os as os_lib
 import re
 import tarfile
 import tempfile
@@ -31,6 +32,7 @@ from utils import (
     check_status,
     get_cluster_nodes_instance_ids,
     instance_stream_name,
+    run_command,
 )
 
 from tests.common.assertions import assert_no_errors_in_logs, wait_for_num_instances_in_cluster
@@ -38,10 +40,31 @@ from tests.common.utils import get_installed_parallelcluster_version, retrieve_l
 
 
 @pytest.mark.usefixtures("instance")
+@pytest.mark.parametrize("use_pcluster_installer", [True, False])
 def test_slurm_cli_commands(
-    request, scheduler, region, os, pcluster_config_reader, clusters_factory, s3_bucket_factory
+    request,
+    scheduler,
+    region,
+    os,
+    pcluster_config_reader,
+    clusters_factory,
+    s3_bucket_factory,
+    monkeypatch,
+    use_pcluster_installer,
 ):
     """Test pcluster cli commands are working."""
+    if use_pcluster_installer:
+        installer_path = request.config.getoption("pcluster_installer_path")
+        if installer_path:
+            if "ERROR" in installer_path:
+                pytest.fail(f"Installer path is not valid: {installer_path}")
+            monkeypatch.setenv("PATH", installer_path + ":" + os_lib.environ["PATH"])
+            logging.info("Using installer: %s", run_command("which pcluster"))
+        else:
+            pytest.skip("Skipping test with installer because installer_path is not provided.")
+    else:
+        logging.info("Using pcluster python package: %s", run_command("which pcluster"))
+
     # Use long scale down idle time so we know nodes are terminated by pcluster stop
     cluster_config = pcluster_config_reader(scaledown_idletime=60)
 


### PR DESCRIPTION
cherry picked from https://github.com/aws/aws-parallelcluster/pull/6790

### Tests
Without this change installer tests fail in release-3.13 branch due to missing test runner option

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
