### PR TITLE
Remove kernel version from held packages

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -249,7 +249,7 @@ phases:
                 [[ $OS =~ rocky ]] && yum versionlock delete rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock delete redhat-release
               else
-                apt-mark unhold linux-aws* linux-base* linux-headers* linux-image* linux-modules-extra*
+                apt-mark unhold linux-aws linux-base linux-headers-aws linux-image-aws linux-modules-extra-aws
               fi
               
               # Handle SSM agent

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -129,7 +129,7 @@ phases:
                 [[ $OS =~ rhel ]] && yum versionlock redhat-release
               else
                 apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
-                apt-mark hold linux-aws-$(uname -r)* linux-base-$(uname -r)* linux-headers-$(uname -r)* linux-image-$(uname -r)* linux-modules-extra-$(uname -r)*
+                apt-mark hold linux-aws linux-base linux-headers-aws linux-image-aws linux-modules-extra-aws
               fi
               echo "Kernel version is $(uname -a)"
 


### PR DESCRIPTION
### Description of changes
* Remove kernel version from held packages
* Only holding the main packages without kernel versions stop any updates to the kernel from occuring.

```
root@ip-172-31-36-50:~# apt-mark showhold
linux-aws
linux-base
linux-headers-aws
linux-image-aws
root@ip-172-31-36-50:~# apt-get install linux-headers-aws
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 linux-aws : Depends: linux-headers-aws (= 6.2.0.1017.17~22.04.1) but 6.8.0-1040.42~22.04.1 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

### Tests
* Build image and test behaviour on an instance.
Before this change, we pinned the specific package version (like `linux-image-6.8.0-1017-aws`). This means that the main `linux-image-aws` package could still be updated. 
This change pin the non kernel specific packages (like `linux-image-aws`) so that upgrading to the new kernel is properly blocked. The version that the non kernel specific packages are is the version of the running kernel. So this change ensures that the running kernel can not be updated. 
This behavior was tested on an instance where I pinned the packages, and tested trying to upgrade them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
