### PR TITLE
[Doc] Update changelog for 3.13.1: remove bug fix on shutdown for ubuntu2404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix a bug in the installation of ARM Performance Library that was causing the build image fail in isolated environments.
-- Fix a bug that was causing compute node self‑termination to hang on Ubuntu 24.04 nodes.
 
 3.13.0
 ------


### PR DESCRIPTION
### Description of changes
Remove the changelog entry for 3.13.1 about bugfixing ubuntu shutdown.
The bugfix was reverted because it does not solve the issue.

Related PRs:
https://github.com/aws/aws-parallelcluster-node/pull/664
https://github.com/aws/aws-parallelcluster-cookbook/pull/2964

### Tests
* schedulers.test_slurm.test_error_handling failed due to compute node being stuck in self termination.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
