### PR TITLE
Install kernel-devel using the same version of kernel on Amazon Linux

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -279,7 +279,7 @@ phases:
                     yum install -y ./${!PACKAGE}.rpm
                   fi
                 else
-                  yum -y install kernel-devel
+                  yum -y install kernel-devel-$(uname -r)
                 fi
 
               elif [[ ${!PLATFORM} == DEBIAN ]]; then


### PR DESCRIPTION
This logic has been applied to RHEL/Rocky. This commit makes Amazon Linux apply the same logic.

Debian systems don't need this change, because they handle version properly

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
