### PR TITLE
[Integ-Test] Increase the ComputeNodes launching time timeout to 6 minutes

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -181,7 +181,7 @@ def assert_scaling_worked(
             )
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(6))
 def wait_for_num_instances_in_cluster(cluster_name, region, desired):
     return assert_num_instances_in_cluster(cluster_name, region, desired)
 

--- a/tests/integration-tests/tests/common/hit_common.py
+++ b/tests/integration-tests/tests/common/hit_common.py
@@ -85,7 +85,7 @@ def assert_compute_node_reasons(scheduler_commands, compute_nodes, expected_reas
         assert_that(node_info).contains(f"Reason={expected_reason}")
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(6))
 def wait_for_num_nodes_in_scheduler(scheduler_commands, desired, filter_by_partition=None):
     assert_num_nodes_in_scheduler(scheduler_commands, desired, filter_by_partition)
 


### PR DESCRIPTION
### Description of changes
* Increase the ComputeNodes launching time timeout from 5 minutes to 6 minutes. Because Ubuntu24 OS instance launching time is longer than other OSs.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
