### PR TITLE
[integ-test] Improve NCCL test to consider instance types with different numbers of GPUs

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -271,6 +271,7 @@ class SlurmCommands(SchedulerCommands):
         command,
         nodes=0,
         slots=None,
+        ntasks_per_node=None,
         host=None,
         after_ok=None,
         partition=None,
@@ -287,6 +288,7 @@ class SlurmCommands(SchedulerCommands):
             job_submit_command,
             nodes=nodes,
             slots=slots,
+            ntasks_per_node=ntasks_per_node,
             host=host,
             after_ok=after_ok,
             partition=partition,
@@ -303,6 +305,7 @@ class SlurmCommands(SchedulerCommands):
         script_args=None,
         nodes=0,
         slots=None,
+        ntasks_per_node=None,
         host=None,
         after_ok=None,
         partition=None,
@@ -325,6 +328,7 @@ class SlurmCommands(SchedulerCommands):
             job_submit_command,
             nodes=nodes,
             slots=slots,
+            ntasks_per_node=ntasks_per_node,
             host=host,
             after_ok=after_ok,
             partition=partition,
@@ -340,6 +344,7 @@ class SlurmCommands(SchedulerCommands):
         job_submit_command,
         nodes=0,
         slots=None,
+        ntasks_per_node=None,
         host=None,
         after_ok=None,
         partition=None,
@@ -355,6 +360,8 @@ class SlurmCommands(SchedulerCommands):
             submission_command += " --nodelist={0}".format(host)
         if slots:
             submission_command += " -n {0}".format(slots)
+        if ntasks_per_node:
+            submission_command += " --ntasks-per-node {0}".format(ntasks_per_node)
         if nodes > 0:
             submission_command += " -N {0}".format(nodes)
         if after_ok:

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -15,7 +15,7 @@ import pytest
 import xmltodict
 from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutor
-from utils import get_compute_nodes_instance_ids
+from utils import get_compute_nodes_instance_ids, get_instance_info
 
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.mpi_common import _test_mpi
@@ -184,8 +184,21 @@ def _test_nccl_benchmarks(remote_command_executor, test_datadir, mpi_module, sch
         str(test_datadir / "nccl_benchmarks" / "init_nccl_benchmarks.sh"), args=[mpi_module], hide=True, timeout=600
     )
 
+    try:
+        gpu_per_node = get_instance_info(instance)["GpuInfo"]["Gpus"][0]["Count"]
+    except Exception as e:
+        # Getting information from us-east-1 is useful for p6e-GB200
+        # because it is only publicly available in us-east-1 while we are testing in other regions.
+        logging.warning(
+            f"Failed to get gpu count for {instance} from the current region. Exception: {e}. "
+            "Trying to retrieve the information from us-east-1..."
+        )
+        gpu_per_node = get_instance_info(instance, "us-east-1")["GpuInfo"]["Gpus"][0]["Count"]
+
     result = scheduler_commands.submit_script(
-        str(test_datadir / "nccl_benchmarks" / "nccl_tests_submit_{0}.sh".format(mpi_module)), nodes=2
+        str(test_datadir / "nccl_benchmarks" / "nccl_tests_submit_{0}.sh".format(mpi_module)),
+        nodes=2,
+        ntasks_per_node=gpu_per_node,
     )
 
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
@@ -215,11 +228,16 @@ def _test_nccl_benchmarks(remote_command_executor, test_datadir, mpi_module, sch
         "cat /shared/nccl_tests.out | grep -E '1073741824\\s+268435456' | awk '{print $12}'"
     ).stdout
 
+    out_of_place_max_bandwidth = remote_command_executor.run_remote_command(
+        "cat /shared/nccl_tests.out | grep -E '1073741824\\s+268435456' | awk '{print $8}'"
+    ).stdout
+
     instance_bandwidth_dict = {
         # p4d.24xlarge - Expected "in-place busbw" bandwidth with 2 nodes, 8 tasks per node is about 27GB/s
         "p4d.24xlarge": 26.0,
         # p5.48xlarge - Expected "in-place busbw" bandwidth with 2 nodes, 8 tasks per node is about 250GB/s
         "p5.48xlarge": 250.0,
+        "p6e-gb200.36xlarge": 500,
     }
 
     expected_bandwidth = instance_bandwidth_dict.get(instance)
@@ -227,3 +245,8 @@ def _test_nccl_benchmarks(remote_command_executor, test_datadir, mpi_module, sch
         pytest.fail(f"Instance {instance} is not valid for multiple bandwidth tests")
 
     assert_that(float(max_bandwidth)).is_greater_than(expected_bandwidth)
+    if instance == "p6e-gb200.36xlarge":
+        # Check "out of place" bandwidth for p6e-GB200
+        # because the GPUs are directly connected for different instances on the same ultra server.
+        # The "out of place" bandwidth is expected to be similar to the in-place bandwidth.
+        assert_that(float(out_of_place_max_bandwidth)).is_greater_than(expected_bandwidth)

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #SBATCH --nodes=2
 #SBATCH --exclusive
-#SBATCH --ntasks-per-node=8
 
 module load openmpi
 NCCL_VERSION='2.27.7-1'


### PR DESCRIPTION
### Description of changes
Remove hard code of `#SBATCH --ntasks-per-node=8` from NCCL submission script, and dynamically set it in the sbatch command flag `--ntasks-per-node` with number of GPU retrieved from EC2 API.

Check "out of place" bandwidth for p6e-GB200 because the GPUs are directly connected for different instances on the same ultra server.

### Tests
* test_efa on AL2023 on p4d has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
