### PR TITLE
[integ-test-framework] Avoid test hanging when data.counter is not decreased

### DIFF
--- a/tests/integration-tests/framework/fixture_utils.py
+++ b/tests/integration-tests/framework/fixture_utils.py
@@ -126,7 +126,7 @@ class SharedFixture:
                 return
 
         timeout = time.time() + 4 * 60 * 60  # 4 hours from now
-        while data.counter > 1:
+        while min(data.counter, len(data.currently_using_processes)) > 1:
             logging.info(
                 "Waiting for all processes to release shared fixture %s, currently in use by %d processes (%s)",
                 self.name,


### PR DESCRIPTION
data.counter is not decreased sometimes when the test fail drastically. And the test will hang with the following message:
```
fixture_utils - Waiting for all processes to release shared fixture vpc_stacks_shared, currently in use by 2 processes ({'gw23: 33792'})
```

This commit uses the min of data.counter and data.currently_using_processes to solve the issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
