### PR TITLE
Trigger build image failure when cookbook execution fails, increase verbosity of build image logs

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -19,7 +19,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               . /etc/os-release
               RELEASE="${!ID}${!VERSION_ID:+.${!VERSION_ID}}"
               case "$RELEASE" in
@@ -40,7 +40,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               # Get OS info
               . /etc/os-release
               # Check input base AMI OS and get OS information, the output should be like amzn.2 | ubuntu.20.04 | ubuntu.22.04 | rhel.8.7 | rocky.8.8
@@ -75,7 +75,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               . /opt/parallelcluster/system_info
 
               # Pin kernel versions and install packages
@@ -132,7 +132,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               . /opt/parallelcluster/system_info
               
               # Disable Nouveau driver
@@ -174,7 +174,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               . /opt/parallelcluster/system_info
               
               # Update CA certificates and install Cinc
@@ -220,7 +220,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -ex
               . /opt/parallelcluster/system_info
               echo "Calling chef-client with /etc/parallelcluster/image_dna.json"
               cat /etc/parallelcluster/image_dna.json
@@ -233,7 +233,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               . /opt/parallelcluster/system_info
               
               # Remove kernel version lock

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -16,7 +16,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               FILE=/etc/os-release
               if [ -e ${!FILE} ]; then
                 . ${!FILE}
@@ -32,7 +32,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
 
               if [ `echo "${!RELEASE}" | grep -w '^amzn\.2'` ]; then
@@ -64,7 +64,7 @@ phases:
         inputs:
           commands:
             - |
-               set -v
+               set -x
                OS='{{ build.OperatingSystemName.outputs.stdout }}'
 
                if [ `echo "${!OS}" | grep -E '^(alinux|rhel|rocky)'` ]; then
@@ -81,7 +81,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
               if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|ubuntu|rhel|rocky)'` ]; then
                 echo "This component does not support '${!RELEASE}'. Failing build."
@@ -102,7 +102,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
 
               if [[ ${!PLATFORM} == DEBIAN ]]; then
@@ -120,7 +120,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
 
@@ -136,7 +136,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               echo ${AWS::Region}
 
       - name: CreatingJsonFile
@@ -152,7 +152,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               DISABLE_KERNEL_UPDATE=$(cat /etc/parallelcluster/image_dna.json | jq -r '.cluster.disable_kernel_update')
               echo "${!DISABLE_KERNEL_UPDATE}"
 
@@ -161,7 +161,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
@@ -186,7 +186,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
@@ -222,7 +222,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
@@ -244,7 +244,7 @@ phases:
         inputs:
           commands:
             - |
-              set -v
+              set -x
               if [[ -f /tmp/imagebuilder_service/ssm_installed ]]; then
                 echo "Keeping SSM agent installed"
                 rm -rf /tmp/imagebuilder_service/ssm_installed


### PR DESCRIPTION
### Description of changes
1. Use `set -ex` for `InstallPClusterPackages` step. This fixes a bug from https://github.com/aws/aws-parallelcluster/pull/6910, which caused build image to succeed even if cookbook execution failed. The reason that the behavior had been right before the previous PR was that the `cinc-client` command was the last command of a step. And the step correctly detects the error of the last command.

2. Replace `set -v` with `set -x` for more verbose output.

`set -ex` cannot be safely applied to all steps because bash commands can exit non-zero with various reasons. For example, installation of a package exits non-zero if the package already exists. In this case we don't want to fail the step. Therefore, to keep minimal behavioral change comparing to previous versions, only use `set -ex` for `InstallPClusterPackages` step

### Tests
* test_build_image_wrong_pcluster_version has been passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
