### PR TITLE
[integ-tests-framework] Add Cache to Retrieve Instance Types to Speed Up Integration Test Setup

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -80,6 +80,10 @@ def _propagate_os_jinja_variables(prefix, result, today_number, supported_x86_os
 
 def _get_instance_type_parameters():  # noqa: C901
     """Gets Instance jinja parameters."""
+    # Return cached result if available
+    if hasattr(_get_instance_type_parameters, "_cache"):
+        return _get_instance_type_parameters._cache
+
     result = {}
     excluded_instance_type_prefixes = [
         "m1",
@@ -104,7 +108,7 @@ def _get_instance_type_parameters():  # noqa: C901
         "p2",
         "p3",
     ]
-    for region in ["us-east-1", "us-west-2", "eu-west-1"]:  # Only populate instance type for big regions
+    for region in ["us-east-1", "us-west-2"]:  # Only populate instance type for big regions
         ec2_client = boto3.client("ec2", region_name=region)
         # The following conversion is required becase Python jinja doesn't like "-"
         region_jinja = region.replace("-", "_").upper()
@@ -175,6 +179,9 @@ def _get_instance_type_parameters():  # noqa: C901
             for index in range(10):
                 result[f"{region_jinja}_GPU_INSTANCE_TYPE_{index}"] = "g4dn.xlarge"
                 result[f"{region_jinja}_GPU_INSTANCE_TYPE_{index}_AZ"] = region
+
+    # Cache the result
+    _get_instance_type_parameters._cache = result
     return result
 
 


### PR DESCRIPTION
### Description of changes
The `describe_instance_type_offerings` call has a huge response body, therefore taking long. Adding a cache to the function to reduce the numer of the API call. This speed up integration test framework startup time by 5 minutes


### Tests
* Test the setup phase with develop.yaml, and verified all Jinja variables in develop.yaml are rendered correctly.

### References
* This is a improvement on https://github.com/aws/aws-parallelcluster/pull/6645

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
