### PR TITLE
[Develop] Remove the build-image default cleanup role trust policy condition

### DIFF
--- a/cli/src/pcluster/imagebuilder_utils.py
+++ b/cli/src/pcluster/imagebuilder_utils.py
@@ -192,11 +192,6 @@ def ensure_default_build_image_stack_cleanup_role(
                 "Effect": "Allow",
                 "Principal": {"Service": "lambda.amazonaws.com"},
                 "Action": "sts:AssumeRole",
-                "Condition": {
-                    "ArnLike": {
-                        "aws:SourceArn": f"arn:{partition}:lambda:*:{account_id}:function:ParallelClusterImage-*"
-                    }
-                },
             }
         ],
     }


### PR DESCRIPTION
### Description of changes
* Remove the build-image default cleanup role trust policy condition, as with it, the DeleteStackFunction lambda failed to create within a VPC.
* What we discovered:
  * When the execution role’s trust policy restricts `sts:AssumeRole` with an `aws:SourceArn` condition, creating a VPC-enabled Lambda function fails with: The function's execution role doesn't have permission to perform this operation.
  * Creating the same function without VPC config succeeds. 
  * Removing the trust policy condition allows creation in the VPC. After creating once without the condition, we can re-add the condition and subsequent creations in the same VPC succeed consistently.
  * This pattern suggests there might be an initialization phase for Lambda in new VPCs that doesn't properly propagate the source ARN context. 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
