### PR TITLE
[integ-test] Improve StarCCM test to handle numbers in scientific notation

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.results.sh
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/starccm.results.sh
@@ -4,5 +4,5 @@ JOBID="$1"
 OUTPUT=$(scontrol show jobs ${JOBID} | grep StdOut | cut -d '=' -f 2)
 start_time=$(tail -n 250 ${OUTPUT} | grep " 501 " | awk '{print $NF}')
 end_time=$(tail -n 250 ${OUTPUT} | grep " 600 " | awk '{print $NF}')
-elapsed_time=$(echo "$end_time - $start_time" | bc -l)
+elapsed_time=$(awk "BEGIN {print $end_time - $start_time}")
 echo $elapsed_time


### PR DESCRIPTION
`bc -l` doesn't handle scientific notation like 5.1759e+02


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
