### PR TITLE
Fix `build-image` failure on Rocky 9, occurring when the parent image does not ship the latest kernel version on the latest Rocky minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix an issue where Security Group validation failed when a rule contained both IPv4 ranges (IpRanges) and security group references (UserIdGroupPairs).
+- Fix `build-image` failure on Rocky 9, occurring when the parent image does not ship the latest kernel version on the latest Rocky minor version.
 
 3.13.2
 ------

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -87,7 +87,8 @@ phases:
                 }
                 
                 PACKAGE_LIST="kernel-headers-$(uname -r) kernel-devel-$(uname -r)"
-                [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" kernel-devel-matched-$(uname -r)"
+                Repository="BaseOS"
+                [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" kernel-devel-matched-$(uname -r)" && Repository="AppStream"
                 
                 if [[ $OS =~ rocky ]]; then
                   for PACKAGE in ${!PACKAGE_LIST}
@@ -97,6 +98,14 @@ phases:
                       sed -i 's|^#baseurl=http://dl.rockylinux.org/$contentdir|baseurl=http://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/*.repo
                       sed -i 's|^#baseurl=https://dl.rockylinux.org/$contentdir|baseurl=https://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/*.repo
                       yum install -y ${!PACKAGE}
+                    } || {
+                      # Download package from vault. Sometimes simply enabling vault is not enough if repodata index is not in vault
+                      # Using the hard-coded links to download rpm is the last safety net.
+                      # Although the following code only deal with individual packages, and doesn't have the global impact of enabling vault.
+                      # We will figure out a global safety net when needed (build failure happens again)
+                      yum install -y wget
+                      wget https://dl.rockylinux.org/vault/rocky/${!VERSION_ID}/${!Repository}/$(uname -m)/os/Packages/k/${!PACKAGE}.rpm
+                      yum install -y ./${!PACKAGE}.rpm
                     }
                   done
                 else


### PR DESCRIPTION
### Description of changes

Add back the safety net to download package from vault. The overall package installation order is:
1. yum install -y ${!PACKAGE} (from the current mirrorlist of OS repo)
2. If (1) fails, enable vault repo as baseurl and retry the installation
3. If (2) fails, download package rpm from vault

The previous commit https://github.com/aws/aws-parallelcluster/pull/6889/commits/6a820d74aa6076b23e490ec69d54b3e75a9ac712 did fix image build on older Rocky minor versions and removed the third safety net. The third safety net could be useful as described in the comment in the code

### Tests
* Build image on non-latest Rocky 9.6 has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
