### PR TITLE
[integ-tests] Let serial_execution_by_instance to take effect on all p-series instances

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1169,7 +1169,7 @@ def s3_bucket_key_prefix():
 @pytest.fixture(scope="class")
 def serial_execution_by_instance(request, instance, region):
     """Enforce serial execution of tests, according to the adopted instance."""
-    if instance in ["c5n.18xlarge", "p4d.24xlarge"]:
+    if instance in ["c5n.18xlarge"] or instance.startswith("p"):
         logging.info("Enforcing serial execution for instance %s", instance)
         outdir = request.config.getoption("output_dir")
         lock_file = f"{outdir}/{instance}{region}.lock"


### PR DESCRIPTION
### Description of changes
Fixture serial_execution_by_instance can be optional used with each test. If the fixture is not used, the test could still run p-series instances in parallel.

This commit fixes a "bug" that some p-series instances serial execution is not enforced even when serial_execution_by_instance is used in the test

### Tests
* Testing will be done after the PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
