### PR TITLE
[integ-test-framework] Remove check on the number of os, scheduler, instances, regions when existing cluster is specified

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -845,15 +845,6 @@ def _get_config_arguments(args):
 
 
 def _check_args(args):
-    # If --cluster is set only one os, scheduler, instance type and region can be provided
-    if args.cluster:
-        if len(args.oss) > 1 or len(args.schedulers) > 1 or len(args.instances) > 1 or len(args.regions) > 1:
-            logger.error(
-                "when cluster option is specified, you can have a single value for oss, regions, instances "
-                "and schedulers and you need to make sure they match the cluster specific ones"
-            )
-            exit(1)
-
     if not args.tests_config:
         assert_that(args.regions).described_as("--regions cannot be empty").is_not_empty()
         assert_that(args.instances).described_as("--instances cannot be empty").is_not_empty()


### PR DESCRIPTION
### Description of changes
When test_config YAML is specified, the meaning of the standalone arguments (--oss, --schedulers, --regions, --instances) are to filter the test, rather than running the test https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/test_runner.py#L814. For example, we use `--regions` in daily run to distinguish tests in develop.yaml across China, commercial, GovCloud

The check is wrong when using test_config YAML. Because we have been running test with test_config YAML, instead of fixing the check, this commit removes the check

This fixes usage of `--cluster` on our testing infrastructure

### Tests
* integration tests have passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
