### PR TITLE
Change awsbatch test to region eu-west-3 so that it doesnt use c4 instances

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -410,7 +410,7 @@ test-suites:
           schedulers: ["awsbatch"]
     test_awsbatch.py::test_awsbatch_defaults:
       dimensions:
-        - regions: ["ap-northeast-1"]
+        - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ BATCH_OS_X86_0 }}]
           schedulers: ["awsbatch"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -185,7 +185,7 @@ test-suites:
           schedulers: ["awsbatch"]
     test_awsbatch.py::test_awsbatch_defaults:
       dimensions:
-        - regions: ["ap-northeast-1"]
+        - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]


### PR DESCRIPTION
### Description of changes
* Change awsbatch test to region eu-west-3 so that it doesnt use c4 instances
* c4 is not available in eu-west-3
* Stops ec2 retirements ticket

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
