### PR TITLE
[GB200] Simplify prolog after moving IMEX nodes configuration from shared to local location.

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -55,13 +55,19 @@ def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: in
 
 def assert_imex_nodes_config_is_correct(cluster: Cluster, queue: str, compute_resource: str, expected_ips: list):
     for compute_node_ip in cluster.get_compute_nodes_private_ip(queue, compute_resource):
-        logging.info(f"Checking IMEX nodes config for compute node {compute_node_ip} contains the expected nodes: {expected_ips}")
+        logging.info(
+            f"Checking IMEX nodes config for compute node {compute_node_ip} contains the expected nodes: {expected_ips}"
+        )
         rce = RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip)
         imex_config_content = read_remote_file(rce, "/etc/nvidia-imex/nodes_config.cfg")
-        imex_config_content_clean = [line for line in imex_config_content.split("\n") if not line.strip().startswith("#")]
+        imex_config_content_clean = [
+            line for line in imex_config_content.split("\n") if not line.strip().startswith("#")
+        ]
         actual_ips = [ip.strip() for ip in imex_config_content_clean]
         assert_that(actual_ips).contains_only(*expected_ips)
-        logging.info(f"IMEX nodes config for compute node {compute_node_ip} contains the expected nodes: {expected_ips}")
+        logging.info(
+            f"IMEX nodes config for compute node {compute_node_ip} contains the expected nodes: {expected_ips}"
+        )
 
 
 def assert_no_errors_in_logs(cluster: Cluster, queue: str, compute_resource: str):

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/91_nvidia_imex_prolog.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
-# This prolog script configures the NVIDIA IMEX nodes config file and reloads the nvidia-imex service.
-# This prolog is meant to be run by compute nodes with exclusive jobs.
+# This prolog script configures the NVIDIA IMEX on compute nodes involved in the job execution.
+#
+# In particular:
+# - Checks whether the job is executed exclusively.
+#   If not, it exits immediately because it requires jobs to be executed exclusively.
+# - Writes the private IP addresses of compute nodes into /etc/nvidia-imex/nodes_config.cfg.
+# - Creates the IMEX default channel.
+#   For more information about IMEX channels, see https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/imexchannels.html
+# - Restarts the IMEX system service.
+#
+# REQUIREMENTS:
+#  - This prolog assumes to be run only with exclusive jobs.
 
 LOG_FILE_PATH="/var/log/parallelcluster/nvidia-imex-prolog.log"
 SCONTROL_CMD="/opt/slurm/bin/scontrol"
@@ -10,6 +20,7 @@ IMEX_STOP_TIMEOUT=15
 #TODO In production, specify p6e-gb200, only. We added g5g only for testing purposes.
 ALLOWED_INSTANCE_TYPES="^(p6e-gb200|g5g)"
 IMEX_SERVICE="nvidia-imex"
+IMEX_NODES_CONFIG="/etc/nvidia-imex/nodes_config.cfg"
 
 function info() {
   echo "$(date "+%Y-%m-%dT%H:%M:%S.%3N") [INFO] [PID:$$] [JOB:${SLURM_JOB_ID}] $1"
@@ -48,24 +59,13 @@ function return_if_unsupported_instance_type() {
   fi
 }
 
-function get_node_names() {
-  local _queue_name=$1
-  local _compute_resource_name=$2
-
-  ${SCONTROL_CMD} show nodes --json | \
-    jq -r \
-      --arg queue_name "${_queue_name}" \
-      --arg compute_resource_name "${_compute_resource_name}" \
-      '[
-        .nodes[] |
-        select(
-          (.partitions[] | contains($queue_name)) and
-          (.features[] | contains($compute_resource_name)) and
-          (.features[] | contains("static"))
-        ) |
-        .name
-      ] |
-      join(",")'
+function return_if_job_is_not_exclusive() {
+  if [[ "${SLURM_JOB_OVERSUBSCRIBE}" = "NO" ]]; then
+    info "Job is exclusive, proceeding with IMEX configuration"
+  else
+    info "Skipping IMEX configuration because the job is not exclusive"
+    prolog_end
+  fi
 }
 
 function get_ips_from_node_names() {
@@ -78,22 +78,6 @@ function get_compute_resource_name() {
   local _queue_name_prefix=$1
   local _slurmd_node_name=$2
   echo "${_slurmd_node_name}" | sed -E "s/${_queue_name_prefix}(.+)-[0-9]+$/\1/"
-}
-
-function write_file() {
-  local _file=$1
-  local _content=$2
-  local _lock_file="${_file}.lock"
-  local _lock_timeout_seconds=60
-
-  if [[ -f "${_file}" ]] && [[ "$(cat "${_file}")" = "${_content}" ]]; then
-    info "File ${_file} already has the expected content, skipping the write operation"
-    return 1 # Not Updated
-  fi
-
-  echo "${_content}" > "${_file}"
-  info "File ${_file} updated"
-  return 0 # Updated
 }
 
 function reload_imex() {
@@ -111,9 +95,6 @@ function reload_imex() {
 }
 
 function create_default_imex_channel() {
-  # This configuration follows
-  # [Nvidia doc](https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/imexchannels.html)
-  # This configuration is only suitable for single user environment, and not compatible with multi-user environment.
   info "Creating IMEX default Channel"
   MAJOR_NUMBER=$(cat /proc/devices | grep nvidia-caps-imex-channels | cut -d' ' -f1)
   if [ ! -d "/dev/nvidia-caps-imex-channels" ]; then
@@ -132,27 +113,19 @@ function create_default_imex_channel() {
 {
   info "PROLOG Start JobId=${SLURM_JOB_ID}: $0"
 
+  return_if_job_is_not_exclusive
   return_if_unsupported_instance_type
 
   create_default_imex_channel
 
-  QUEUE_NAME=$SLURM_JOB_PARTITION
-  COMPUTE_RESOURCE_NAME=$(get_compute_resource_name "${QUEUE_NAME}-st-" $SLURMD_NODENAME)
-  CR_NODES=$(get_node_names "${QUEUE_NAME}" "${COMPUTE_RESOURCE_NAME}")
-  IPS_FROM_CR=$(get_ips_from_node_names "${CR_NODES}")
-  IMEX_MAIN_CONFIG="/etc/nvidia-imex/config.cfg"
-  IMEX_NODES_CONFIG="/etc/nvidia-imex/nodes_config.cfg"
+  IPS_FROM_CR=$(get_ips_from_node_names "${SLURM_NODELIST}")
 
-  info "Queue Name: ${QUEUE_NAME}"
-  info "CR Name: ${COMPUTE_RESOURCE_NAME}"
-  info "CR Nodes: ${CR_NODES}"
-  info "Node IPs from CR: ${IPS_FROM_CR}"
-  info "IMEX Main Config: ${IMEX_MAIN_CONFIG}"
+  info "Node Names: ${SLURM_NODELIST}"
+  info "Node IPs: ${IPS_FROM_CR}"
   info "IMEX Nodes Config: ${IMEX_NODES_CONFIG}"
 
   info "Updating IMEX nodes config ${IMEX_NODES_CONFIG}"
-  write_file "${IMEX_NODES_CONFIG}" "${IPS_FROM_CR}"
-
+  echo "${IPS_FROM_CR}" > "${IMEX_NODES_CONFIG}"
   reload_imex
 
   prolog_end


### PR DESCRIPTION
### Description of changes
Simplify prolog after moving IMEX nodes configuration from shared to local location.
In particular:
1. immediately return if the job is not executed exclusively. Exclusive execution is a requirement of our prolog that we also mention in our public documentation and more clearly state in the script description. To identify whether the job is exclusive or not, we check the envar `SLURM_JOB_OVERSUBSCRIBE `, which is accessible from Prolog and it is expected to be set to `NO` if the job is exclusive. Docs: https://slurm.schedmd.com/prolog_epilog.html
2. removed file locking to update IMEX nodes config file. Locking mechanism is not required if we enforce exclusive execution. 
3. Update IMEX nodes config with the IPs of the nodes involved in the job, only, not the whole compute resource.
4. Added more detailed description of the prolog script at the top.

### Tests
Manually tested on a cluster using GB200.

When submitting a non exclusive job
```
[root@ip-192-168-56-193 rocky]# sbatch --wrap 'sleep 60' -w q1-st-cr1-[1-2]
Submitted batch job 24
```

prolog is skipped:

```
2025-09-22T17:13:16.009 [INFO] [PID:41536] [JOB:24] PROLOG Start JobId=24: /opt/slurm/etc/scripts/prolog.d/91_nvidia_imex_prolog.sh
2025-09-22T17:13:16.010 [INFO] [PID:41536] [JOB:24] Skipping IMEX configuration because the job is not exclusive
2025-09-22T17:13:16.011 [INFO] [PID:41536] [JOB:24] PROLOG End JobId=24: /opt/slurm/etc/scripts/prolog.d/91_nvidia_imex_prolog.sh
```

When submitting an exclusive job:

```
[root@ip-192-168-56-193 rocky]# sbatch --wrap 'sleep 60' -w q1-st-cr1-[1-2] --exclusive
Submitted batch job 25
```

prolog is executed:

```
2025-09-22T17:14:16.356 [INFO] [PID:41677] [JOB:25] PROLOG Start JobId=25: /opt/slurm/etc/scripts/prolog.d/91_nvidia_imex_prolog.sh
2025-09-22T17:14:16.357 [INFO] [PID:41677] [JOB:25] Job is exclusive, proceeding with IMEX configuration
2025-09-22T17:14:16.375 [INFO] [PID:41677] [JOB:25] Creating IMEX default Channel
2025-09-22T17:14:16.379 [INFO] [PID:41677] [JOB:25] IMEX default Channel already exists
2025-09-22T17:14:16.389 [INFO] [PID:41677] [JOB:25] Node Names: q1-st-cr1-[1-2]
2025-09-22T17:14:16.390 [INFO] [PID:41677] [JOB:25] Node IPs: 192.168.150.123
192.168.147.221
2025-09-22T17:14:16.390 [INFO] [PID:41677] [JOB:25] IMEX Nodes Config: /etc/nvidia-imex/nodes_config.cfg
2025-09-22T17:14:16.391 [INFO] [PID:41677] [JOB:25] Updating IMEX nodes config /etc/nvidia-imex/nodes_config.cfg
2025-09-22T17:14:16.392 [INFO] [PID:41677] [JOB:25] Stopping IMEX
2025-09-22T17:14:20.634 [INFO] [PID:41677] [JOB:25] Restarting IMEX
2025-09-22T17:14:20.861 [INFO] [PID:41677] [JOB:25] PROLOG End JobId=25: /opt/slurm/etc/scripts/prolog.d/91_nvidia_imex_prolog.sh
```

IMEx is healthy after prolog execution:

```
[root@q1-st-cr1-2 ~]# /usr/bin/nvidia-imex-ctl -N -j
{
 "nodes": {
  "0": {
   "status": "READY",
   "host": "192.168.147.221",
   "connections": {
    "0": {
     "host": "192.168.147.221",
     "status": "CONNECTED",
     "changed": true
    },
    "1": {
     "host": "192.168.150.123",
     "status": "CONNECTED",
     "changed": true
    }
   },
   "changed": true,
   "version": "570.172.08"
  },
  "1": {
   "status": "READY",
   "host": "192.168.150.123",
   "connections": {
    "1": {
     "host": "192.168.150.123",
     "status": "CONNECTED",
     "changed": true
    },
    "0": {
     "host": "192.168.147.221",
     "status": "CONNECTED",
     "changed": true
    }
   },
   "changed": true,
   "version": "570.172.08"
  }
 },
 "timestamp": "9/22/2025 17:20:01.039",
 "status": "UP"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
