### PR TITLE
[Test] OSU: print and save multi NIC benchmark osu_mbw_mr + execute the test using the number of slots of the instance

### DIFF
--- a/tests/integration-tests/tests/common/data/osu/osu_mbw_mr_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_mbw_mr_submit_openmpi.sh
@@ -4,12 +4,13 @@ module load openmpi
 
 BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
+NUM_OF_PROCESSES={{ num_of_processes }}
+NUM_OF_PROCESSES_PER_NODE={{ num_of_processes_per_node }}
 
 env
 
 # Run multiple bandwidth/message rate benchmark
-# NOTE: The test is sized for two P4d compute nodes.
-# -N: number of processes per node (48, 1 for each CPU)
-# -n total number of processes to run (96, all CPUs from 2 nodes)
+# -N: number of processes per node (equal to the number of cores per node; e.g. 48 in a p4d.24xlarge, 96 in a p6-b200.48xlarge)
+# -n total number of processes to run (all cores from 2 nodes; e.g. 96 in a p4d.24xlarge, 192 in a p6-b200.48xlarge)
 # -x FI_EFA_USE_DEVICE_RDMA=1 Enables RDMA support
-mpirun --mca btl_tcp_if_exclude lo -n 96 -N 48 -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out
+mpirun --mca btl_tcp_if_exclude lo -n "${NUM_OF_PROCESSES}" -N "${NUM_OF_PROCESSES_PER_NODE}" -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/common/osu_common.py
+++ b/tests/integration-tests/tests/common/osu_common.py
@@ -92,6 +92,7 @@ def run_individual_osu_benchmark(
         benchmark_name=benchmark_name,
         osu_benchmark_version=OSU_BENCHMARK_VERSION,
         num_of_processes=slots,
+        num_of_processes_per_node=slots_per_instance,
         network_interfaces_count=network_interfaces_count,
     )
     if partition:

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -563,13 +563,19 @@ def get_capacity_reservation_id(request, instance_type, region, count, os):
     reservations_ids = []
     ec2_client = boto3.client("ec2", region_name=region)
     if request.config.getoption("capacity_reservation_id"):
-        capacity_reservation = ec2_client.describe_capacity_reservations(CapacityReservationIds=[request.config.getoption("capacity_reservation_id")])
+        capacity_reservation = ec2_client.describe_capacity_reservations(
+            CapacityReservationIds=[request.config.getoption("capacity_reservation_id")]
+        )
         if capacity_reservation:
             reservations_ids.append(
                 {
-                    "CapacityReservationId": capacity_reservation.get("CapacityReservations", [])[0]["CapacityReservationId"],
+                    "CapacityReservationId": capacity_reservation.get("CapacityReservations", [])[0][
+                        "CapacityReservationId"
+                    ],
                     "TotalInstanceCount": capacity_reservation.get("CapacityReservations", [])[0]["TotalInstanceCount"],
-                    "AvailableInstanceCount": capacity_reservation.get("CapacityReservations", [])[0]["AvailableInstanceCount"],
+                    "AvailableInstanceCount": capacity_reservation.get("CapacityReservations", [])[0][
+                        "AvailableInstanceCount"
+                    ],
                 }
             )
     else:

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -58,7 +58,7 @@ def test_efa(
     max_queue_size = 2
     p6_b200_capacity_reservation_id = None
     if instance == "p6-b200.48xlarge":
-        capacity_reservations_ids = get_capacity_reservation_id(request,instance, region, max_queue_size, os)
+        capacity_reservations_ids = get_capacity_reservation_id(request, instance, region, max_queue_size, os)
         if capacity_reservations_ids:
             p6_b200_capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")
         else:

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -133,6 +133,8 @@ def test_osu(
             remote_command_executor,
             scheduler_commands,
             test_datadir,
+            output_dir,
+            os,
             slots_per_instance,
             network_interfaces_count,
             partition="efa-enabled",
@@ -229,6 +231,8 @@ def _test_osu_benchmarks_multiple_bandwidth(
     remote_command_executor,
     scheduler_commands,
     test_datadir,
+    output_dir,
+    os,
     slots_per_instance,
     network_interfaces_count,
     partition=None,
@@ -252,10 +256,12 @@ def _test_osu_benchmarks_multiple_bandwidth(
         "p6-b200.48xlarge": 160000,
     }
     num_instances = 2
+    mpi_version = "openmpi"
+    benchmark_name = "osu_mbw_mr"
     run_individual_osu_benchmark(
-        "openmpi",
+        mpi_version,
         "mbw_mr",
-        "osu_mbw_mr",
+        benchmark_name,
         partition,
         remote_command_executor,
         scheduler_commands,
@@ -264,8 +270,19 @@ def _test_osu_benchmarks_multiple_bandwidth(
         network_interfaces_count,
         test_datadir,
     )
+
+    output_file = f"/shared/{benchmark_name}.out"
+    output = remote_command_executor.run_remote_command(f"cat {output_file}").stdout
+
+    logging.info(output)
+    write_file(
+        dirname=f"{output_dir}/osu-results",
+        filename=f"{os}-{instance}-{mpi_version}-{benchmark_name}.out",
+        content=output,
+    )
+
     max_bandwidth = remote_command_executor.run_remote_command(
-        "cat /shared/osu_mbw_mr.out | tail -n +4 | awk '{print $2}' | sort -n | tail -n 1"
+        f"cat {output_file} | tail -n +4 | awk '{{print $2}}' | sort -n | tail -n 1"
     ).stdout
 
     expected_bandwidth = instance_bandwidth_dict.get(instance)

--- a/tests/integration-tests/tests/ultraserver/test_gb200.py
+++ b/tests/integration-tests/tests/ultraserver/test_gb200.py
@@ -41,7 +41,11 @@ FAKE_IPS = ["0.0.0.0"] * 9
 def submit_job_imex_status(rce: RemoteCommandExecutor, queue: str, max_nodes: int = 1, ignore_imex_check: bool = False):
     logging.info("Submitting job to check IMEX status")
     slurm = SlurmCommands(rce)
-    job_command = "/opt/parallelcluster/shared/nvidia-imex-status.job ignore-imex-check" if ignore_imex_check else "/opt/parallelcluster/shared/nvidia-imex-status.job"
+    job_command = (
+        "/opt/parallelcluster/shared/nvidia-imex-status.job ignore-imex-check"
+        if ignore_imex_check
+        else "/opt/parallelcluster/shared/nvidia-imex-status.job"
+    )
     job_id = slurm.submit_command_and_assert_job_accepted(
         submit_command_args={
             "command": job_command,


### PR DESCRIPTION
### Description of changes
1. Print and save multi NIC benchmark osu_mbw_mr.
We need to have a datapoint about bandwidth for B200 to check if we are able through OSU to validate the expected bandwidth performance, 3200Gbps
1. The test had hard wired values for p4d.24xlarge. We made those values dynamic, according to the specifics of the instance type.
1. Fixed code linter findings.

### Tests
SUCCEEDED `test_osu`. Also verified that the output is printed on test logs and it is saved as file to the test output folder.

Sample output:

```
# OSU MPI Multiple Bandwidth / Message Rate Test v5.7.1
# [ pairs: 48 ] [ window size: 64 ]
# Size                  MB/s        Messages/s
1                      58.09       58086503.51
2                     115.00       57500814.69
4                     229.47       57367514.56
8                     442.76       55344560.42
16                    884.75       55296951.11
32                   1763.03       55094788.32
64                   3508.74       54824052.63
128                  6968.58       54442003.14
256                 14033.56       54818583.86
512                 26968.05       52671979.93
1024                51844.46       50629356.52
2048                99357.09       48514205.09
4096               168173.26       41057925.89
8192               215059.30       26252355.73
16384              213072.29       13004900.33
32768              209000.12        6378177.46
65536              199804.18        3048769.90
131072             211502.83        1613638.55
262144             193180.05         736923.43
524288             191493.00         365243.91
1048576            234770.08         223894.20
2097152            234653.43         111891.47
4194304            235056.18          56041.76
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
