### PR TITLE
[CodeStyle] Addressing code linter errors

### DIFF
--- a/cli/.flake8
+++ b/cli/.flake8
@@ -21,7 +21,10 @@ ignore =
     # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
     # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
     B028,
-    T499
+    T499,
+    # B042: Exception class with `__init__` should pass all args to `super().__init__()` in order to work with `copy.copy()`.
+    # Affected by false positive, https://github.com/PyCQA/flake8-bugbear/issues/525
+    B042
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D202 No blank lines allowed after function docstring

--- a/cli/.pylintrc
+++ b/cli/.pylintrc
@@ -36,10 +36,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/cli/src/pcluster/api/models/dryrun_operation_exception_response_content.py
+++ b/cli/src/pcluster/api/models/dryrun_operation_exception_response_content.py
@@ -65,7 +65,8 @@ class DryrunOperationExceptionResponseContent(Model):
     def validation_messages(self):
         """Gets the validation_messages of this DryrunOperationExceptionResponseContent.
 
-        List of messages collected during cluster config validation whose level is lower than the 'validationFailureLevel' set by the user.  # noqa: E501
+        List of messages collected during cluster config validation whose level is lower
+        than the 'validationFailureLevel' set by the user.  # noqa: E501
 
         :return: The validation_messages of this DryrunOperationExceptionResponseContent.
         :rtype: List[ConfigValidationMessage]
@@ -76,7 +77,8 @@ class DryrunOperationExceptionResponseContent(Model):
     def validation_messages(self, validation_messages):
         """Sets the validation_messages of this DryrunOperationExceptionResponseContent.
 
-        List of messages collected during cluster config validation whose level is lower than the 'validationFailureLevel' set by the user.  # noqa: E501
+        List of messages collected during cluster config validation whose level is lower
+        than the 'validationFailureLevel' set by the user.  # noqa: E501
 
         :param validation_messages: The validation_messages of this DryrunOperationExceptionResponseContent.
         :type validation_messages: List[ConfigValidationMessage]

--- a/cli/src/pcluster/api/models/log_stream.py
+++ b/cli/src/pcluster/api/models/log_stream.py
@@ -181,7 +181,8 @@ class LogStream(Model):
     def last_event_timestamp(self):
         """Gets the last_event_timestamp of this LogStream.
 
-        The time of the last event of the stream. The lastEventTime value updates on an eventual consistency basis. It typically updates in less than an hour from ingestion, but in rare situations might take longer.  # noqa: E501
+        The time of the last event of the stream. The lastEventTime value updates on an eventual consistency basis.
+        It typically updates in less than an hour from ingestion, but in rare situations might take longer.
 
         :return: The last_event_timestamp of this LogStream.
         :rtype: datetime
@@ -192,7 +193,8 @@ class LogStream(Model):
     def last_event_timestamp(self, last_event_timestamp):
         """Sets the last_event_timestamp of this LogStream.
 
-        The time of the last event of the stream. The lastEventTime value updates on an eventual consistency basis. It typically updates in less than an hour from ingestion, but in rare situations might take longer.  # noqa: E501
+        The time of the last event of the stream. The lastEventTime value updates on an eventual consistency basis.
+        It typically updates in less than an hour from ingestion, but in rare situations might take longer.
 
         :param last_event_timestamp: The last_event_timestamp of this LogStream.
         :type last_event_timestamp: datetime

--- a/cli/src/pcluster/cli/commands/cluster_logs.py
+++ b/cli/src/pcluster/cli/commands/cluster_logs.py
@@ -82,7 +82,7 @@ class ExportClusterLogsCommand(ExportLogsCommand, CliCommand):
             return self._export_cluster_logs(args, args.output_file)
         except Exception as e:
             utils.error(f"Unable to export cluster's logs.\n{e}")
-            return None
+            return None  # pylint: disable=unreachable
 
     @staticmethod
     def _export_cluster_logs(args: Namespace, output_file: str = None):

--- a/cli/src/pcluster/cli/commands/image_logs.py
+++ b/cli/src/pcluster/cli/commands/image_logs.py
@@ -74,7 +74,7 @@ class ExportImageLogsCommand(ExportLogsCommand, CliCommand):
             return self._export_image_logs(args, args.output_file)
         except Exception as e:
             utils.error(f"Unable to export image's logs.\n{e}")
-            return None
+            return None  # pylint: disable=unreachable
 
     @staticmethod
     def _export_image_logs(args: Namespace, output_file: str = None):

--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -31,7 +31,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _ssh(args, extra_args):
-    # pylint: disable=import-outside-toplevel
+    # FIXME we should remove the dependency to pipes as it is deprecated (pointed out by PyLint deprecated-module).
+    # pylint: disable=import-outside-toplevel,deprecated-module
     """
     Execute an SSH command to the head node instance, according to the [aliases] section if there.
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1361,7 +1361,7 @@ class LoginNodesNetworking(_BaseNetworking, SubnetsMixin):
     @property
     def is_subnet_public(self):
         """Get if the subnet is public or private."""
-        return AWSApi.instance().ec2.is_subnet_public(self.subnet_ids[0])
+        return AWSApi.instance().ec2.is_subnet_public(self.subnet_ids[0])  # pylint: disable=unsubscriptable-object
 
 
 class LoginNodesPool(Resource):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -8,6 +8,8 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+# FIXME
+# pylint: disable=invalid-name
 from enum import Enum
 
 PCLUSTER_NAME_MAX_LENGTH = 60

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -76,7 +76,7 @@ from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from pcluster.utils import datetime_to_epoch, generate_random_name_with_prefix, get_installed_version, get_partition
 from pcluster.validators.common import FailureLevel, ValidationResult
 
-ImageBuilderStatusMapping = {
+ImageBuilderStatusMapping = {  # pylint: disable=invalid-name
     "BUILD_IN_PROGRESS": [
         "CREATE_IN_PROGRESS",
         "UPDATE_IN_PROGRESS",

--- a/cli/src/pcluster/templates/cdk_artifacts_manager.py
+++ b/cli/src/pcluster/templates/cdk_artifacts_manager.py
@@ -153,7 +153,7 @@ class CDKArtifactsManager:
                     "content": asset_file_content,
                 }
             )
-            LOGGER.info(f"Uploading asset {asset_id} to S3")
+            LOGGER.info("Uploading asset %s to S3", asset_id)
 
             bucket.upload_cfn_asset(
                 asset_file_content=asset_file_content, asset_name=asset_id, format=S3FileFormat.MINIFIED_JSON


### PR DESCRIPTION
### Description of changes
Addressing code linter errors by fixing some lines and ignoring some minor rules.
Changes that are worth mentioning:
1. ignore Flake8   rule B042 as it is a minor, and it is also affected by false positiveness https://github.com/PyCQA/flake8-bugbear/issues/525.
2. ignore the rule `unreachable-code` in cluster_logs.py and image_logs.py because that is not really an unreachable code (bad thing), but a redundant return statement (minor thing). Removing the return statement would trigger a much worse linter error 'inconsistent-return-statements'. This situation is kind of a red flag for this piece of code in terms of code style, but the refactoring is not worth it.
3. ignore the rule `invalid-name` trigger by some names of constants because the refactoring is not worth it.
4. ignore the rule `unsubscriptable-object` on a specific line because it is a false positive.


### Tests
* PR checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
