### PR TITLE
[Develop] Move SharedStorageType Enum from cluster_config.py to common.py

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -28,11 +28,12 @@ from pcluster.config.common import (
     BaseDevSettings,
     BaseTag,
     CapacityType,
-    DefaultUserHomeType, SharedStorageType,
+    DefaultUserHomeType,
 )
 from pcluster.config.common import Imds as TopLevelImds
 from pcluster.config.common import (
     Resource,
+    SharedStorageType,
 )
 from pcluster.constants import (
     CIDR_ALL_IPS,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -28,7 +28,7 @@ from pcluster.config.common import (
     BaseDevSettings,
     BaseTag,
     CapacityType,
-    DefaultUserHomeType,
+    DefaultUserHomeType, SharedStorageType,
 )
 from pcluster.config.common import Imds as TopLevelImds
 from pcluster.config.common import (
@@ -289,15 +289,6 @@ class LocalStorage(Resource):
         super().__init__(**kwargs)
         self.root_volume = root_volume or RootVolume(implied=True)
         self.ephemeral_volume = ephemeral_volume
-
-
-class SharedStorageType(Enum):
-    """Define storage types to be used as shared storage."""
-
-    EBS = "ebs"
-    RAID = "raid"
-    EFS = "efs"
-    FSX = "fsx"
 
 
 class SharedEbs(Ebs):

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -434,3 +434,12 @@ class ExtraChefAttributes:
         attribute_json = {"cluster": self._cluster_attributes}
         attribute_json.update(self._extra_attributes)
         return json.dumps(attribute_json, sort_keys=True)
+
+
+class SharedStorageType(Enum):
+    """Define storage types to be used as shared storage."""
+
+    EBS = "ebs"
+    RAID = "raid"
+    EFS = "efs"
+    FSX = "fsx"

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -22,7 +22,8 @@ from aws_cdk import aws_logs as logs
 from aws_cdk.aws_ec2 import CfnSecurityGroup
 from aws_cdk.core import CfnOutput, CfnResource, Construct, Fn, Stack
 
-from pcluster.config.cluster_config import AwsBatchClusterConfig, CapacityType, SharedStorageType
+from pcluster.config.cluster_config import AwsBatchClusterConfig, CapacityType
+from pcluster.config.common import SharedStorageType
 from pcluster.constants import AWSBATCH_CLI_REQUIREMENTS, CW_LOG_GROUP_NAME_PREFIX, IAM_ROLE_PATH
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.templates.cdk_builder_utils import (

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -29,11 +29,11 @@ from pcluster.config.cluster_config import (
     BaseQueue,
     HeadNode,
     LoginNodesPool,
-    SharedStorageType,
     SlurmClusterConfig,
     SlurmComputeResource,
     SlurmQueue,
 )
+from pcluster.config.common import SharedStorageType
 from pcluster.constants import (
     COOKBOOK_PACKAGES_VERSIONS,
     CW_LOGS_RETENTION_DAYS_DEFAULT,

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -53,10 +53,9 @@ from pcluster.config.cluster_config import (
     SharedEbs,
     SharedEfs,
     SharedFsxLustre,
-    SharedStorageType,
     SlurmClusterConfig,
 )
-from pcluster.config.common import DefaultUserHomeType
+from pcluster.config.common import DefaultUserHomeType, SharedStorageType
 from pcluster.constants import (
     ALL_PORTS_RANGE,
     CW_ALARM_DATAPOINTS_TO_ALARM_DEFAULT,

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -17,7 +17,8 @@ from aws_cdk import aws_logs as logs
 from aws_cdk.aws_cloudwatch import IAlarm
 from aws_cdk.core import Construct, Duration, Stack
 
-from pcluster.config.cluster_config import BaseClusterConfig, ExistingFileCache, SharedFsxLustre, SharedStorageType
+from pcluster.config.cluster_config import BaseClusterConfig, ExistingFileCache, SharedFsxLustre
+from pcluster.config.common import SharedStorageType
 from pcluster.constants import Feature
 from pcluster.utils import is_feature_supported
 

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -8,8 +8,8 @@ from aws_cdk import aws_logs as logs
 from aws_cdk.core import CfnTag, Construct, Fn, NestedStack, Stack, Tags
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.config.cluster_config import LoginNodesPool, SharedStorageType, SlurmClusterConfig
-from pcluster.config.common import DefaultUserHomeType
+from pcluster.config.cluster_config import LoginNodesPool, SlurmClusterConfig
+from pcluster.config.common import DefaultUserHomeType, SharedStorageType
 from pcluster.constants import (
     DEFAULT_EPHEMERAL_DIR,
     NODE_BOOTSTRAP_TIMEOUT,

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -7,8 +7,8 @@ from aws_cdk.core import CfnTag, Fn, NestedStack, Stack
 from constructs import Construct
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.config.cluster_config import SharedStorageType, SlurmClusterConfig, SlurmComputeResource, SlurmQueue
-from pcluster.config.common import DefaultUserHomeType
+from pcluster.config.cluster_config import SlurmClusterConfig, SlurmComputeResource, SlurmQueue
+from pcluster.config.common import DefaultUserHomeType, SharedStorageType
 from pcluster.constants import (
     DEFAULT_EPHEMERAL_DIR,
     NODE_BOOTSTRAP_TIMEOUT,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -676,7 +676,7 @@ class ExistingFsxNetworkingValidator(Validator):
                         self._add_failure(
                             f"The current security group settings on file storage '{file_storage_id}' does not"
                             " satisfy mounting requirement. The file storage must be associated to a security group"
-                            f" that allows {direction } {protocol.upper()} traffic through ports {ports}. "
+                            f" that allows {direction} {protocol.upper()} traffic through ports {ports}. "
                             f"Missing ports: {missing_ports}",
                             FailureLevel.ERROR,
                         )

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 from assertpy import assert_that
 
-from pcluster.config.cluster_config import SharedStorageType
+from pcluster.config.common import SharedStorageType
 from pcluster.constants import Feature
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder


### PR DESCRIPTION
### Description of changes
* Move SharedStorageType enum to common.py to prevent circular import of SharedStorageType in cluster_validators.py

### Tests

### References

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
