### PR TITLE
Install kernel headers before kernel devel

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -279,6 +279,7 @@ phases:
                     yum install -y ./${!PACKAGE}.rpm
                   fi
                 else
+                  yum -y install kernel-headers-$(uname -r)
                   yum -y install kernel-devel-$(uname -r)
                 fi
 


### PR DESCRIPTION
kernel-headers is a dependency of kernel-devel. Sometimes, when installing kernel-devel, a different version of kernel-headers is pulled in, which is wrong. This commit ensures both kernel-headers and kernel-devel have consistent kernel version of the running cluster

### Tests
Manually run the commands
```
yum -y install kernel-headers-$(uname -r)
yum -y install kernel-devel-$(uname -r)
```

Prior to this commit
```
yum list installed | grep kernel-headers
kernel-headers.x86_64                  6.12.25-32.101.amzn2023           @amazonlinux 
```

After this commit
```
yum list installed | grep kernel-headers
kernel-headers.x86_64                  6.1.134-152.225.amzn2023           @amazonlinux 
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
