### PR TITLE
[GB200] Fix assertion on logs.

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -442,4 +442,4 @@ def _assert_build_image_stack_deleted(stack_name, region, timeout_seconds=600, p
 def assert_regex_in_file(rce: RemoteCommandExecutor, file_name: str, pattern: str, negate: bool = True):
     file_content = read_remote_file(rce, file_name)
     assertion = assert_that(bool(re.search(pattern, file_content, re.IGNORECASE)))
-    assertion.is_false() if negate else assertion.is_fals()
+    assertion.is_false() if negate else assertion.is_true()

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -80,7 +80,7 @@ def assert_no_errors_in_logs(cluster: Cluster, queue: str, compute_resource: str
             if log == "/var/log/nvidia-imex-verbose.log" and not is_existing_remote_file(rce, log):
                 logging.info("IMEX log file not found. Not an issue as IMEX writes logs there only in case of errors.")
                 continue
-            assert_regex_in_file(rce, log, r"(warn|error|fail)", negate=True)
+            assert_regex_in_file(rce, log, r"(error|fail)", negate=True)
 
 
 def assert_imex_status(

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -72,14 +72,11 @@ def assert_imex_nodes_config_is_correct(cluster: Cluster, queue: str, compute_re
 
 
 def assert_no_errors_in_logs(cluster: Cluster, queue: str, compute_resource: str):
-    logs = ["/var/log/nvidia-imex-verbose.log", "/var/log/parallelcluster/nvidia-imex-prolog.log"]
+    logs = ["/var/log/parallelcluster/nvidia-imex-prolog.log"]
     for compute_node_ip in cluster.get_compute_nodes_private_ip(queue, compute_resource):
         rce = RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip)
         for log in logs:
             logging.info(f"Checking file {log} log does not contain any error")
-            if log == "/var/log/nvidia-imex-verbose.log" and not is_existing_remote_file(rce, log):
-                logging.info("IMEX log file not found. Not an issue as IMEX writes logs there only in case of errors.")
-                continue
             assert_regex_in_file(rce, log, r"(error|fail)", negate=True)
 
 

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -46,7 +46,7 @@ def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: in
             "command": "/opt/parallelcluster/shared/nvidia-imex-status.job",
             "partition": queue,
             "nodes": max_nodes,
-            "other_options": " --exclusive=topo"
+            "other_options": " --exclusive=topo",
         }
     )
     slurm.wait_job_completed(job_id)


### PR DESCRIPTION
### Description of changes
Fix assertion on logs used in test_gb200:
1. Removed check on nvidia-imex-verbose.log as it fails on false positive. This check is too sensitive because it is expected for that log to contain warnings and errors due to service reloads. Also, since we already verify that IMEX converges to a stable state, there is no point in checking for past errors.
1. Fix positive assertion (negate=False)

### Tests
ONGOING: test_gb200

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
