### PR TITLE
Revert "Using Pseudo Function to get Service URL Domain (#6632)"

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -359,7 +359,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: ec2.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -170,7 +170,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: ec2.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
@@ -189,7 +189,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: ec2.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -59,7 +59,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:
@@ -105,7 +105,7 @@ Resources:
                 Condition:
                   StringEquals:
                     iam:PassedToService:
-                      - !Sub ec2.${AWS::URLSuffix}
+                      - !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
               - Action:
                   - ec2:DescribeInstances
                   - ec2:DescribeInstanceStatus
@@ -147,7 +147,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:
@@ -235,7 +235,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: !If [ GovCloud, 'ec2.amazonaws-us-gov.com', !If [ China, 'ec2.amazonaws.cn', 'ec2.amazonaws.com']]
         Version: '2012-10-17'
       Path: /parallelcluster/
       ManagedPolicyArns:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
@@ -73,7 +73,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: !Sub ec2.${AWS::URLSuffix}
+              Service: ec2.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore


### PR DESCRIPTION
### Description of changes

This reverts commit 28330be1b52c8243b0b3c21f761abccb4061efa4.

This is to unblock Isolated region testing 
3.13 -> https://github.com/aws/aws-parallelcluster/pull/6946/files


### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
