### PR TITLE
Add build-image support for kernel 6.12 of AL2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Add support for p6e-gb200 instances via capacity blocks.
 - Echo chef-client log when a node fails to bootstrap. This helps with investigating bootstrap failures in cases CloudWatch logs are not available.
+- Add `build-image` support for kernel 6.12 of Amazon Linux 2023. The official ParallelCluster Amazon Linux 2023 AMIs use kernel 6.12.
 
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -60,6 +60,12 @@ phases:
               CINC_URL="https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/archives/cinc/cinc-install-1.4.0.sh"
               [ -n "${CfnParamCincInstaller}" ] && CINC_URL="${CfnParamCincInstaller}"
               
+              if [[ $OS == alinux2023 && $(uname -r) == 6.12.* ]]; then
+                KERNEL_PACKAGES_PREFIX="kernel6.12"
+              else
+                KERNEL_PACKAGES_PREFIX="kernel"
+              fi
+              
               # Output all variables to persistent location
               mkdir -p /opt/parallelcluster
               echo "OS=$OS" > /opt/parallelcluster/system_info
@@ -69,6 +75,7 @@ phases:
               echo "COOKBOOK_URL=$COOKBOOK_URL" >> /opt/parallelcluster/system_info
               echo "CINC_URL=$CINC_URL" >> /opt/parallelcluster/system_info
               echo "COOKBOOK_NAME=$COOKBOOK_NAME" >> /opt/parallelcluster/system_info
+              echo "KERNEL_PACKAGES_PREFIX=$KERNEL_PACKAGES_PREFIX" >> /opt/parallelcluster/system_info
 
       - name: PinVersion
         action: ExecuteBash
@@ -86,9 +93,9 @@ phases:
                   yum clean all
                 }
                 
-                PACKAGE_LIST="kernel-headers-$(uname -r) kernel-devel-$(uname -r)"
+                PACKAGE_LIST="${!KERNEL_PACKAGES_PREFIX}-headers-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-devel-$(uname -r)"
                 Repository="BaseOS"
-                [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" kernel-devel-matched-$(uname -r)" && Repository="AppStream"
+                [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" ${!KERNEL_PACKAGES_PREFIX}-devel-matched-$(uname -r)" && Repository="AppStream"
                 
                 if [[ $OS =~ rocky ]]; then
                   for PACKAGE in ${!PACKAGE_LIST}
@@ -117,7 +124,7 @@ phases:
 
                 yum install -y yum-plugin-versionlock
                 # listing all the packages because wildcard does not work as expected
-                yum versionlock kernel kernel-core kernel-modules
+                yum versionlock ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
                 [[ $OS =~ rocky ]] && yum versionlock rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock redhat-release
               else
@@ -238,7 +245,7 @@ phases:
               
               # Remove kernel version lock
               if [[ ${!PLATFORM} == RHEL ]]; then
-                yum versionlock delete kernel kernel-core kernel-modules
+                yum versionlock delete ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
                 [[ $OS =~ rocky ]] && yum versionlock delete rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock delete redhat-release
               else

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -165,12 +165,17 @@ phases:
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+              if [[ $OS == alinux2023 && $(uname -r) == 6.12.* ]]; then
+                KERNEL_PACKAGES_PREFIX="kernel6.12"
+              else
+                KERNEL_PACKAGES_PREFIX="kernel"
+              fi
 
               if [[ ${!DISABLE_KERNEL_UPDATE} == true ]]; then
                 if [[ ${!PLATFORM} == RHEL ]]; then
                   yum install -y yum-plugin-versionlock
                   # listing all the packages because wildcard does not work as expected
-                  yum versionlock kernel kernel-core kernel-modules
+                  yum versionlock ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
 
                   if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                     yum versionlock rocky-release rocky-repos
@@ -226,10 +231,15 @@ phases:
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+              if [[ $OS == alinux2023 && $(uname -r) == 6.12.* ]]; then
+                KERNEL_PACKAGES_PREFIX="kernel6.12"
+              else
+                KERNEL_PACKAGES_PREFIX="kernel"
+              fi
 
               # Remove kernel version lock
               if [[ ${!DISABLE_KERNEL_UPDATE} == true ]] && [[ ${!PLATFORM} == RHEL ]]; then
-                yum versionlock delete kernel kernel-core kernel-modules
+                yum versionlock delete ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
 
                 if [[ ${!OS} == "rocky8" ]] || [[ ${!OS} == "rocky9" ]] ; then
                   yum versionlock delete rocky-release


### PR DESCRIPTION
### Description of changes
The kernel packages name patterns follow the official AL2023 doc https://docs.aws.amazon.com/linux/al2023/ug/kernel-update.html#al2023-kernel-faq

Although both 6.1 and 6.12 are actively supported, supporting p6e-GB200 requires kernel 6.12.

### Tests
* First stage build has been passed

### References
* Cookbook PR https://github.com/aws/aws-parallelcluster-cookbook/pull/3016

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
