### PR TITLE
[Test] Disable nvidia and lustre installation for ubuntu2404 in createami test

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -129,6 +129,11 @@ def test_build_image(
     enable_nvidia = True
     update_os_packages = False
     enable_lustre_client = True
+
+    # Disable nvidia installation for ubuntu2404 because nvidia drivers are failing with newest kernel
+    if os in ["ubuntu2404"]:
+        enable_nvidia = False
+
     # Get base AMI
     if os in ["alinux2", "ubuntu2004"]:
         # Test Deep Learning AMIs
@@ -143,7 +148,7 @@ def test_build_image(
             logging.info("First stage AMI not available, using official AMI instead.")
             base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
             update_os_packages = True
-            if os in ["ubuntu2204", "rhel9"]:
+            if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
                 enable_lustre_client = False
     else:
         # Test vanilla AMIs.


### PR DESCRIPTION
### Description of changes
* Disable nvidia and lustre installation for ubuntu2404 in createami test
* ubuntu2404 8.14 kernel causes a failure with the nvidia installation
* lustre also does not support the newest ubuntu2404 6.8 kernel or the 6.14 kernel
* In the second stage build we use an older 6.8 kernel from the last successful first stage build.
* Instead if pinning the kernel in this test, I decided to disable the nvidia and lustre installatiion

### Tests
* Ran test_build_image for ubuntu2404

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
