### PR TITLE
[integ-tests] Avoid rerunning long tests to reduce overall test running time

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -45,6 +45,12 @@ from tests.common.utils import (
 )
 
 
+class ImageNotFound(Exception):
+    """Exception when image is not found."""
+
+    pass
+
+
 @pytest.mark.usefixtures("instance")
 def test_invalid_config(
     region,
@@ -95,6 +101,7 @@ def test_invalid_config(
     assert_that(suppressed.message).contains("Request would have succeeded")
 
 
+@pytest.mark.flaky(only_rerun=["ImageNotFound"])
 @pytest.mark.usefixtures("scheduler")
 def test_build_image(
     region,
@@ -419,6 +426,8 @@ def _test_image_tag_and_volume(image):
         .get("Images")
     )
     logging.info(f"Image List: {image_list}, length {len(image_list)}")
+    if not image_list:
+        raise ImageNotFound()
     assert_that(len(image_list)).is_equal_to(1)
 
     created_image = image_list[0]

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -33,6 +33,7 @@ OSU_BENCHMARKS_INSTANCES = ["c5n.18xlarge", "p5en.48xlarge", "p6-b200.48xlarge"]
 
 
 @pytest.mark.usefixtures("serial_execution_by_instance")
+@pytest.mark.flaky(reruns=0)
 def test_osu(
     os,
     region,

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -58,6 +58,7 @@ def calculate_observed_value(result, remote_command_executor, scheduler_commands
 
 
 @pytest.mark.usefixtures("serial_execution_by_instance")
+@pytest.mark.flaky(reruns=0)
 def test_starccm(
     vpc_stack,
     instance,
@@ -108,8 +109,9 @@ def test_starccm(
         instance_slots = fetch_instance_slots(region, instance, multithreading_disabled=True)
         run_command = f'sbatch --ntasks={num_of_nodes * instance_slots} starccm.slurm.sh "{podkey}" "{licpath}"'
         multiple_runs = []
-        # Run at least twice up to whatever parallelism allows to maximize usage of available nodes
-        number_of_runs = max(parallelism, 2)
+        # Run at least four times up to whatever parallelism allows to maximize usage of available nodes
+        # Running the test multiple times reduces and get the average value improves stability of the result.
+        number_of_runs = max(parallelism, 4)
         for _ in range(number_of_runs):
             multiple_runs.append(remote_command_executor.run_remote_command(run_command))
         for run in multiple_runs:


### PR DESCRIPTION
### Description of changes
StarCCM: add iterations within a single test run to get more stable performance result and remove overall rerun 
OSU: remove overall rerun
StarCCM and OSU rerun prolong the running time of the whole integration tests suite because they are run in serial because they share the same c5n.18xlarge capacity reservation. build-image: only rerun if image build fails. If the subsequent cluster creation fails, avoid rerun. The cluster creation failure is rare but the rerun significantly prolong the job running time

### Tests
* The following tests have finished running (there are failures related to performance, insufficient capacity. But no failures related to this PR)
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  create:
    test_create.py::test_create_imds_secured:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
  performance_tests:
    test_osu.py::test_osu:
      dimensions:
        - regions: [ {{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_2_HOURS_YESPG_NO_ROCKY_OS_X86_0 }} ]
          instances: [ "c5n.18xlarge" ]
          oss: [ {{ NO_ROCKY_OS_X86_0 }} ] # ParallelCluster does not release official Rocky images. Skip the test.
          schedulers: [ "slurm" ]
    test_starccm.py::test_starccm:
      dimensions:
        - regions: [ {{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_2_HOURS_YESPG_NO_ROCKY_OS_X86_0 }} ]
          instances: [ "c5n.18xlarge" ]
          oss: [ {{ NO_ROCKY_OS_X86_0 }} ] # ParallelCluster does not release official Rocky images. Skip the test.
          schedulers: [ "slurm" ]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
