### PR TITLE
Add instance type property to avoid capacity reservation from being checked during an update

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2385,9 +2385,8 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
 
     def __init__(self, instance_type=None, **kwargs):
         super().__init__(**kwargs)
-        _instance_type = instance_type if instance_type else self._instance_type_from_capacity_reservation()
-        self.instance_type = Resource.init_param(_instance_type)
         self.__instance_type_info = None
+        self._instance_type = Resource.init_param(instance_type)
 
     def is_flexible(self):
         """Return False because the ComputeResource can not contain multiple instance types."""
@@ -2397,6 +2396,14 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
     def instance_types(self) -> List[str]:
         """List of instance types under this compute resource."""
         return [self.instance_type]
+
+    @property
+    # Do not invoke in update path
+    def instance_type(self):
+        """Instance type of this compute resource."""
+        if not self._instance_type:
+            self._instance_type = Resource.init_param(self._instance_type_from_capacity_reservation())
+        return self._instance_type
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2446,13 +2453,9 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
             self.capacity_reservation_target.capacity_reservation_id if self.capacity_reservation_target else None
         )
         if capacity_reservation_id:
-            try:
-                capacity_reservations = AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation_id])
-                if capacity_reservations:
-                    instance_type = capacity_reservations[0].instance_type()
-            except AWSClientError:
-                # In case the CR has expired and we are unable to retrieve the instance type
-                instance_type = None
+            capacity_reservations = AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation_id])
+            if capacity_reservations:
+                instance_type = capacity_reservations[0].instance_type()
         return instance_type
 
 


### PR DESCRIPTION
### Description of changes
* Add instance type property to avoid capacity reservation from being checked during an update
* Prevent `_instance_type_from_capacity_reservation` from being run during a cluster update

### Tests
* Ran capacity reservation integ test
* Tested cluster create and update

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
