### PR TITLE
[Test] For EFS auxiliary stack, make instance depends on the instance profile to mitigate risks of instance bootstrap failures

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -282,7 +282,8 @@ def write_file_into_efs(
             ],
         )
     )
-    iam_instance_profile = write_file_template.add_resource(InstanceProfile("IamTlsProfile", Roles=[Ref(role)]))
+    instance_profile_name = "IamTlsProfile"
+    iam_instance_profile = write_file_template.add_resource(InstanceProfile(instance_profile_name, Roles=[Ref(role)]))
     launch_template = LaunchTemplate.from_dict(
         "LaunchTemplateIMDSv2",
         {
@@ -304,6 +305,7 @@ def write_file_into_efs(
             UserData=Base64(Sub(user_data)),
             KeyName=key_name,
             IamInstanceProfile=Ref(iam_instance_profile),
+            DependsOn=instance_profile_name,
         )
     )
     stack_name = generate_stack_name("integ-tests-efs-write-file", request.config.getoption("stackname_suffix"))


### PR DESCRIPTION
### Description of changes
For EFS auxiliary stack used by `test_multiple_efs`, make instance depends on the instance profile to mitigate risks of instance bootstrap failures.
We assumed the implicit dependency would be honored, but this seems not to be the case, so adding an explicit dependency should definitively mitigate the issue.

### Tests
SUCCEEDED `test_multiple_efs`, also verified that the explicit dependency is honored: the instance starts the creation only after the instance profile completed its creation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
