### PR TITLE
Do not install curl on Amazon Linux 2023 to avoid conflicts

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -234,7 +234,11 @@ phases:
                   fi
                 fi
                 yum -y update krb5-libs
-                yum -y groupinstall development && sudo yum -y install curl wget jq
+                yum -y groupinstall development && sudo yum -y install wget jq
+                if [[ ${!OS} != alinux2023 ]]; then
+                  # Do not install curl on al2023 since curl-minimal-8.5.0-1.amzn2023* is already shipped and conflicts.
+                  yum -y install curl
+                fi
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 if [[ "${CfnParamUpdateOsAndReboot}" == "false" ]]; then
                   # disable apt-daily.timer to avoid dpkg lock


### PR DESCRIPTION
The same code change has existed in cookbook https://github.com/aws/aws-parallelcluster-cookbook/blob/develop/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_alinux2023.rb#L36

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
