### PR TITLE
Adjust error message to show that the capacity reservation does not exist

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -500,6 +500,8 @@ class Cluster:
         except ConfigValidationError as e:
             raise e
         except Exception as e:
+            if "Invalid type for parameter InstanceTypes[0], value: None, type: <class 'NoneType'>" in e.__str__():
+                raise ConfigValidationError(f"Invalid cluster configuration: Capacity reservation does not exist.")
             raise ConfigValidationError(f"Invalid cluster configuration: {e}")
 
         return config, validation_failures


### PR DESCRIPTION
### Description of changes
* Adjust error message to show that the capacity reservation does not exist.
* Orginal error can not be thrown [here](https://github.com/aws/aws-parallelcluster/blob/b1093071e72abddc9bf86838f736300678fb80e2/cli/src/pcluster/config/cluster_config.py#L2448-L2455) because then it causes a failure during cluster update.
* This change only catches the error during cluster creation validation

### Tests
* Tested that the appropriate error message occurs during cluster creating when a capacity reservation is specified but not the instance type
* Tested that the appropriate error message occurs during cluster creation when neither a capacity reservation or instance type is specified.
* Ran full set of integration tests.

### References
* Related to this change: https://github.com/aws/aws-parallelcluster/pull/6883

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
