### PR TITLE
Upgrade libfabric version to 2.1.0

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
@@ -8,7 +8,7 @@ set -ex
 FABTESTS_DIR="$1"
 
 FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"
-FABTESTS_VERSION="1.21.0"
+FABTESTS_VERSION="2.1.0"
 FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
 CUDA_DIR="/usr/local/cuda"


### PR DESCRIPTION
### Description of changes
* Upgrade libfabric version to 2.1.0
* Since we upgraded to efa 1.41.0, the corresponding libfabric version is 2.1.0

### Tests
* Running test_efa integ test

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
