### PR TITLE
[B200] Install kernel-modules-extra before kernel pinning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **ENHANCEMENTS**
 - Add support for P6e-GB200 instances. ParallelCluster sets up Slurm topology plugin to handle P6e-GB200 UltraServers. See limitations section for important additional setup requirements.
+- Add support for P6-B200 instances for all OSs except AL2.
 - Echo chef-client logs in the instance console when a node fails to bootstrap. This helps with investigating bootstrap failures in cases CloudWatch logs are not available.
 - Add `build-image` support for Amazon Linux 2023 AMIs based on kernel 6.12 (in addition to 6.1).
 - Support `prioritized` and `capacity-optimized-prioritized` Allocation Strategy. This allows users to prioritize subnets for instance placement to optimize costs and performance.

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -93,7 +93,7 @@ phases:
                   yum clean all
                 }
                 
-                PACKAGE_LIST="${!KERNEL_PACKAGES_PREFIX}-headers-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-devel-$(uname -r)"
+                PACKAGE_LIST="${!KERNEL_PACKAGES_PREFIX}-headers-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-devel-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-modules-extra-$(uname -r)"
                 Repository="BaseOS"
                 [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" ${!KERNEL_PACKAGES_PREFIX}-devel-matched-$(uname -r)" && Repository="AppStream"
                 
@@ -128,8 +128,8 @@ phases:
                 [[ $OS =~ rocky ]] && yum versionlock rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock redhat-release
               else
-                apt-get -y install linux-headers-$(uname -r)
-                apt-mark hold linux-aws* linux-base* linux-headers* linux-image* 
+                apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
+                apt-mark hold linux-aws* linux-base* linux-headers* linux-image*
               fi
               echo "Kernel version is $(uname -a)"
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -124,12 +124,12 @@ phases:
 
                 yum install -y yum-plugin-versionlock
                 # listing all the packages because wildcard does not work as expected
-                yum versionlock ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
+                yum versionlock ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules ${!KERNEL_PACKAGES_PREFIX}-modules-extra
                 [[ $OS =~ rocky ]] && yum versionlock rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock redhat-release
               else
                 apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
-                apt-mark hold linux-aws* linux-base* linux-headers* linux-image*
+                apt-mark hold linux-aws* linux-base* linux-headers* linux-image* linux-modules-extra*
               fi
               echo "Kernel version is $(uname -a)"
 
@@ -245,11 +245,11 @@ phases:
               
               # Remove kernel version lock
               if [[ ${!PLATFORM} == RHEL ]]; then
-                yum versionlock delete ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
+                yum versionlock delete ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules ${!KERNEL_PACKAGES_PREFIX}-modules-extra
                 [[ $OS =~ rocky ]] && yum versionlock delete rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock delete redhat-release
               else
-                apt-mark unhold linux-aws* linux-base* linux-headers* linux-image* 
+                apt-mark unhold linux-aws* linux-base* linux-headers* linux-image* linux-modules-extra*
               fi
               
               # Handle SSM agent


### PR DESCRIPTION
### Description of changes
With this change we install the kernel-modules-extra package, which is required to support p6-b200 instance type. In particular, the package is required by the Infiniband packages installed in https://github.com/aws/aws-parallelcluster-cookbook/pull/3022.

This PR requires https://github.com/aws/aws-parallelcluster-cookbook/pull/3022

### Tests
* Manually built custom AMIs for all OSs executing the same steps of this PR + https://github.com/aws/aws-parallelcluster-cookbook/pull/3022 and validated that these steps are the ones required to make P6-B200 work (verified with dcgmi diagnosis)
* ONGOING Build image on all OSes
* PENDING integ tests: gpu_health_check
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
