### PR TITLE
[integ-tests] Improve NCCL test to get better performance numbers

### DIFF
--- a/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
@@ -18,8 +18,7 @@ mpirun \
 -x FI_EFA_USE_DEVICE_RDMA=1 \
 -x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:${OFI_PATH}:$LD_LIBRARY_PATH \
 -x RDMAV_FORK_SAFE=1 \
--x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \
--x NCCL_PROTO=simple \
+-x NCCL_TESTS_SPLIT_MASK=0x0 \
 --mca pml ^cm --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --bind-to none \
-/shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out
+/shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 1024 -e 8G -f 2 -g 1 -c 1 > /shared/nccl_tests.out


### PR DESCRIPTION
### Description of changes
1. Remove hard coding algorithm and proto to let OFI plugin pick the best values. This change aims at testing the best possible performance.
2. Specify NCCL_TESTS_SPLIT_MASK=0x0. This is consistent with other internal testing method. For the meaning of the parameter see https://github.com/NVIDIA/nccl-tests
3. Increase the minimal message size to 1024, and maximum size to 8G. It doesn't seem to be useful to monitor smaller message sizes, and bigger message sizes use the bandwidth fully.
4. Reduce the number of run from 100 to 20 (default). This makes the test running time stay the same after the message size is increased

### Tests
* test_efa has passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
