### PR TITLE
Increase pytest timeout to 6 hours

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -563,7 +563,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
 
     pytest_args.append("--tests-log-file={0}/{1}".format(args.output_dir, log_file))
     pytest_args.append("--output-dir={0}/{1}".format(args.output_dir, out_dir))
-    pytest_args.append("--timeout=14400")
+    pytest_args.append("--timeout=21600")
     pytest_args.append(f"--key-name={args.key_name}")
     pytest_args.append(f"--key-path={args.key_path}")
     pytest_args.extend(["--stackname-suffix", args.stackname_suffix])


### PR DESCRIPTION
### Description of changes
* Increase pytest timeout to 6 hours
* Increased to 6 hours because test_build_image is what is causing the timeout. test_build_image usually takes up to 3 hours and then does a retry.
* This is to avoid `subnet does not exist` failures that occur when the time out is reached, the vpc stack is deleted, and then the test does a retry.


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
