### PR TITLE
[IntegTest][GB200] Fix GB200 Integ Test and Improve the IMEX Setup Prolog Script

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -279,8 +279,8 @@ test-suites:
   ultraserver:
     test_gb200.py::test_gb200:
       dimensions:
-        - regions: [ "us-east-1" ]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        - regions: [ "use1-az1" ] # do not move, unless instance type support is moved as well
+          instances: [ "g5g.xlarge" ]
           oss: [ "alinux2023" ]
           schedulers: [ "slurm" ]
   health_checks:

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -72,14 +72,13 @@ def assert_no_errors_in_logs(cluster: Cluster, queue: str, compute_resource: str
             assert_regex_in_file(cluster, compute_node_ip, log, r"(warn|error|fail)", negate=True)
 
 
-def assert_imex_status(  # noqa: C901
+def assert_imex_status(
     rce: RemoteCommandExecutor,
     job_id: str,
     ips: list,
     service_status: str = "UP",
     node_status: str = "READY",
     connection_status: str = "CONNECTED",
-    retry_on_failure: bool = True,
 ):
     """
     Assert that the output returned by the nvidia-imex-ctl command represent a healthy status for IMEX.
@@ -153,90 +152,86 @@ def assert_imex_status(  # noqa: C901
     }
     """
 
-    def _check_imex_status():
-        slurm = SlurmCommands(rce)
-        unique_ips = set(ips)
+    slurm = SlurmCommands(rce)
+    unique_ips = set(ips)
 
-        imex_statuses = []
-        for reporting_node_ip in unique_ips:
-            # When fake ips are used we cannot retrieve the node name from the ip.
-            # We retrieve the nodename from the list of nodes executing the job to check IMEX status.
-            if reporting_node_ip in FAKE_IPS:
-                reporting_node_name = slurm.get_batch_host_for_job(job_id)
-            else:
-                reporting_node_name = slurm.get_nodename_from_ip(reporting_node_ip)
-            logging.info(
-                f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}"
+    imex_statuses = []
+    for reporting_node_ip in unique_ips:
+        # When fake ips are used we cannot retrieve the node name from the ip.
+        # We retrieve the nodename from the list of nodes executing the job to check IMEX status.
+        if reporting_node_ip in FAKE_IPS:
+            reporting_node_name = slurm.get_batch_host_for_job(job_id)
+        else:
+            reporting_node_name = slurm.get_nodename_from_ip(reporting_node_ip)
+        logging.info(f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}")
+        result_file_name = f"result_{job_id}_{reporting_node_name}"
+        result_stdout = rce.run_remote_command(f"cat {result_file_name}.out").stdout
+        result_stderr = rce.run_remote_command(f"cat {result_file_name}.err").stdout
+        if service_status == "UP":
+            assert_that(result_stderr).is_empty()
+        logging.info(
+            f"IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}: {result_stdout}"
+        )
+        imex_statuses.append(json.loads(result_stdout))
+    latest_imex_status = max(imex_statuses, key=lambda i: datetime.strptime(i["timestamp"], "%m/%d/%Y %H:%M:%S.%f"))
+    logging.info(f"Checking IMEX connections according to the latest status: {latest_imex_status}")
+    assert_that(latest_imex_status["status"]).is_equal_to(service_status)
+    for ip_source in unique_ips:
+        node_item = next(filter(lambda i: i["host"] == ip_source, latest_imex_status["nodes"].values()), None)
+        assert_that(node_item).is_not_none()
+        assert_that(node_item["status"]).is_equal_to(node_status)
+        for ip_destination in unique_ips:
+            connection_item = next(
+                filter(lambda i: i["host"] == ip_destination, node_item["connections"].values()), None
             )
-            result_file_name = f"result_{job_id}_{reporting_node_name}"
-            result_stdout = rce.run_remote_command(f"cat {result_file_name}.out").stdout
-            result_stderr = rce.run_remote_command(f"cat {result_file_name}.err").stdout
-            if service_status == "UP":
-                assert_that(result_stderr).is_empty()
-            logging.info(
-                f"IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}: {result_stdout}"
-            )
-            imex_statuses.append(json.loads(result_stdout))
-        latest_imex_status = max(imex_statuses, key=lambda i: datetime.strptime(i["timestamp"], "%m/%d/%Y %H:%M:%S.%f"))
-        logging.info(f"Checking IMEX connections according to the latest status: {latest_imex_status}")
-        assert_that(latest_imex_status["status"]).is_equal_to(service_status)
-        for ip_source in unique_ips:
-            node_item = next(filter(lambda i: i["host"] == ip_source, latest_imex_status["nodes"].values()), None)
-            assert_that(node_item).is_not_none()
-            assert_that(node_item["status"]).is_equal_to(node_status)
-            for ip_destination in unique_ips:
-                connection_item = next(
-                    filter(lambda i: i["host"] == ip_destination, node_item["connections"].values()), None
-                )
-                assert_that(connection_item).is_not_none()
-                assert_that(connection_item["status"]).is_equal_to(connection_status)
-
-    if not retry_on_failure:
-        _check_imex_status()
-        return
-
-    # Retry mechanism: check every 30 seconds for up to 700 seconds
-    timeout_seconds = 700
-    retry_interval = 30
-    start_time = time.time()
-
-    while True:
-        try:
-            _check_imex_status()
-            logging.info("IMEX status check succeeded")
-            return
-        except Exception as e:
-            elapsed_time = time.time() - start_time
-            if elapsed_time >= timeout_seconds:
-                logging.error(f"IMEX status check failed after {elapsed_time:.1f} seconds: {e}")
-                raise
-
-            logging.warning(
-                f"IMEX status check failed after {elapsed_time:.1f}s: {e}. Retrying in {retry_interval}s..."
-            )
-            time.sleep(retry_interval)
+            assert_that(connection_item).is_not_none()
+            assert_that(connection_item["status"]).is_equal_to(connection_status)
 
 
 def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):
-    rce = RemoteCommandExecutor(cluster)
+    def _check_imex_healthy():
+        rce = RemoteCommandExecutor(cluster)
 
-    launch_template_id = cluster.get_compute_nodes_launch_template_logical_id(queue, compute_resource)
-    logging.info(
-        f"Launch template for nodes in queue {queue} and compute resource {compute_resource}: " f"{launch_template_id}"
-    )
+        launch_template_id = cluster.get_compute_nodes_launch_template_logical_id(queue, compute_resource)
+        logging.info(
+            f"Launch template for nodes in queue {queue} and compute resource {compute_resource}: "
+            f"{launch_template_id}"
+        )
 
-    job_id = submit_job_imex_status(rce, queue, max_nodes)
+        job_id = submit_job_imex_status(rce, queue, max_nodes)
 
-    logging.info(
-        f"Retrieving private IP addresses for {max_nodes} compute nodes "
-        f"in queue {queue} and compute resource {compute_resource}"
-    )
-    ips = cluster.get_compute_nodes_private_ip(queue, compute_resource, ["running"], max_nodes)
-    logging.info(f"Private IP addresses for nodes in queue {queue} and compute resource {compute_resource}: " f"{ips}")
+        logging.info(
+            f"Retrieving private IP addresses for {max_nodes} compute nodes "
+            f"in queue {queue} and compute resource {compute_resource}"
+        )
+        ips = cluster.get_compute_nodes_private_ip(queue, compute_resource, ["running"], max_nodes)
+        logging.info(
+            f"Private IP addresses for nodes in queue {queue} and compute resource {compute_resource}: " f"{ips}"
+        )
 
-    assert_imex_nodes_config_is_correct(rce, launch_template_id, ips)
-    assert_imex_status(rce, job_id, ips, service_status="UP", node_status="READY", connection_status="CONNECTED")
-    assert_no_errors_in_logs(cluster, queue, compute_resource)
+        assert_imex_nodes_config_is_correct(rce, launch_template_id, ips)
+        assert_imex_status(rce, job_id, ips, service_status="UP", node_status="READY", connection_status="CONNECTED")
+        assert_no_errors_in_logs(cluster, queue, compute_resource)
+
+    # Retry mechanism: retry every 5 minutes, maximum 2 retries (3 total attempts)
+    max_retries = 2
+    retry_interval = 300  # 5 minutes
+
+    for attempt in range(max_retries + 1):
+        try:
+            _check_imex_healthy()
+            logging.info("IMEX health check succeeded")
+            return
+        except Exception as e:
+            if attempt == max_retries:
+                logging.error(f"IMEX health check failed after {attempt + 1} attempts: {e}")
+                raise
+
+            logging.warning(
+                f"IMEX health check failed on attempt {attempt + 1}/{max_retries + 1}: {e}. "
+                f"Retrying in {retry_interval}s..."
+            )
+            time.sleep(retry_interval)
 
 
 def assert_imex_not_configured(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):
@@ -498,9 +493,6 @@ def test_gb200(
     cluster.update(str(final_cluster_config), force_update=True)
     cluster.start()
     wait_for_computefleet_changed(cluster, "RUNNING")
-    wait_for_instances_in_compute_resource(
-        cluster, queue_with_imex, compute_resource_with_imex, ["running"], max_queue_size_updated
-    )
 
     # Verify topology plugin is completely disabled after removing force_configuration
     assert_topology_plugin_completely_disabled(cluster)

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -332,9 +332,9 @@ def assert_topology_plugin_completely_disabled(cluster: Cluster):
 
     # Check TopologyPlugin is not configured or empty
     logging.info("Checking TopologyPlugin is completely disabled")
-    result = rce.run_remote_command("scontrol show config | grep TopologyPlugin || echo 'TopologyPlugin not found'")
-    # TopologyPlugin should either not be present or be empty
-    assert_that(result.stdout.strip()).is_equal_to("TopologyPlugin not found")
+    result = rce.run_remote_command("scontrol show config | grep TopologyPlugin")
+    assert_that(result.stdout.strip()).contains("TopologyPlugin")
+    assert_that(result.stdout.strip()).contains("= topology/default")
 
     # Check topology.conf does not exist
     topology_conf_path = "/opt/slurm/etc/topology.conf"

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import json
 import logging
+import time
 from datetime import datetime
 
 import boto3
@@ -78,6 +79,7 @@ def assert_imex_status(
     service_status: str = "UP",
     node_status: str = "READY",
     connection_status: str = "CONNECTED",
+    retry_on_failure: bool = True,
 ):
     """
     Assert that the output returned by the nvidia-imex-ctl command represent a healthy status for IMEX.
@@ -150,40 +152,59 @@ def assert_imex_status(
      "status": "DOWN"
     }
     """
-    slurm = SlurmCommands(rce)
-    unique_ips = set(ips)
+    def _check_imex_status():
+        slurm = SlurmCommands(rce)
+        unique_ips = set(ips)
 
-    imex_statuses = []
-    for reporting_node_ip in unique_ips:
-        # When fake ips are used we cannot retrieve the node name from the ip.
-        # We retrieve the nodename from the list of nodes executing the job to check IMEX status.
-        if reporting_node_ip in FAKE_IPS:
-            reporting_node_name = slurm.get_batch_host_for_job(job_id)
-        else:
-            reporting_node_name = slurm.get_nodename_from_ip(reporting_node_ip)
-        logging.info(f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}")
-        result_file_name = f"result_{job_id}_{reporting_node_name}"
-        result_stdout = rce.run_remote_command(f"cat {result_file_name}.out").stdout
-        result_stderr = rce.run_remote_command(f"cat {result_file_name}.err").stdout
-        if service_status == "UP":
-            assert_that(result_stderr).is_empty()
-        logging.info(
-            f"IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}: {result_stdout}"
-        )
-        imex_statuses.append(json.loads(result_stdout))
-    latest_imex_status = max(imex_statuses, key=lambda i: datetime.strptime(i["timestamp"], "%m/%d/%Y %H:%M:%S.%f"))
-    logging.info(f"Checking IMEX connections according to the latest status: {latest_imex_status}")
-    assert_that(latest_imex_status["status"]).is_equal_to(service_status)
-    for ip_source in unique_ips:
-        node_item = next(filter(lambda i: i["host"] == ip_source, latest_imex_status["nodes"].values()), None)
-        assert_that(node_item).is_not_none()
-        assert_that(node_item["status"]).is_equal_to(node_status)
-        for ip_destination in unique_ips:
-            connection_item = next(
-                filter(lambda i: i["host"] == ip_destination, node_item["connections"].values()), None
+        imex_statuses = []
+        for reporting_node_ip in unique_ips:
+            # When fake ips are used we cannot retrieve the node name from the ip.
+            # We retrieve the nodename from the list of nodes executing the job to check IMEX status.
+            if reporting_node_ip in FAKE_IPS:
+                reporting_node_name = slurm.get_batch_host_for_job(job_id)
+            else:
+                reporting_node_name = slurm.get_nodename_from_ip(reporting_node_ip)
+            logging.info(f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}")
+            result_file_name = f"result_{job_id}_{reporting_node_name}"
+            result_stdout = rce.run_remote_command(f"cat {result_file_name}.out").stdout
+            result_stderr = rce.run_remote_command(f"cat {result_file_name}.err").stdout
+            if service_status == "UP":
+                assert_that(result_stderr).is_empty()
+            logging.info(
+                f"IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}: {result_stdout}"
             )
-            assert_that(connection_item).is_not_none()
-            assert_that(connection_item["status"]).is_equal_to(connection_status)
+            imex_statuses.append(json.loads(result_stdout))
+        latest_imex_status = max(imex_statuses, key=lambda i: datetime.strptime(i["timestamp"], "%m/%d/%Y %H:%M:%S.%f"))
+        logging.info(f"Checking IMEX connections according to the latest status: {latest_imex_status}")
+        assert_that(latest_imex_status["status"]).is_equal_to(service_status)
+        for ip_source in unique_ips:
+            node_item = next(filter(lambda i: i["host"] == ip_source, latest_imex_status["nodes"].values()), None)
+            assert_that(node_item).is_not_none()
+            assert_that(node_item["status"]).is_equal_to(node_status)
+            for ip_destination in unique_ips:
+                connection_item = next(
+                    filter(lambda i: i["host"] == ip_destination, node_item["connections"].values()), None
+                )
+                assert_that(connection_item).is_not_none()
+                assert_that(connection_item["status"]).is_equal_to(connection_status)
+
+    # First attempt
+    try:
+        _check_imex_status()
+        return
+    except Exception as e:
+        if not retry_on_failure:
+            raise
+        logging.warning(f"IMEX status check failed on first attempt: {e}. Retrying once after 3 minutes...")
+    
+    # Retry once after delay to handle transitory DEGRADED to UP state
+    time.sleep(180)
+    try:
+        _check_imex_status()
+        logging.info("IMEX status check succeeded on retry")
+    except Exception as e:
+        logging.error(f"IMEX status check failed on retry: {e}")
+        raise
 
 
 def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -467,6 +467,9 @@ def test_gb200(
     cluster.update(str(final_cluster_config), force_update=True)
     cluster.start()
     wait_for_computefleet_changed(cluster, "RUNNING")
+    wait_for_instances_in_compute_resource(
+        cluster, queue_with_imex, compute_resource_with_imex, ["running"], max_queue_size_updated
+    )
 
     # Verify topology plugin is completely disabled after removing force_configuration
     assert_topology_plugin_completely_disabled(cluster)

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -72,7 +72,7 @@ def assert_no_errors_in_logs(cluster: Cluster, queue: str, compute_resource: str
             assert_regex_in_file(cluster, compute_node_ip, log, r"(warn|error|fail)", negate=True)
 
 
-def assert_imex_status(
+def assert_imex_status(  # noqa: C901
     rce: RemoteCommandExecutor,
     job_id: str,
     ips: list,
@@ -152,6 +152,7 @@ def assert_imex_status(
      "status": "DOWN"
     }
     """
+
     def _check_imex_status():
         slurm = SlurmCommands(rce)
         unique_ips = set(ips)
@@ -164,7 +165,9 @@ def assert_imex_status(
                 reporting_node_name = slurm.get_batch_host_for_job(job_id)
             else:
                 reporting_node_name = slurm.get_nodename_from_ip(reporting_node_ip)
-            logging.info(f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}")
+            logging.info(
+                f"Retrieving IMEX status reported by node {reporting_node_ip} with hostname {reporting_node_name}"
+            )
             result_file_name = f"result_{job_id}_{reporting_node_name}"
             result_stdout = rce.run_remote_command(f"cat {result_file_name}.out").stdout
             result_stderr = rce.run_remote_command(f"cat {result_file_name}.err").stdout
@@ -191,12 +194,12 @@ def assert_imex_status(
     if not retry_on_failure:
         _check_imex_status()
         return
-    
+
     # Retry mechanism: check every 30 seconds for up to 700 seconds
     timeout_seconds = 700
     retry_interval = 30
     start_time = time.time()
-    
+
     while True:
         try:
             _check_imex_status()
@@ -207,8 +210,10 @@ def assert_imex_status(
             if elapsed_time >= timeout_seconds:
                 logging.error(f"IMEX status check failed after {elapsed_time:.1f} seconds: {e}")
                 raise
-            
-            logging.warning(f"IMEX status check failed after {elapsed_time:.1f}s: {e}. Retrying in {retry_interval}s...")
+
+            logging.warning(
+                f"IMEX status check failed after {elapsed_time:.1f}s: {e}. Retrying in {retry_interval}s..."
+            )
             time.sleep(retry_interval)
 
 

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -330,7 +330,7 @@ def assert_topology_plugin_completely_disabled(cluster: Cluster):
     """Verify that TopologyPlugin is completely disabled and no topology configuration exists."""
     rce = RemoteCommandExecutor(cluster)
 
-    # Check TopologyPlugin is not configured or empty
+    # Check TopologyPlugin is not configured -> default
     logging.info("Checking TopologyPlugin is completely disabled")
     result = rce.run_remote_command("scontrol show config | grep TopologyPlugin")
     assert_that(result.stdout.strip()).contains("TopologyPlugin")

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -188,23 +188,28 @@ def assert_imex_status(
                 assert_that(connection_item).is_not_none()
                 assert_that(connection_item["status"]).is_equal_to(connection_status)
 
-    # First attempt
-    try:
+    if not retry_on_failure:
         _check_imex_status()
         return
-    except Exception as e:
-        if not retry_on_failure:
-            raise
-        logging.warning(f"IMEX status check failed on first attempt: {e}. Retrying once after 3 minutes...")
     
-    # Retry once after delay to handle transitory DEGRADED to UP state
-    time.sleep(180)
-    try:
-        _check_imex_status()
-        logging.info("IMEX status check succeeded on retry")
-    except Exception as e:
-        logging.error(f"IMEX status check failed on retry: {e}")
-        raise
+    # Retry mechanism: check every 30 seconds for up to 700 seconds
+    timeout_seconds = 700
+    retry_interval = 30
+    start_time = time.time()
+    
+    while True:
+        try:
+            _check_imex_status()
+            logging.info("IMEX status check succeeded")
+            return
+        except Exception as e:
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout_seconds:
+                logging.error(f"IMEX status check failed after {elapsed_time:.1f} seconds: {e}")
+                raise
+            
+            logging.warning(f"IMEX status check failed after {elapsed_time:.1f}s: {e}. Retrying in {retry_interval}s...")
+            time.sleep(retry_interval)
 
 
 def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
@@ -91,14 +91,40 @@ function write_file() {
     return 1 # Not Updated
   fi
 
-  touch "${_lock_file}"
-
+  # Try to acquire lock with timeout
   (
-      flock -x -w ${_lock_timeout_seconds} 200 || error_exit "Cannot acquire lock to write to ${_file}"
+      if ! flock -x -w ${_lock_timeout_seconds} 200; then
+        # If timeout, assume deadlock and try to recover
+        info "Lock timeout after ${_lock_timeout_seconds}s, attempting deadlock recovery"
+        exit 1
+      fi
       echo "${_content}" > "${_file}"
   ) 200>"${_lock_file}"
-
-  return 0 # Updated
+  
+  local _lock_result=$?
+  
+  if [[ ${_lock_result} -eq 0 ]]; then
+    return 0 # Updated successfully
+  fi
+  
+  # Deadlock recovery: remove stale lock file and retry once
+  error "Potential deadlock detected for ${_file}, attempting recovery"
+  rm -f "${_lock_file}"
+  sleep 1  # Brief pause to avoid race conditions
+  
+  (
+      if ! flock -x -w 10 200; then
+        exit 1
+      fi
+      echo "${_content}" > "${_file}"
+  ) 200>"${_lock_file}"
+  
+  if [[ $? -eq 0 ]]; then
+    info "Lock acquired after deadlock recovery for ${_file}"
+    return 0 # Updated
+  fi
+  
+  error_exit "Failed to acquire lock for ${_file} even after deadlock recovery"
 }
 
 function reload_imex() {

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
@@ -9,7 +9,7 @@ SCONTROL_CMD="/opt/slurm/bin/scontrol"
 IMEX_START_TIMEOUT=60
 IMEX_STOP_TIMEOUT=15
 WAIT_TIME_TO_STABILIZE=30
-#TODO In production, specify p6e-gb200, only. We added m6g only for testing purposes.
+#TODO In production, specify p6e-gb200, only. We added g5g only for testing purposes.
 ALLOWED_INSTANCE_TYPES="^(p6e-gb200|g5g)"
 IMEX_SERVICE="nvidia-imex"
 
@@ -100,25 +100,25 @@ function write_file() {
       fi
       echo "${_content}" > "${_file}"
   ) 200>"${_lock_file}"
-  
+
   local _lock_result=$?
-  
+
   if [[ ${_lock_result} -eq 0 ]]; then
     return 0 # Updated successfully
   fi
-  
+
   # Deadlock recovery: remove stale lock file and retry once
   error "Potential deadlock detected for ${_file}, attempting recovery"
   rm -f "${_lock_file}"
   sleep 1  # Brief pause to avoid race conditions
-  
+
   (
       if ! flock -x -w 10 200; then
         exit 1
       fi
       echo "${_content}" > "${_file}"
   ) 200>"${_lock_file}"
-  
+
   if [[ $? -eq 0 ]]; then
     info "Lock acquired after deadlock recovery for ${_file}"
     return 0 # Updated

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
@@ -10,7 +10,7 @@ IMEX_START_TIMEOUT=60
 IMEX_STOP_TIMEOUT=15
 WAIT_TIME_TO_STABILIZE=30
 #TODO In production, specify p6e-gb200, only. We added m6g only for testing purposes.
-ALLOWED_INSTANCE_TYPES="^(p6e-gb200|m6g)"
+ALLOWED_INSTANCE_TYPES="^(p6e-gb200|g5g)"
 IMEX_SERVICE="nvidia-imex"
 
 function info() {

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/90-nvidia-imex.prolog.sh
@@ -9,8 +9,8 @@ SCONTROL_CMD="/opt/slurm/bin/scontrol"
 IMEX_START_TIMEOUT=60
 IMEX_STOP_TIMEOUT=15
 WAIT_TIME_TO_STABILIZE=30
-#TODO In production, specify p6e-gb200, only. We added g4dn only for testing purposes.
-ALLOWED_INSTANCE_TYPES="^(p6e-gb200|g4dn)"
+#TODO In production, specify p6e-gb200, only. We added m6g only for testing purposes.
+ALLOWED_INSTANCE_TYPES="^(p6e-gb200|m6g)"
 IMEX_SERVICE="nvidia-imex"
 
 function info() {

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
@@ -42,7 +42,7 @@ Scheduling:
     ComputeResources:
       - Name: {{ compute_resource_without_imex }}
         InstanceType: m6g.xlarge
-        MinCount: 1
+        MinCount: 0
         MaxCount: 1
     Networking:
       SubnetIds:


### PR DESCRIPTION
### Description of changes
* Wait for instance launch before check topology plugin.
* Change queue without imex MinCount to 0 to make the queue updated. So that the slurmctld can be restarted.
* Add retry mechanism for IMEX health checks
* Add deadlock recovery mechnism
* Use ARM GPU instance type g5g.xlarge instead of m6g(CPU)/g4dn(x86).
* Fix assert_topology_plugin_completely_disabled function.

### Tests
* Integ test passed.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
