### PR TITLE
Increase time waiting for build image stack to delete

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -200,7 +200,7 @@ def test_build_image(
     _test_cluster_creation(
         image.ec2_image_id, pcluster_config_reader, region, clusters_factory, scheduler_commands_factory
     )
-    _assert_build_image_stack_deleted(image.image_id, region, 600, 30)
+    _assert_build_image_stack_deleted(image.image_id, region, 900, 30)
 
 
 def _test_cluster_creation(image_id, pcluster_config_reader, region, clusters_factory, scheduler_commands_factory):


### PR DESCRIPTION
### Description of changes
* Increase time waiting for build image stack to delete
* We get sporadic test_build_image failures due to a timeout when deleting the image stack


### Tests
* Ran test_build_image


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
