### PR TITLE
[Gb200][Prolog] Use Slurm environment variables for getting queue and compute resource name

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -47,9 +47,13 @@ def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: in
     return job_id
 
 
-def assert_imex_nodes_config_is_correct(rce: RemoteCommandExecutor, launch_template_id: str, expected_ips: list):
+def assert_imex_nodes_config_is_correct(
+    rce: RemoteCommandExecutor, queue_name: str, compute_resource_name: str, expected_ips: list
+):
     logging.info(f"Checking IMEX nodes config contains the expected nodes: {expected_ips}")
-    imex_nodes_config_file = f"/opt/parallelcluster/shared/nvidia-imex/nodes_config_{launch_template_id}.cfg"
+    imex_nodes_config_file = (
+        f"/opt/parallelcluster/shared/nvidia-imex/nodes_config_{queue_name}_{compute_resource_name}.cfg"
+    )
     imex_config_content = read_remote_file(rce, imex_nodes_config_file)
     imex_config_content_clean = [line for line in imex_config_content.split("\n") if not line.strip().startswith("#")]
     actual_ips = [ip.strip() for ip in imex_config_content_clean]
@@ -189,12 +193,6 @@ def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max
     def _check_imex_healthy():
         rce = RemoteCommandExecutor(cluster)
 
-        launch_template_id = cluster.get_compute_nodes_launch_template_logical_id(queue, compute_resource)
-        logging.info(
-            f"Launch template for nodes in queue {queue} and compute resource {compute_resource}: "
-            f"{launch_template_id}"
-        )
-
         job_id = submit_job_imex_status(rce, queue, max_nodes)
 
         logging.info(
@@ -206,7 +204,7 @@ def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max
             f"Private IP addresses for nodes in queue {queue} and compute resource {compute_resource}: " f"{ips}"
         )
 
-        assert_imex_nodes_config_is_correct(rce, launch_template_id, ips)
+        assert_imex_nodes_config_is_correct(rce, queue, compute_resource, ips)
         assert_imex_status(rce, job_id, ips, service_status="UP", node_status="READY", connection_status="CONNECTED")
         assert_no_errors_in_logs(cluster, queue, compute_resource)
 
@@ -234,14 +232,9 @@ def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max
 def assert_imex_not_configured(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):
     rce = RemoteCommandExecutor(cluster)
 
-    launch_template_id = cluster.get_compute_nodes_launch_template_logical_id(queue, compute_resource)
-    logging.info(
-        f"Launch template for nodes in queue {queue} and " f"compute resource {compute_resource}: {launch_template_id}"
-    )
-
     job_id = submit_job_imex_status(rce, queue, max_nodes)
 
-    assert_imex_nodes_config_is_correct(rce, launch_template_id, FAKE_IPS)
+    assert_imex_nodes_config_is_correct(rce, queue, compute_resource, FAKE_IPS)
     assert_imex_status(
         rce, job_id, FAKE_IPS, service_status="DOWN", node_status="UNAVAILABLE", connection_status="INVALID"
     )

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
@@ -4,7 +4,6 @@
 # This prolog is meant to be run by compute nodes.
 
 LOG_FILE_PATH="/var/log/parallelcluster/nvidia-imex-prolog.log"
-DNA_JSON_FILE="/etc/chef/dna.json"
 SCONTROL_CMD="/opt/slurm/bin/scontrol"
 IMEX_START_TIMEOUT=60
 IMEX_STOP_TIMEOUT=15
@@ -77,8 +76,8 @@ function get_ips_from_node_names() {
   ${SCONTROL_CMD} -ao show node "${_nodes}" | sed 's/^.* NodeAddr=\([^ ]*\).*/\1/'
 }
 
-function get_dna_parameter() {
-  jq -r ".cluster.${1}" "${DNA_JSON_FILE}"
+function get_compute_resource_name() {
+  echo "${2}" | sed -E "s/${1}(.+)-[0-9]+$/\1/"
 }
 
 function check_imex_needs_reload() {
@@ -234,18 +233,16 @@ function create_default_imex_channel() {
 
   create_default_imex_channel
 
-  QUEUE_NAME=$(get_dna_parameter "scheduler_queue_name")
-  COMPUTE_RESOURCE_NAME=$(get_dna_parameter "scheduler_compute_resource_name")
-  LAUNCH_TEMPLATE_ID=$(get_dna_parameter "launch_template_id")
+  QUEUE_NAME=$SLURM_JOB_PARTITION
+  COMPUTE_RESOURCE_NAME=$(get_compute_resource_name "${QUEUE_NAME}-st-" $SLURMD_NODENAME)
   CR_NODES=$(get_node_names "${QUEUE_NAME}" "${COMPUTE_RESOURCE_NAME}")
   IPS_FROM_CR=$(get_ips_from_node_names "${CR_NODES}")
-  IMEX_MAIN_CONFIG="/opt/parallelcluster/shared/nvidia-imex/config_${LAUNCH_TEMPLATE_ID}.cfg"
-  IMEX_NODES_CONFIG="/opt/parallelcluster/shared/nvidia-imex/nodes_config_${LAUNCH_TEMPLATE_ID}.cfg"
+  IMEX_MAIN_CONFIG="/opt/parallelcluster/shared/nvidia-imex/config_${QUEUE_NAME}_${COMPUTE_RESOURCE_NAME}.cfg"
+  IMEX_NODES_CONFIG="/opt/parallelcluster/shared/nvidia-imex/nodes_config_${QUEUE_NAME}_${COMPUTE_RESOURCE_NAME}.cfg"
 
   info "Queue Name: ${QUEUE_NAME}"
   info "CR Name: ${COMPUTE_RESOURCE_NAME}"
   info "CR Nodes: ${CR_NODES}"
-  info "Launch Template Id: ${LAUNCH_TEMPLATE_ID}"
   info "Node IPs from CR: ${IPS_FROM_CR}"
   info "IMEX Main Config: ${IMEX_MAIN_CONFIG}"
   info "IMEX Nodes Config: ${IMEX_NODES_CONFIG}"

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/nvidia-imex-status.job
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/nvidia-imex-status.job
@@ -4,7 +4,8 @@
 #SBATCH --output=slurm-%j.out
 #SBATCH --error=slurm-%j.err
 
-LAUNCH_TEMPLATE_ID=$(cat "/etc/chef/dna.json" | jq -r ".cluster.launch_template_id")
-IMEX_CONFIG_FILE="/opt/parallelcluster/shared/nvidia-imex/config_${LAUNCH_TEMPLATE_ID}.cfg"
+QUEUE_NAME=$(cat "/etc/chef/dna.json" | jq -r ".cluster.scheduler_queue_name")
+COMPUTE_RES_NAME=$(cat "/etc/chef/dna.json" | jq -r ".cluster.scheduler_compute_resource_name")
+IMEX_CONFIG_FILE="/opt/parallelcluster/shared/nvidia-imex/config_${QUEUE_NAME}_${COMPUTE_RES_NAME}.cfg"
 
 srun bash -c "/usr/bin/nvidia-imex-ctl -N -j -c ${IMEX_CONFIG_FILE} > result_\${SLURM_JOB_ID}_\$(hostname).out 2> result_\${SLURM_JOB_ID}_\$(hostname).err"


### PR DESCRIPTION
### Description of changes
* [Gb200][Prolog] Using SLURM environment variables for getting queue name and compute resource name
* [Gb200][Test] Update Imex job status to point to correct files

### Tests
* test_gb200 with https://github.com/aws/aws-parallelcluster-cookbook/pull/3024

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
