### PR TITLE
Checking for owner of default s3 bucket

### DIFF
--- a/cli/src/pcluster/aws/s3.py
+++ b/cli/src/pcluster/aws/s3.py
@@ -39,14 +39,17 @@ class S3Client(Boto3Client):
                 error_code=client_error.response["Error"]["Code"],
             )
 
-    def head_bucket(self, bucket_name):
+    def head_bucket(self, bucket_name, expected_bucket_owner=None):
         """Retrieve metadata for a bucket without returning the object itself."""
         try:
-            return self._client.head_bucket(Bucket=bucket_name)
+            if expected_bucket_owner:
+                return self._client.head_bucket(Bucket=bucket_name, ExpectedBucketOwner=expected_bucket_owner)
+            else:
+                return self._client.head_bucket(Bucket=bucket_name)
         except ClientError as client_error:
             raise AWSClientError(
                 function_name="head_bucket",
-                message=_process_s3_bucket_error(client_error, bucket_name),
+                message=_process_s3_bucket_error(client_error, bucket_name, expected_bucket_owner),
                 error_code=client_error.response["Error"]["Code"],
             )
 
@@ -148,6 +151,11 @@ def _process_s3_bucket_error(client_error, bucket_name, expected_bucket_owner=No
     elif expected_bucket_owner and error_code == "403" and error_message == "Forbidden" and object_name:
         message = (
             f"Failed when accessing object '{object_name}' from bucket '{bucket_name}'. This can be due to "
+            f"bucket owner not matching the expected one '{expected_bucket_owner}'"
+        )
+    elif expected_bucket_owner and error_code == "403" and error_message == "Forbidden":
+        message = (
+            f"Failed in accessing bucket '{bucket_name}'. This can be due to "
             f"bucket owner not matching the expected one '{expected_bucket_owner}'"
         )
     elif object_name and error_code == "404" and error_message == "Not Found":

--- a/cli/src/pcluster/models/s3_bucket.py
+++ b/cli/src/pcluster/models/s3_bucket.py
@@ -133,9 +133,12 @@ class S3Bucket:
         """
         return hashlib.sha256((account_id + region).encode()).hexdigest()[0:16]
 
-    def check_bucket_exists(self):
+    def check_bucket_exists(self, default_bucket=None):
         """Check bucket existence by bucket name."""
-        AWSApi.instance().s3.head_bucket(bucket_name=self.name)
+        if default_bucket:
+            AWSApi.instance().s3.head_bucket(bucket_name=self.name, expected_bucket_owner=self.account_id)
+        else:
+            AWSApi.instance().s3.head_bucket(bucket_name=self.name)
 
     def create_bucket(self):
         """Create a new S3 bucket."""
@@ -457,7 +460,7 @@ class S3BucketFactory:
     def _check_default_bucket(cls, service_name: str, artifact_directory: str, stack_name: str):
         bucket = S3Bucket(service_name=service_name, artifact_directory=artifact_directory, stack_name=stack_name)
         try:
-            bucket.check_bucket_exists()
+            bucket.check_bucket_exists(default_bucket=True)
         except AWSClientError as e:
             cls._create_bucket(bucket, e)
 

--- a/cli/tests/pcluster/cli/test_commands.py
+++ b/cli/tests/pcluster/cli/test_commands.py
@@ -62,6 +62,7 @@ def _mock_cluster(
         "mock_generated_bucket_name",
         "expected_bucket_name",
         "provided_bucket_name",
+        "default_bucket",
     ),
     [
         (
@@ -74,6 +75,7 @@ def _mock_cluster(
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             None,
+            True,
         ),
         (
             "awsbatch",
@@ -85,6 +87,7 @@ def _mock_cluster(
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             None,
+            True,
         ),
         (
             "slurm",
@@ -96,6 +99,7 @@ def _mock_cluster(
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
             None,
+            True,
         ),
         (
             "slurm",
@@ -107,6 +111,7 @@ def _mock_cluster(
             None,
             "user_provided_bucket",
             "user_provided_bucket",
+            False,
         ),
     ],
 )
@@ -121,6 +126,7 @@ def test_setup_bucket_with_resources_success(
     mock_generated_bucket_name,
     expected_bucket_name,
     provided_bucket_name,
+    default_bucket,
 ):
     """Verify that create_bucket_with_batch_resources behaves as expected."""
     # mock calls for bucket property in cluster object
@@ -154,7 +160,10 @@ def test_setup_bucket_with_resources_success(
     for dir in expected_dirs:
         cluster.bucket.upload_resources(dir)
 
-    check_bucket_mock.assert_called_with()
+    if default_bucket:
+        check_bucket_mock.assert_called_with(default_bucket=default_bucket)
+    else:
+        check_bucket_mock.assert_called_with()
 
     # assert upload has been called
     upload_config_mock.assert_called_with(expected_config, "fake_config_name")
@@ -339,4 +348,7 @@ def test_setup_bucket_with_resources_upload_failure(
     with pytest.raises(ClusterActionError, match=upload_instance_types_data_action_error):
         cluster._upload_instance_types_data()
 
-    check_bucket_mock.assert_called_with()
+    if provided_bucket_name:
+        check_bucket_mock.assert_called_with(default_bucket=True)
+    else:
+        check_bucket_mock.assert_called_with()


### PR DESCRIPTION
### Description of changes
* Checking for owner of default s3 bucket

### Tests 
* Hardcoded `self._client.head_bucket(Bucket=bucket_name, ExpectedBucketOwner=expected_bucket_owner)` to use a different account and see Failure `{
  "message": "Unable to initialize s3 bucket. Failed in accessing bucket 'parallelcluster-<hash>-v1-do-not-delete'. This can be due to bucket owner not matching the expected one 'ACCOUNT_ID'"
}` when I try to create a cluster for the 1st Time.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
