### PR TITLE
Enable vault repository for Rocky when mirrors don't work

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -206,21 +206,14 @@ phases:
                 fi
 
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
-                  if [[ ${!OS} == "rocky8" ]] ; then
-                    REPOSITORY="BaseOS"
-                  else
-                    REPOSITORY="AppStream"
-                  fi
                   for PACKAGE in ${!PACKAGE_LIST}
                   do
-                    # try to install kernel source for a specific release version
                     yum install -y ${!PACKAGE}
                     if [ $? -ne 0 ]; then
-                      yum install -y wget
-                      # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
-                      # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
-                      wget https://dl.rockylinux.org/vault/rocky/${!RELEASE_VERSION}/${!REPOSITORY}/$(uname -m)/os/Packages/k/${!PACKAGE}.rpm
-                      yum install -y ./${!PACKAGE}.rpm
+                      # Enable vault repository
+                      sed -i 's|^#baseurl=http://dl.rockylinux.org/$contentdir|baseurl=http://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/*.repo
+                      sed -i 's|^#baseurl=https://dl.rockylinux.org/$contentdir|baseurl=https://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/*.repo
+                      yum install -y ${!PACKAGE}
                     fi
                   done
                 else


### PR DESCRIPTION
This commit improves the Rocky9 vault repository usage. Instead of using `wget` from the URL of the vault, this commit enables vault repository, so all subsequent `yum` commands will be able to use the vault. This reduces code duplication and improves robustness.

Example of repo configuration in Rocky:
```
cat /etc/yum.repos.d/Rocky-AppStream.repo
# Rocky-AppStream.repo
#
# The mirrorlist system uses the connecting IP address of the client and the
# update status of each mirror to pick current mirrors that are geographically
# close to the client.  You should use this for Rocky updates unless you are
# manually picking other mirrors.
#
# If the mirrorlist does not work for you, you can try the commented out
# baseurl line instead.

[appstream]
name=Rocky Linux $releasever - AppStream
mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/$basearch/os/
gpgcheck=1
enabled=1
countme=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
