### PR TITLE
[Test] Fix `test_existing_hosted_zone`, `test_hit_no_cluster_dns_mpi` + Make `test_startup_time` and `test_multiple_efs` more robust

### DIFF
--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -46,7 +46,7 @@ def _test_mpi(
         remote_command_executor.run_remote_command(interactive_command)
 
     # Historically, we assumed a timeout of 20 seconds with 48 slots per instance.
-    timeout = math.ceil((20.0 / 48.0) * slots_per_instance)
+    timeout = max(math.ceil((20.0 / 48.0) * slots_per_instance), 20)
 
     if partition:
         # submit script using additional files

--- a/tests/integration-tests/tests/performance_tests/test_startup_time.py
+++ b/tests/integration-tests/tests/performance_tests/test_startup_time.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import boto3
 import pytest
 from dateutil.relativedelta import relativedelta
+from retrying import retry
+from time_utils import seconds
 from utils import describe_cluster_instances
 
 MINIMUM_DATASET_SIZE = 5
@@ -76,6 +78,7 @@ def evaluate_data(value, os, instance_type):
     return True, distance
 
 
+@retry(retry_on_result=lambda result: result is None, wait_fixed=seconds(10), stop_max_delay=seconds(60))
 def get_metric(os, cluster, instance_type, instance_id, cw_client):
     startup_time_value = None
 

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -324,7 +324,7 @@ def _write_user_data(efs_id, random_file_name, access_point_id=None):
     access_point_mount_parameter = f",accesspoint={access_point_id}" if access_point_id is not None else ""
     return f"""
         - mkdir -p {mount_dir}
-        - mount -t efs -o tls,iam{access_point_mount_parameter} {efs_id}:/ {mount_dir}
+        - for i in {{1..10}}; do mount -t efs -o tls,iam{access_point_mount_parameter} {efs_id}:/ {mount_dir} && break || {{ echo "Attempt $i failed, retrying in 10s..."; sleep 10; }}; done
         - touch {mount_dir}/{random_file_name}
         - umount {mount_dir}
         """  # noqa: E501


### PR DESCRIPTION
### Description of changes
Fix issues with the following tests:
1. `test_existing_hosted_zone` `test_hit_no_cluster_dns_mpi`: Set 20s as the minimum timeout for the MPI ring job used by multiple tests. In https://github.com/aws/aws-parallelcluster/commit/8f266c04c82a621c7415101f786d31196b875007 we made this timeout proportional to the number of slots as a follow up of the validation with B200 instance type. This proportion works with high number of slots, but not with smaller instance types, such as g4dn.8xlarge, where the timeout goes to 2seconds, which is obviously too short. 
1. `test_startup_time`: Add retry around logic to retrieve metric from CloudWatch.
1. `test_multiple_efs`: Add retry logic for mounting EFS with IAM authentication. The retry is necessary to mitigate transient failures caused by IMDs unavailability and IAM eventual consistency.

### Tests
SUCCESS `test_existing_hosted_zone`
SUCCESS `test_hit_no_cluster_dns_mpi`
SUCCESS `test_startup_time`
SUCCESS `test_multiple_efs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
