### PR TITLE
[GB200] Add IMEX channel configuration and improve GB200 integration tests

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
@@ -141,10 +141,31 @@ function reload_imex() {
   timeout ${IMEX_START_TIMEOUT} systemctl start ${IMEX_SERVICE}
 }
 
+function create_default_imex_channel() {
+  # This configuration follows
+  # [Nvidia doc](https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/imexchannels.html)
+  # This configuration is only suitable for single user environment, and not compatible with multi-user environment.
+  info "Creating IMEX default Channel"
+  MAJOR_NUMBER=$(cat /proc/devices | grep nvidia-caps-imex-channels | cut -d' ' -f1)
+  if [ ! -d "/dev/nvidia-caps-imex-channels" ]; then
+    sudo mkdir /dev/nvidia-caps-imex-channels
+  fi
+
+  # Then check and create device node
+  if [ ! -e "/dev/nvidia-caps-imex-channels/channel0" ]; then
+    sudo mknod /dev/nvidia-caps-imex-channels/channel0 c $MAJOR_NUMBER 0
+    info "IMEX default Channel created"
+  else
+    info "IMEX default Channel already exists"
+  fi
+}
+
 {
   info "PROLOG Start JobId=${SLURM_JOB_ID}: $0"
 
   return_unless_gb200_with_imex
+
+  create_default_imex_channel
 
   QUEUE_NAME=$(get_dna_parameter "scheduler_queue_name")
   COMPUTE_RESOURCE_NAME=$(get_dna_parameter "scheduler_compute_resource_name")

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: m6g.xlarge
+  InstanceType: c7g.16xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.update.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: m6g.xlarge
+  InstanceType: c7g.16xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: m6g.xlarge
+  InstanceType: c7g.16xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:


### PR DESCRIPTION
### Description of changes
* [integ-tests] Use Larger Head Node for GB200 test
* Add major channel configuration in the prolog to configure IMEX

See commit descriptions for details

### Tests
* test_gb200 on U24, AL2023, Rocky9 has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
