### PR TITLE
[integ-tests] Fix insufficient capacity error for test_efa_and_placement_group

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -198,7 +198,8 @@ def test_efa_and_placement_group(
         placement_group_config=placement_group_config["configuration"],
     )
     inject_additional_config_settings(config_path, request, region, architecture)
-    clusters_factory(config_path)
+    response = clusters_factory(config_path, dryrun=True, raise_on_error=False).creation_response
+    assert_that(response.get("message")).is_equal_to("Request would have succeeded, but DryRun flag is set.")
 
 
 def test_efa_unsupported(request, vpc_stack, key_name, region, os, instance, scheduler, clusters_factory, test_datadir):


### PR DESCRIPTION
### Description of changes
Instead of creating a cluster, we changed the test verify `create-cluster` dryrun succeeds. This change still serve the purpose of test of `pcluster configure` process well

### Tests
* test_efa_and_placement_group has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
