### PR TITLE
[integ-tests] Remove crash file check in DCV

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -75,10 +75,6 @@ def _test_dcv_configuration(
     _check_shared_dir(head_node_remote_command_executor, shared_dir)
     _check_shared_dir(login_node_remote_command_executor, shared_dir)
 
-    # Ensure no system programs crashed
-    _check_no_crashes(head_node_remote_command_executor, test_datadir)
-    _check_no_crashes(login_node_remote_command_executor, test_datadir)
-
     # Check that logs are stored in CloudWatch as expected
     FeatureSpecificCloudWatchLoggingTestRunner.run_tests_for_feature(
         cluster, scheduler, os, "dcv_enabled", region, shared_dir


### PR DESCRIPTION
The crash file could contain crashes from other components, therefore, generate unnecessary sporadic test failures

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
