### PR TITLE
[Test] Improve the fixture that retrieves equivalent instance types to prevent cluster creation failures.

### DIFF
--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1024,7 +1024,6 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
             {"Name": "vcpu-info.default-vcpus", "Values": [str(target_vcpus)]},
             {"Name": "vcpu-info.default-threads-per-core", "Values": [str(target_threads)]},
         ],
-        PaginationConfig={"MaxItems": max_items} if max_items else {},
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
@@ -1037,10 +1036,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
                 and instance_inference_accelerators == target_inference_accelerators
             ):
                 similar_instances.append(instance["InstanceType"])
-
-        # Check if we've reached max_items
-        if max_items and len(similar_instances) >= max_items:
-            similar_instances = similar_instances[:max_items]
-            break
+                if max_items and len(similar_instances) >= max_items:
+                    return similar_instances
 
     return similar_instances

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1012,6 +1012,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     target_threads = target["VCpuInfo"]["DefaultThreadsPerCore"]
     target_has_efa = target.get("NetworkInfo", {}).get("EfaSupported", False)
     target_has_gpu = "GpuInfo" in target
+    target_inference_accelerators = target.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
 
     # Now query for similar instances using filters
     paginator = ec2.get_paginator("describe_instance_types")
@@ -1025,11 +1026,16 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
         ],
         PaginationConfig={"MaxItems": max_items} if max_items else {},
     ):
-        # Filter for EFA support and GPU presence here
+        # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
             instance_has_gpu = "GpuInfo" in instance
-            if instance_has_efa == target_has_efa and instance_has_gpu == target_has_gpu:
+            instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
+            if (
+                instance_has_efa == target_has_efa
+                and instance_has_gpu == target_has_gpu
+                and instance_inference_accelerators == target_inference_accelerators
+            ):
                 similar_instances.append(instance["InstanceType"])
 
         # Check if we've reached max_items


### PR DESCRIPTION
### Description of changes
Improve the fixture that retrieves equivalent instance types by adding the condition to have the same inference accelerators to prevent cluster creation failures.

Without this change it may happen that the fixture considers equivalent two instance types that have different inference accelerators leading to cluster creation failures like the one below:

```
E                       	* ERROR - InstancesAcceleratorsValidator:
E                       		Instance types listed under Compute Resource compute-resource-0 must have the same number of Inference Accelerators ({'c5.xlarge': 0, 'inf1.xlarge': 1}).
E                       	* ERROR - InstancesAcceleratorsValidator:
E                       		Instance types listed under Compute Resource compute-resource-0 must have the same inference accelerator manufacturer ({'c5.xlarge': '', 'inf1.xlarge': 'AWS'}).
```

With this change this failure does not occur anymore.

#### Other Minor Changes
1. improved the logic by preventing unnecessary iterations on the paginated results and using the default page size.
2. Disabled Flake8 rule B042 as it is a minor thing and it is also affected by false positiveness https://github.com/PyCQA/flake8-bugbear/issues/525




### Tests
* SUCCEEDED `test_ebs_single ` in us-gov-east-1 where the fixture used to raise the above error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
