### PR TITLE
Remove krb5-libs pinning

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -225,7 +225,6 @@ phases:
                     yum clean all
                   fi
                 fi
-                yum -y update krb5-libs
                 yum -y groupinstall development && sudo yum -y install wget jq
                 if [[ ${!OS} != alinux2023 ]]; then
                   # Do not install curl on al2023 since curl-minimal-8.5.0-1.amzn2023* is already shipped and conflicts.


### PR DESCRIPTION
### Description of changes
* Remove krb5-libs pinning
* Not longer need to pin because because we are using a rhel9.5 base image so we are no longer impacted by the CVE.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
