### PR TITLE
Add RDMAV_FORK_SAFE parameter to NCCL test

### DIFF
--- a/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
@@ -21,5 +21,6 @@ mpirun \
 -x NCCL_DEBUG=WARNING \
 -x NCCL_TESTS_SPLIT_MASK=0x0 \
 -x NCCL_SOCKET_FAMILY=AF_INET \
+-x RDMAV_FORK_SAFE=1 \
 --bind-to none \
 /shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 1024 -e 8G -f 2 -g 1 -c 1 > /shared/nccl_tests.out


### PR DESCRIPTION
### Description of changes
* Add RDMAV_FORK_SAFE parameter to NCCL test
* Revert the removal of this parameter from: https://github.com/aws/aws-parallelcluster/commit/1c938de66f463d947b0a736068c1ceadf805df97

### Tests
* ran `test_efa`


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
