### PR TITLE
[integ-test] Add Rocky/RHEL to NCCL test

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -62,7 +62,7 @@ def test_efa(
 
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
 
-    if instance in ["p4d.24xlarge", "p5.48xlarge"] and not os.startswith(("rocky", "rhel")):
+    if instance in ["p4d.24xlarge", "p5.48xlarge"]:
         # Doc of supported instance types and operating systems:
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands, instance)

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -25,3 +25,16 @@ wget https://github.com/NVIDIA/nccl-tests/archive/v${NCCL_BENCHMARKS_VERSION}.ta
 tar zxvf "v${NCCL_BENCHMARKS_VERSION}.tar.gz"
 cd "nccl-tests-${NCCL_BENCHMARKS_VERSION}/"
 NVCC_GENCODE="${NVCC_GENCODE}" make MPI=1 MPI_HOME=${MPI_HOME} NCCL_HOME=/shared/${1}/nccl-${NCCL_VERSION}/build/ CUDA_HOME=/usr/local/cuda
+
+# Compile OFI NCCL plugin for RHEL and Rocky because EFA doesn't ship the plugin on the OSes
+. /etc/os-release
+if [[ $ID==rhel || $ID==rocky ]]; then
+  OFI_NCCL_VERSION='1.16.3'
+  wget https://github.com/aws/aws-ofi-nccl/archive/v${OFI_NCCL_VERSION}.tar.gz
+  tar xvfz v${OFI_NCCL_VERSION}.tar.gz
+  cd aws-ofi-nccl-${OFI_NCCL_VERSION}
+  ./autogen.sh
+  ./configure --with-libfabric=/opt/amazon/efa --with-cuda=/usr/local/cuda/ --with-nccl=/shared/openmpi/nccl-${NCCL_VERSION}/build/ --with-mpi=${MPI_HOME} --prefix /shared/openmpi/ofi-plugin
+  make
+  make install
+fi

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -6,10 +6,17 @@ module load openmpi
 NCCL_VERSION='2.27.7-1'
 NCCL_BENCHMARKS_VERSION='2.16.7'
 
+. /etc/os-release
+if [[ $ID==rhel || $ID==rocky ]]; then
+  OFI_PATH="/shared/openmpi/ofi-plugin/lib/"
+else
+  OFI_PATH=$(cat /etc/ld.so.conf.d/100_ofinccl.conf)
+fi
+
 mpirun \
 -x FI_PROVIDER="efa" \
 -x FI_EFA_USE_DEVICE_RDMA=1 \
--x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:$(cat /etc/ld.so.conf.d/100_ofinccl.conf):$LD_LIBRARY_PATH \
+-x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:${OFI_PATH}:$LD_LIBRARY_PATH \
 -x RDMAV_FORK_SAFE=1 \
 -x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \


### PR DESCRIPTION
### Description of changes
https://github.com/aws/aws-parallelcluster/commit/7adae16aee9ce6c4bc3c329dc9c8d547431022ad removed OFI plugin compilation because EFA includes OFI plugin in its installation.

https://github.com/aws/aws-parallelcluster/commit/c0e43557c3939c7aaebc59a102d9a2376b3d68da skipped NCCL test on Rocky and RHEL, because OFI plugin only supports Amazon Linux 2023, Amazon Linux 2, Ubuntu 24.04, and Ubuntu 22.04.

This commit finds a workaround to re-introduce the compilation of OFI plugin on Rocky/RHEL, and NCCL has passed on the OSes.

### Tests
* test_efa on Rocky has passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
