### PR TITLE
add timestamp to cli log files

### DIFF
--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -271,7 +271,8 @@ def error(message) -> NoReturn:
 
 
 def get_cli_log_file():
-    default_log_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+    log_timestamp = to_iso_timestr(datetime.datetime.now())
+    default_log_file = os.path.expanduser(os.path.join("~", ".parallelcluster", f"pcluster-cli-{log_timestamp}.log"))
     return os.environ.get("PCLUSTER_LOG_FILE", default=default_log_file)
 
 


### PR DESCRIPTION
### Description of changes
* I am adding a timestamp to the cli log files to make it easier to send these to aws support

### Tests
* no automated tests added

### Checklist
- all checked

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
