### PR TITLE
[Gb200][Test] Skip cr-08be2f796cdaf5015 for test_gb200 as it fails NC…

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -582,6 +582,8 @@ def get_capacity_reservation_id(request, instance_type, region, count, os):
                     and os_platform == reservation.get("InstancePlatform")
                     and reservation.get("AvailableInstanceCount") >= count
                     and reservation.get("State") == "active"
+                    and reservation["CapacityReservationId"] != "cr-08be2f796cdaf5015"
+                    # Skip this Gb200 Capacity Reservation which fails NCCL benchmarks
                 ):
                     reservations_ids.append(
                         {

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_with_subnet_prioritization/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_with_subnet_prioritization/pcluster.config.yaml
@@ -23,16 +23,18 @@ Scheduling:
         SubnetIds:
           - {{ public_subnet_ids[0] }}
           - {{ public_subnet_ids[1] }}
-    - Name: queue2
-      CapacityType: SPOT
-      AllocationStrategy: capacity-optimized-prioritized
-      ComputeResources:
-        - Name: queue2-i1
-          Instances:
-            - InstanceType: {{ instance }}
-          MinCount: 0
-          MaxCount: 10
-      Networking:
-        SubnetIds:
-          - {{ public_subnet_ids[0] }}
-          - {{ public_subnet_ids[1] }}
+# Uncomment for testing SPOT + capacity-optimized-prioritized as EC2 Create Fleet
+#  optimizes capacity first and our priorities are taken on best-effort basis
+#    - Name: queue2
+#      CapacityType: SPOT
+#      AllocationStrategy: capacity-optimized-prioritized
+#      ComputeResources:
+#        - Name: queue2-i1
+#          Instances:
+#            - InstanceType: {{ instance }}
+#          MinCount: 0
+#          MaxCount: 10
+#      Networking:
+#        SubnetIds:
+#          - {{ public_subnet_ids[0] }}
+#          - {{ public_subnet_ids[1] }}


### PR DESCRIPTION
### Description of changes
* Skip cr-08be2f796cdaf5015 for test_gb200 as it fails NCCL benchmarks
* Remove SPOT queue as EC2 will not guarantee the capacity in the Subnet we prioritize. Keeping the queue commented out as it will be quicker to test in case of emergency

### Tests
* test_gb200 with other reservation are passing

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
