### PR TITLE
[Gb200][Test]For non-imex domain nodes we expect the IMEX status to be down

### DIFF
--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -38,12 +38,13 @@ from tests.common.utils import (
 FAKE_IPS = ["0.0.0.0"] * 9
 
 
-def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: int = 1):
+def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: int = 1, ignore_imex_check: bool = False):
     logging.info("Submitting job to check IMEX status")
     slurm = SlurmCommands(rce)
+    job_command = "/opt/parallelcluster/shared/nvidia-imex-status.job ignore-imex-check" if ignore_imex_check else "/opt/parallelcluster/shared/nvidia-imex-status.job"
     job_id = slurm.submit_command_and_assert_job_accepted(
         submit_command_args={
-            "command": "/opt/parallelcluster/shared/nvidia-imex-status.job",
+            "command": job_command,
             "partition": queue,
             "nodes": max_nodes,
             "other_options": " --exclusive=topo",
@@ -245,7 +246,7 @@ def assert_imex_healthy(cluster: Cluster, queue: str, compute_resource: str, max
 def assert_imex_not_configured(cluster: Cluster, queue: str, compute_resource: str, max_nodes: int = 1):
     rce = RemoteCommandExecutor(cluster)
 
-    job_id = submit_job_imex_status(rce, queue, max_nodes)
+    job_id = submit_job_imex_status(rce, queue, max_nodes, ignore_imex_check=True)
 
     assert_imex_nodes_config_is_correct(cluster, queue, compute_resource, FAKE_IPS)
     assert_imex_status(

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/check_imex_status.sh
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/check_imex_status.sh
@@ -7,6 +7,7 @@ MAX_ATTEMPTS=10
 
 # Function to run the command and check status
 verify_imex_is_up() {
+    local non_imex_job="$1"
     local command="/usr/bin/nvidia-imex-ctl -N -j"
     local file_name="result_${SLURM_JOB_ID}_$(hostname)"
 
@@ -16,7 +17,7 @@ verify_imex_is_up() {
         command_output=$(${command})
         echo "Output from IMEX for $i/$MAX_ATTEMPTS attempt: $command_output"
         # Check if the status is UP
-        if [ "$(echo "$command_output" | jq -r '.status')" == "UP" ] ; then
+        if [ "$(echo "$command_output" | jq -r '.status')" == "UP" ] || [ "$non_imex_job" == "ignore-imex-check" ] ; then
             echo "IMEX is UP. Exiting loop."
             echo "writing the output in ${file_name}.out"
             echo "$command_output" > ${file_name}.out 2> ${file_name}.err

--- a/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/nvidia-imex-status.job
+++ b/tests/integration-tests/tests/ultraserver/test_gb200/test_gb200/nvidia-imex-status.job
@@ -8,4 +8,4 @@ QUEUE_NAME=$(cat "/etc/chef/dna.json" | jq -r ".cluster.scheduler_queue_name")
 COMPUTE_RES_NAME=$(cat "/etc/chef/dna.json" | jq -r ".cluster.scheduler_compute_resource_name")
 
 # Run for NVIDIA IMEX
-srun bash -c "source /opt/parallelcluster/shared/check_imex_status.sh; verify_imex_is_up"
+srun bash -c "source /opt/parallelcluster/shared/check_imex_status.sh; verify_imex_is_up $1"


### PR DESCRIPTION

### Description of changes

For non-imex domain nodes we expect the IMEX status to be down

* We also check the IMEX status is down for nodes which are non-imex
* adding a `ignore-imex-check` for non-imex nodes so that result_*.out file is created

With this change https://github.com/aws/aws-parallelcluster/pull/7024 and https://github.com/aws/aws-parallelcluster/pull/7023 we write result_*.out only if the IMEX status is UP. However, for non-imex nodes we expect the status to be down. 


### Tests
* Test_gb200 with g5g

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
