### PR TITLE
[integ-test-framework] Make OS rotation deterministic

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -71,8 +71,8 @@ def _propagate_os_jinja_variables(prefix, result, today_number, supported_x86_os
         supported_arm_oses = supported_x86_oses
     # The OS list is the intersection of supported OSes and available AMIs.
     # If the intersection is empty, fallback to supported OS to prevent the framework from failing of div by 0
-    available_amis_oss_x86 = list(set(supported_x86_oses) & set(available_amis_oss_x86)) or supported_x86_oses
-    available_amis_oss_arm = list(set(supported_arm_oses) & set(available_amis_oss_arm)) or supported_arm_oses
+    available_amis_oss_x86 = sorted(list(set(supported_x86_oses) & set(available_amis_oss_x86))) or supported_x86_oses
+    available_amis_oss_arm = sorted(list(set(supported_arm_oses) & set(available_amis_oss_arm))) or supported_arm_oses
     for index in range(len(supported_x86_oses)):
         result[f"{prefix}OS_X86_{index}"] = available_amis_oss_x86[(today_number + index) % len(available_amis_oss_x86)]
         result[f"{prefix}OS_ARM_{index}"] = available_amis_oss_arm[(today_number + index) % len(available_amis_oss_arm)]


### PR DESCRIPTION
This issue was discovered because there were some tests running with the same OS for a few days

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
