### PR TITLE
[Test] Push performance test mpi variation to DynamoDB table

### DIFF
--- a/tests/integration-tests/tests/performance_tests/common.py
+++ b/tests/integration-tests/tests/performance_tests/common.py
@@ -255,7 +255,7 @@ def _log_output_performance_difference(node, performance_degradation, observed_v
     )
 
 
-def push_result_to_dynamodb(name, result, instance, os):
+def push_result_to_dynamodb(name, result, instance, os, mpi_variation=None):
     reporting_region = METADATA_DEFAULT_REGION
     logging.info(f"Metadata reporting region {reporting_region}")
     # Create the metadata table in case it doesn't exist
@@ -274,6 +274,7 @@ def push_result_to_dynamodb(name, result, instance, os):
             "timestamp": int(time.time()),
             "result": str(result),
             "pcluster_version": f"v{get_installed_parallelcluster_version()}",
+            "mpi_variation": str(mpi_variation),
         }
 
         # Put item in the table

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -239,7 +239,7 @@ def _check_osu_benchmarks_results(test_datadir, output_dir, os, instance, mpi_ve
     metric_namespace = "ParallelCluster/test_efa"
     evaluation_output = ""
     result = re.findall(r"(\d+)\s+(\d+)\.", output)
-    push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os)
+    push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os, mpi_version)
     for packet_size, value in result:
         with open(
             str(test_datadir / "osu_benchmarks" / "results" / os / instance / mpi_version / benchmark_name),


### PR DESCRIPTION
### Description
With this change we are differentiating Open MPI and Intel MPI performance results recorded in DynamoDB. This is useful because performance result is consistently different between the two variations, so we want to track them separately.

### Test
The change will be tested, once merged, by our daily integration tests.
We think this is acceptable ion this case because the change is not risky, is on test code only.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
