### PR TITLE
[Gb200] Adding p6e-gb200 test in daily integration test if it exist

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -283,6 +283,10 @@ test-suites:
           instances: [ "g5g.xlarge" ]
           oss: [ "alinux2023" ]
           schedulers: [ "slurm" ]
+        - regions: [ "usw2-az4" ] # do not move, unless instance type support is moved as well
+          instances: [ "p6e-gb200.36xlarge" ]
+          oss: [ "ubuntu2204" ]
+          schedulers: [ "slurm" ]
   health_checks:
     test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
       dimensions:

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -25,11 +25,6 @@ from tests.common.assertions import assert_regex_in_file, wait_for_instances_in_
 from tests.common.schedulers_common import SlurmCommands
 from tests.common.utils import is_existing_remote_file, read_remote_file, terminate_nodes_manually
 
-# This is the capacity block reservation for p6e-gb200.36xlarge.
-# Given the limited availability of this capacity we test this instance type on demand,
-# hardwiring the reservation id here when we need it.
-CAPACITY_BLOCK_RESERVATION_ID = "cr-123456789"
-
 # We use placeholder IPs just to get IMEX started.
 # These values are hardwired in the cookbook.
 FAKE_IPS = ["0.0.0.0"] * 9
@@ -349,6 +344,33 @@ def assert_topology_plugin_completely_disabled(cluster: Cluster):
     logging.info("TopologyPlugin correctly completely disabled")
 
 
+def get_ultraserver_capacity_reservation_id(instance, region):
+    ec2_client = boto3.client("ec2", region_name=region)
+    paginator = ec2_client.get_paginator("describe_capacity_block_status")
+
+    # List to store matching reservation IDs
+    ultraserver_reservations_ids = []
+
+    # Paginate through the results
+    for page in paginator.paginate():
+        for block in page.get("CapacityBlockStatuses", []):
+            for reservation in block.get("CapacityReservationStatuses", []):
+                # Check if TotalCapacity equals TotalAvailableCapacity
+                if (
+                    reservation.get("TotalCapacity") == reservation.get("TotalAvailableCapacity")
+                    and reservation.get("TotalCapacity") is not None
+                ):
+
+                    ultraserver_reservations_ids.append(
+                        {
+                            "CapacityReservationId": reservation["CapacityReservationId"],
+                            "TotalCapacity": reservation["TotalCapacity"],
+                        }
+                    )
+
+    return ultraserver_reservations_ids
+
+
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_gb200(
     pcluster_config_reader, file_reader, clusters_factory, test_datadir, s3_bucket_factory, region, instance
@@ -383,9 +405,18 @@ def test_gb200(
     This is a reasonable approximation for the test because the focus of the test is on IMEX and topology configuration,
     which can be executed on g4dn as well.
     """
-    max_queue_size = 2
+    capacity_max_queue_size = capacity_reservation_id = None
+    if instance == "p6e-gb200.36xlarge":
+        ultraserver_reservations_ids = get_ultraserver_capacity_reservation_id(instance, region)
+        if ultraserver_reservations_ids:
+            capacity_reservation_id = ultraserver_reservations_ids[0].get("CapacityReservationId")
+            capacity_max_queue_size = ultraserver_reservations_ids[0].get("TotalCapacity")
+        else:
+            pytest.skip(f"Skipping the test No Capacity Block for {instance} was found in {region}")
+
+    max_queue_size = 2 if capacity_max_queue_size is None else capacity_max_queue_size
     min_queue_size_without_imex = 1 if instance != "p6e-gb200.36xlarge" else 0
-    capacity_block_reservation_id = CAPACITY_BLOCK_RESERVATION_ID if instance == "p6e-gb200.36xlarge" else None
+    capacity_block_reservation_id = capacity_reservation_id if instance == "p6e-gb200.36xlarge" else None
 
     # Create an S3 bucket for custom action scripts
     bucket_name = s3_bucket_factory()


### PR DESCRIPTION
### Description of changes
* Run test_gb200 integ test with p6e-gb200 in daily run f a Capacity Block exist. Otherwise skip the test.

### Tests
```
test-suites:
  ultraserver:
    test_gb200.py::test_gb200:
      dimensions:
        - regions: [ "usw2-az4" ]
          instances: ["p6e-gb200.36xlarge"]
          oss: [ "ubuntu2404" ]
          schedulers: [ "slurm" ]
        - regions: [ "use1-az1" ]
          instances: [ "g5g.xlarge" ]
          oss: [ "alinux2023" ]
          schedulers: [ "slurm" ]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
