### PR TITLE
Fix test_slurm_accounting InvalidParameter error

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -25,7 +25,9 @@ Scheduling:
       ComputeResources:
         - Name: cit
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: m5.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
@@ -26,7 +26,9 @@ Scheduling:
       ComputeResources:
         - Name: cit
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: m5.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 0
           MaxCount: 12
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -25,9 +25,7 @@ Scheduling:
           MaxCount: 10
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -18,7 +18,9 @@ Scheduling:
       ComputeResources:
         - Name: cit
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: m5.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:


### PR DESCRIPTION
### Description of changes
* Fix test_slurm_accounting InvalidParameter error by using a database vpc subnet for compute nodes
* Add multiple instance types

### Tests
* ran test_slurm_accounting

### References
* Revert: https://github.com/aws/aws-parallelcluster/pull/7031

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
