### PR TITLE
[integ-tests] Fix NCCL test by using the right LD Library Path

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -10,7 +10,7 @@ NCCL_BENCHMARKS_VERSION='2.13.8'
 mpirun \
 -x FI_PROVIDER="efa" \
 -x FI_EFA_USE_DEVICE_RDMA=1 \
--x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:/shared/openmpi/ofi-plugin/lib/:$LD_LIBRARY_PATH \
+-x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:$(cat /etc/ld.so.conf.d/100_ofinccl.conf):$LD_LIBRARY_PATH \
 -x RDMAV_FORK_SAFE=1 \
 -x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \


### PR DESCRIPTION
### Description of changes
* This commit is necessary due to a recent upgrade of EFA
Without this commit, the NCCL test with `-x NCCL_DEBUG=WARNING` shows the following message
```
NCCL INFO NET/Plugin : dlerror=libnccl-net.so: cannot open shared object file: No such file or directory No plugin found (libnccl-net.so), using internal implementation
```

### Tests
* NCCL test has been able to use EFA on AL2023

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
