### PR TITLE
[integ-test] Skip NCCL test on Rocky and RHEL

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -62,7 +62,9 @@ def test_efa(
 
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
 
-    if instance in ["p4d.24xlarge", "p5.48xlarge"]:
+    if instance in ["p4d.24xlarge", "p5.48xlarge"] and not os.startswith(("rocky", "rhel")):
+        # Doc of supported instance types and operating systems:
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands, instance)
 
     with soft_assertions():


### PR DESCRIPTION
### Description of changes
Skip NCCL test on Rocky and RHEL because OFI plugin doesn't support Rocky and RHEL

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html:
> Only Amazon Linux 2023, Amazon Linux 2, Ubuntu 24.04, and Ubuntu 22.04 base AMIs are supported.

https://github.com/aws/aws-ofi-nccl:
> The plugin is regularly tested on the following operating systems:
    Amazon Linux 2 and Amazon Linux 2023
    Ubuntu 22.04 LTS and 24.04 LTS.

### Tests
* test_efa has passed on RHEL9


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
