### PR TITLE
[ImageBuilder] Quote S3 URLs to prevent bash from splitting presigned URLs on `&` during source

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -68,14 +68,14 @@ phases:
               
               # Output all variables to persistent location
               mkdir -p /opt/parallelcluster
-              echo "OS=$OS" > /opt/parallelcluster/system_info
-              echo "PLATFORM=$PLATFORM" >> /opt/parallelcluster/system_info
-              echo "RELEASE=$RELEASE" >> /opt/parallelcluster/system_info
-              echo "VERSION_ID=$VERSION_ID" >> /opt/parallelcluster/system_info
-              echo "COOKBOOK_URL=$COOKBOOK_URL" >> /opt/parallelcluster/system_info
-              echo "CINC_URL=$CINC_URL" >> /opt/parallelcluster/system_info
-              echo "COOKBOOK_NAME=$COOKBOOK_NAME" >> /opt/parallelcluster/system_info
-              echo "KERNEL_PACKAGES_PREFIX=$KERNEL_PACKAGES_PREFIX" >> /opt/parallelcluster/system_info
+              echo "OS='$OS'" > /opt/parallelcluster/system_info
+              echo "PLATFORM='$PLATFORM'" >> /opt/parallelcluster/system_info
+              echo "RELEASE='$RELEASE'" >> /opt/parallelcluster/system_info
+              echo "VERSION_ID='$VERSION_ID'" >> /opt/parallelcluster/system_info
+              echo "COOKBOOK_URL='$COOKBOOK_URL'" >> /opt/parallelcluster/system_info
+              echo "CINC_URL='$CINC_URL'" >> /opt/parallelcluster/system_info
+              echo "COOKBOOK_NAME='$COOKBOOK_NAME'" >> /opt/parallelcluster/system_info
+              echo "KERNEL_PACKAGES_PREFIX='$KERNEL_PACKAGES_PREFIX'" >> /opt/parallelcluster/system_info
 
       - name: PinVersion
         action: ExecuteBash


### PR DESCRIPTION
### Description of changes
* Quote S3 URLs to prevent bash from splitting presigned URLs on `&` during source

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
