### PR TITLE
[Test] Wrap the DRA check with retry.

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -375,6 +375,7 @@ def test_efs_correctly_mounted(remote_command_executor, mount_dir, tls=False, ia
             assert_that(result.stdout).matches(rf".* {mount_dir} efs _netdev,noresvport 0 0")
 
 
+@retry(wait_fixed=seconds(15), stop_max_delay=seconds(60))
 def check_dra(
     cluster,
     region,


### PR DESCRIPTION
### Description of changes
Wrap the DRA check with retry to mitigate transient issues caused by DRA sync latencies.
The check executes some FSx calls and verifies that the expected file has been made available by the DRA.
The observed failure is on the file existence check, so in theory it could be enough to wrap with a retry only that specific line.
However, to mitigate also potential failures caused by the other calls made by the check, I preferred to wrap the whole logic, which is in any case very short.

### Tests
1. `test_fsx_lustre_dra` SUCCEEDED

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
