### PR TITLE
[Integ-tests] Add Active state as filter for Capacity Reservations

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -569,6 +569,7 @@ def get_capacity_reservation_id(instance_type, region, count, os):
                 instance_type == reservation.get("InstanceType")
                 and os_platform == reservation.get("InstancePlatform")
                 and reservation.get("AvailableInstanceCount") >= count
+                and reservation.get("State") == "active"
             ):
                 reservations_ids.append(
                     {


### PR DESCRIPTION
### Description of changes
[Integ-tests] Add Active state as filter for Capacity Reservations
* CapacityBlockStatus does not need this filter but CapacityReservations API does

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_capacity_reservations.html


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
