### PR TITLE
[Test] Add new setting to be injected into cluster config for tests: `flexible_instance_types` to facilitate the mitigation of ICEs in tests. 

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -79,6 +79,7 @@ from utils import (
     get_instance_info,
     get_metadata,
     get_network_interfaces_count,
+    get_similar_instance_types,
     get_vpc_snakecase_value,
     random_alphanumeric,
     to_pascal_case,
@@ -634,6 +635,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, a
         default_values = _get_default_template_values(vpc_stack, request)
         inject_internal_storage_settings(kwargs)
         inject_placement_group_settings(vpc_stack, instance, kwargs)
+        inject_flexible_instance_types_settings(instance, region, kwargs)
         file_loader = FileSystemLoader(str(test_datadir))
         env = SandboxedEnvironment(loader=file_loader)
         rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
@@ -656,6 +658,9 @@ def inject_placement_group_settings(vpc_stack, instance, kwargs):
     if vpc_stack.az_override:
         kwargs["capacity_reservation_framework_placement_group"] = f"{instance}_placement_group_{vpc_stack.az_override}"
 
+
+def inject_flexible_instance_types_settings(instance, region, kwargs):
+    kwargs["flexible_instance_types"] = list({instance, *get_similar_instance_types(instance, region, 5)})
 
 def inject_additional_image_configs_settings(image_config, request):
     with open(image_config, encoding="utf-8") as conf_file:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -34,7 +34,9 @@ Scheduling:
           DesiredvCpus: 4
           {% else %}
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           {% endif %}
       Networking:
@@ -49,7 +51,9 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           MaxCount: 1
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -23,12 +23,16 @@ Scheduling:
         - Name: compute-resource-0
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
-            - {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -995,3 +995,57 @@ def get_free_tier_instance_types(region: str = None):
 
 def or_regex(items: list):
     return "|".join(map(re.escape, items))
+
+
+def get_similar_instance_types(instance_type: str, region: str = None, max_items: int = None):
+    ec2 = boto3.client('ec2', region_name=region)
+
+    # First, get the target instance details to use as filter criteria
+    target_response = ec2.describe_instance_types(
+        InstanceTypes=[instance_type]
+    )
+
+    if not target_response['InstanceTypes']:
+        return []
+
+    target = target_response['InstanceTypes'][0]
+    target_arch = target['ProcessorInfo']['SupportedArchitectures'][0]
+    target_vcpus = target['VCpuInfo']['DefaultVCpus']
+    target_threads = target['VCpuInfo']['DefaultThreadsPerCore']
+    target_has_efa = target.get('NetworkInfo', {}).get('EfaSupported', False)
+    target_has_gpu = 'GpuInfo' in target
+
+    # Now query for similar instances using filters
+    paginator = ec2.get_paginator('describe_instance_types')
+    similar_instances = []
+
+    for page in paginator.paginate(
+            Filters=[
+                {
+                    'Name': 'processor-info.supported-architecture',
+                    'Values': [target_arch]
+                },
+                {
+                    'Name': 'vcpu-info.default-vcpus',
+                    'Values': [str(target_vcpus)]
+                },
+                {
+                    'Name': 'vcpu-info.default-threads-per-core',
+                    'Values': [str(target_threads)]
+                }
+            ],
+            PaginationConfig={'MaxItems': max_items} if max_items else {}
+    ):
+        # Filter for EFA support and GPU presence here
+        for instance in page['InstanceTypes']:
+            instance_has_efa = instance.get('NetworkInfo', {}).get('EfaSupported', False)
+            instance_has_gpu = 'GpuInfo' in instance
+            if instance_has_efa == target_has_efa and instance_has_gpu == target_has_gpu:
+                similar_instances.append(instance['InstanceType'])
+
+        # Check if we've reached max_items
+        if max_items and len(similar_instances) >= max_items:
+            similar_instances = similar_instances[:max_items]
+            break
+
+    return similar_instances


### PR DESCRIPTION
### Description of changes
Add new setting to be injected into cluster config for tests: `flexible_instance_types` to facilitate the mitigation of ICEs in tests.  Such new setting contains the list of instance types equivalent to the instance type selected for the tests. 
We can use this new setting to easily use flexible instance types for testing.

Using such new setting in `test_ebs` and `test_fsx_lustre_configuration_options`.

Two instance types are considered equivalent if the have the same:
1. architecture
2. number of default vCPUs
3. number of default threads per core
4. EFA support
5. GPU support (not same GPU, but have or not a GPU)

#### Developer Experience
When you set the `instance` dimension for a test, the test framework retrieves for that instance type a list of equivalent instance types in the same region and exposes a new setting for cluster config: `flexible_instance_types`, trhat can be used this way in cluster configs:

```
Scheduling:
  Scheduler: slurm
  SlurmQueues
    - Name: queue-0
      ComputeResources:
        - Name: compute-resource-0
          Instances:
            {% for instance_type in flexible_instance_types %}
            - InstanceType: {{ instance_type }}
            {% endfor %}
```

### Tests
* SUCCEEDED `test_ebs`
* SUCCEEDED `test_fsx_lustre_configuration_options`

Verified that when such tests are executed with `instance=c5.xlarge`, the following configuration is created:

```
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - ComputeResources:
    - Instances:
      - InstanceType: c5.xlarge
      - InstanceType: r6a.xlarge
      - InstanceType: m6id.xlarge
      - InstanceType: r6i.xlarge
      - InstanceType: c6in.xlarge
      - InstanceType: m5d.xlarge
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
