### PR TITLE
[Test] Add test runner option --capacity-reservation-id to reuse a specific reservation id for a testing.

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -235,6 +235,10 @@ def pytest_addoption(parser):
         "--api-stack",
         help="Name of CFN stack providing the ParallelCluster API infrastructure.",
     )
+    parser.addoption(
+        "--capacity-reservation-id",
+        help="Use an existing capacity reservation.",
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -104,6 +104,7 @@ TEST_DEFAULTS = {
     "global_build_number": 0,
     "proxy_stack": None,
     "build_image_roles_stack": None,
+    "capacity_reservation_id": None,
 }
 
 
@@ -495,6 +496,11 @@ def _init_argparser():
         help="Name of CFN stack providing the ParallelCluster API infrastructure.",
         default=TEST_DEFAULTS.get("api_stack"),
     )
+    debug_group.add_argument(
+        "--capacity-reservation-id",
+        help="Use an existing capacity reservation.",
+        default=TEST_DEFAULTS.get("capacity_reservation_id"),
+    )
 
     return parser
 
@@ -735,6 +741,9 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.api_stack:
         pytest_args.extend(["--api-stack", args.api_stack])
+
+    if args.capacity_reservation_id:
+        pytest_args.extend(["--capacity-reservation-id", args.capacity_reservation_id])
 
 
 def _set_validate_instance_type_args(args, pytest_args):

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -67,13 +67,16 @@ def test_osu(
         max_queue_size = 2
         capacity_type = "CAPACITY_BLOCK"
         placement_group_enabled = False
-        capacity_reservations_ids = get_capacity_reservation_id(instance, region, max_queue_size, os)
-        if capacity_reservations_ids:
-            capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")
+        if request.config.getoption("capacity_reservation_id"):
+            capacity_reservation_id = request.config.getoption("capacity_reservation_id")
         else:
-            message = f"Skipping the test as no Capacity Block for {instance} and os {os} was found in {region}"
-            logging.warn(message)
-            pytest.skip(message)
+            capacity_reservations_ids = get_capacity_reservation_id(instance, region, max_queue_size, os)
+            if capacity_reservations_ids:
+                capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")
+            else:
+                message = f"Skipping the test as no Capacity Block for {instance} and os {os} was found in {region}"
+                logging.warn(message)
+                pytest.skip(message)
 
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(


### PR DESCRIPTION
### Description of changes
Add test runner option --capacity-reservation-id to reuse a specific reservation id for a testing.
This is useful when we are retaining a cluster that makes use of capacity reservations.
Adapted OSU to make use of this new option.

### Tests
Executed OSU with the option

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
