### PR TITLE
Increase retry time when waiting for build stack to delete

### DIFF
--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -107,8 +107,8 @@ def _cloudformation_wait(region, stack_name, status):
     config = Config(region_name=region)
     cloud_formation = boto3.client("cloudformation", config=config)
     waiter = cloud_formation.get_waiter(status)
-    # 180 attempts, one every 30 seconds, times out after 90 minutes
-    waiter.wait(StackName=stack_name, WaiterConfig={"MaxAttempts": 180})
+    # 200 attempts, one every 30 seconds, times out after 100 minutes
+    waiter.wait(StackName=stack_name, WaiterConfig={"MaxAttempts": 200})
 
 
 def _ec2_wait_running(region, instances):

--- a/tests/integration-tests/tests/pyxis/test_pyxis/test_pyxis/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pyxis/test_pyxis/test_pyxis/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
     ComputeResources:
       - Name: compute-resource-0
         Instances:
-          - InstanceType: t3.small
+          - InstanceType: t3.large
         MinCount: 0
         MaxCount: {{ max_queue_size }}
     Networking:


### PR DESCRIPTION
### Description of changes
* Increase retry time when waiting for build stack to delete
* test_custom_image is intermittently failing due to a timeout waiting for the cfn stack to delete when the image is available
* Use t3.large instance for test_pyxis to fix memory issue
  * `RealMemory (reported:1713 < 90.00% of configured:1945) `

### Tests
* ran test_custom_image
* ran test_pyxis

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
