### PR TITLE
[integ-test] Upgrade Fabtests to version 2.3.0

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/install-fabtests.sh
@@ -8,7 +8,7 @@ set -ex
 FABTESTS_DIR="$1"
 
 FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"
-FABTESTS_VERSION="2.1.0"
+FABTESTS_VERSION="2.3.0"
 FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
 CUDA_DIR="/usr/local/cuda"


### PR DESCRIPTION
### Description of changes
* This fix fabtest on p6-b200 on Ubuntu and Amazon Linux 2023 fabtest is still failing on Rocky

### Tests
* Test on Ubuntu22 and Amazon Linux 2023 has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
