### PR TITLE
Revert "[Test] Execute test_build_image on both x86 and arm instance types, both for develop and released branch"

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -149,10 +149,6 @@ test-suites:
           instances: ["g4dn.2xlarge"]
           schedulers: [ "slurm" ]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
-        - regions: [ "use1-az6" ]
-          instances: ["g5g.2xlarge"]
-          schedulers: [ "slurm" ]
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
         - regions: ["cnn1-az1"]
           instances: ["g4dn.2xlarge"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -82,11 +82,11 @@ test-suites:
     test_createami.py::test_build_image:
       dimensions:
         - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 + common.INSTANCES_DEFAULT_ARM }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
           oss: ["ubuntu2404", "alinux2", "alinux2023"]
         - regions: ["us-east-1"] # This region has to have first stage AMIs.
-          instances: {{ common.INSTANCES_DEFAULT_X86 + common.INSTANCES_DEFAULT_ARM}}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]
           oss: ["rocky8", "rhel8", "rhel9", "rocky9", "ubuntu2204"]
     test_createami.py::test_build_image_custom_components:


### PR DESCRIPTION
### Description of changes
This reverts commit fe6a186e9957ba7e85f83c1774225d83326c93a4.

This is a temporary revert to attempt to fix intermittent build image failure with "InvalidInstanceId". We will observe the test for a few days. If the revert fixes the issue, it means it is an API throttling issue, and we will raise the API throttling limit and reintroduce the commit

Reverting the commit is the easiest way to test because this suspected throttling only happens when the whole suite of develop.yaml is run. i.e. the intermittent "InvalidInstanceId" failure doesn't happen when running only the build image tests

### Tests
* Tests will be done after the PR is merged

### References
* This PR reverts https://github.com/aws/aws-parallelcluster/pull/6924

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
