### PR TITLE
Add RDMAV_FORK_SAFE parameter to NCCL test

### DIFF
--- a/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/nccl/nccl_tests_submit_openmpi.sh
@@ -19,5 +19,6 @@ mpirun \
 -x LD_LIBRARY_PATH=/shared/openmpi/nccl-${NCCL_VERSION}/build/lib/:${OFI_PATH}:$LD_LIBRARY_PATH \
 -x NCCL_DEBUG=WARNING \
 -x NCCL_TESTS_SPLIT_MASK=0x0 \
+-x RDMAV_FORK_SAFE=1 \
 --bind-to none \
 /shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 1024 -e 8G -f 2 -g 1 -c 1 > /shared/nccl_tests.out


### PR DESCRIPTION
### Description of changes
* Add RDMAV_FORK_SAFE parameter to NCCL test
* Cherry pick of: https://github.com/aws/aws-parallelcluster/pull/7014

### Tests
* ran `test_efa`


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
