### PR TITLE
[SubnetPrioritization][Test] Remove SPOT queue2 from test

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -254,7 +254,7 @@ def test_cluster_with_subnet_prioritization(
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     public_subnets = vpc_stack.get_all_public_subnets()
-    queues = ["queue1", "queue2"]
+    queues = ["queue1"]
     logging.info(f"Public subnets: {public_subnets}")
     # Check that all instances are launched in the subnet with the highest priority
     for queue in queues:


### PR DESCRIPTION
### Description of changes
* [SubnetPrioritization][Test] Remove SPOT queue2 from test which was removed in https://github.com/aws/aws-parallelcluster/pull/7034



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
