### PR TITLE
Remove pinning of kernel-abi-stablelists

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -196,12 +196,6 @@ phases:
                 # listing all the packages because wildcard does not work as expected
                 yum versionlock kernel kernel-core kernel-modules
 
-                if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
-                  yum versionlock kernel-abi-whitelists
-                else
-                  yum versionlock kernel-abi-stablelists
-                fi
-
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                   yum versionlock rocky-release rocky-repos
                 elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
@@ -347,12 +341,6 @@ phases:
               # Remove kernel version lock
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum versionlock delete kernel kernel-core kernel-modules
-
-                if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
-                  yum versionlock delete kernel-abi-whitelists
-                else
-                  yum versionlock delete kernel-abi-stablelists
-                fi
 
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                   yum versionlock delete rocky-release rocky-repos

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -200,12 +200,6 @@ phases:
                   # listing all the packages because wildcard does not work as expected
                   yum versionlock kernel kernel-core kernel-modules
 
-                  if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
-                    yum versionlock kernel-abi-whitelists
-                  else
-                    yum versionlock kernel-abi-stablelists
-                  fi
-
                   if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                     yum versionlock rocky-release rocky-repos
                   elif [[ ${!OS} == "rhel8" ]] || [[ ${!OS} == "rhel9" ]] ; then
@@ -300,12 +294,6 @@ phases:
               # Remove kernel version lock
               if [[ ${!DISABLE_KERNEL_UPDATE} == true ]] && [[ ${!PLATFORM} == RHEL ]]; then
                 yum versionlock delete kernel kernel-core kernel-modules
-
-                if [[ ${!OS} == "alinux2" ]] || [[ ${!OS} == "alinux2023" ]] ; then
-                  yum versionlock delete kernel-abi-whitelists
-                else
-                  yum versionlock delete kernel-abi-stablelists
-                fi
 
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                   yum versionlock delete rocky-release


### PR DESCRIPTION
According to https://access.redhat.com/solutions/444773

With Red Hat Enterprise Linux 7 and 8, the stablelist is valid for the particular major release. This means that once a symbol has been introduced into kABI for a particular major release, it will not be removed, nor will its meaning be changed during that kernel major release complete life cycle.

With Red Hat Enterprise Linux 9, each minor release will have a unique stablelist that is valid throughout the minor release lifecycle. For more information on this, please refer to the following knowledgebase article;

We are pinning  the minor release for the duration of the build. So the stablelist for the minor version will be installed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
