### PR TITLE
[integ-tests-framework] Fix a bug that the same CIDR is used by two subnets

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -343,7 +343,7 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
         ):
             # Subnets visual representation:
             # http://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=16&division=7.70
-            index = len(az_id_name_dict) + index - 1
+            index = len(az_id_name_dict) + index
             subnets.append(
                 SubnetConfig(
                     name=subnet_name(visibility="Public", az_id=az_id),


### PR DESCRIPTION
### Description of changes
* This commit fixes a bug from https://github.com/aws/aws-parallelcluster/pull/7046

### Tests
* Test is running in DFW local zone

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
