### PR TITLE
[integ-tests] Use c7g.4xlarge instead of c7g.16xlarge to avoid ICE in test_gb200

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.final.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: c7g.16xlarge
+  InstanceType: c7g.4xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.update.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: c7g.16xlarge
+  InstanceType: c7g.4xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: c7g.16xlarge
+  InstanceType: c7g.4xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:


### PR DESCRIPTION
### Description of changes
c7g.xlarge is too small and sometimes causes job hang c7g.16xlarge is sometimes rare and causes ICE.
c7g.4xlarge could be a good balance.
ToDo: Long-term solution should be making the test framework use a dynamic head node instance type

### Tests
* tests will be done after the PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
