### PR TITLE
[Gb200][Test] Disable GPU heath check  for quick NCCL and MPI jobs execution

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
@@ -8,7 +8,6 @@ DNA_JSON_FILE="/etc/chef/dna.json"
 SCONTROL_CMD="/opt/slurm/bin/scontrol"
 IMEX_START_TIMEOUT=60
 IMEX_STOP_TIMEOUT=15
-WAIT_TIME_TO_STABILIZE=30
 #TODO In production, specify p6e-gb200, only. We added g5g only for testing purposes.
 ALLOWED_INSTANCE_TYPES="^(p6e-gb200|g5g)"
 IMEX_SERVICE="nvidia-imex"
@@ -200,8 +199,7 @@ function handle_imex_reload() {
   if check_imex_needs_reload "${_ips_from_cr}" "${_imex_main_config}"; then
     info "${_reload_message}"
     if reload_imex; then
-      info "Sleeping ${WAIT_TIME_TO_STABILIZE} seconds to let IMEX stabilize"
-      sleep ${WAIT_TIME_TO_STABILIZE}
+      info "IMEX has been reloaded"
     else
       error "Failed to reload IMEX service"
     fi

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
@@ -37,9 +37,6 @@ Scheduling:
         Efa:
           Enabled: true
         {% endif %}
-        HealthChecks:
-          Gpu:
-            Enabled: True
     Networking:
       {% if instance == "p6e-gb200.36xlarge" %}
       PlacementGroup:


### PR DESCRIPTION
### Description of changes
* Disable GPU heath check  for quick NCCL and MPI jobs runs and enable it during the update when we check IMEX and Topology verification
* Remove 30 second stabalize time as we have added retry mechanism for IMEX health status https://github.com/aws/aws-parallelcluster/pull/6959


### Tests
* test_gb200 with cherry picks from https://github.com/aws/aws-parallelcluster/pull/6964/files

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
