### PR TITLE
[integ-tests] Retain build image instance on failure for easy debugging

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -35,4 +35,4 @@ DeploymentSettings:
         SecurityGroupIds:
         - {{ default_vpc_security_group_id }}
 DevSettings:
-    TerminateInstanceOnFailure: True
+    TerminateInstanceOnFailure: False


### PR DESCRIPTION
### Description of changes
* This fixes a bug from https://github.com/aws/aws-parallelcluster/pull/6979. The boolean value was wrong.

### Tests
* Test will be done after PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
