### PR TITLE
[Dependencies] Constraint flask to version ~=3.1.0 (rather than ~=3.0) to reduce the risk of breaking changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
 **CHANGES**
 - Add validator that warns against the downsides of disabling in-place updates on compute and login nodes through DevSettings.
 - Upgrade Connexion to ~=2.15.1 (from ~=2.13.0).
-- Upgrade Flask to ~=3.0 (from >=2.2.5,<2.3).
+- Upgrade Flask to ~=3.1.0 (from >=2.2.5,<2.3).
 - Upgrade Werkzeug to ~=3.1 (from ~=2.0) to address [CVE-2024-34069](https://nvd.nist.gov/vuln/detail/cve-2024-34069).
 
 **BUG FIXES**

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -24,5 +24,5 @@ PyYAML>=5.3.1,!=5.4
 tabulate>=0.8.8,<=0.8.10
 connexion~=2.15.1
 werkzeug~=3.1
-flask~=3.0
+flask~=3.1.0
 packaging~=25.0

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -51,7 +51,7 @@ REQUIRES = [
     "jmespath~=0.10",
     "jsii==1.85.0",
     "werkzeug~=3.1",
-    "flask~=3.0",
+    "flask~=3.1.0",
     "packaging~=25.0",
 ]
 


### PR DESCRIPTION
### Description of changes
Constraint flask to version ~=3.1.0 (rather than ~=3.0) to reduce the risk of breaking changes.

According to Flask release notes, there may be breaking changes in minor releases. See release notes for [3.1.0](https://github.com/pallets/flask/releases/tag/3.1.0).

Constraining to 3.1.x is also suggested by Dependabot in https://github.com/aws/aws-parallelcluster/pull/6568 and it is consistent with the approach we applied before the recent upgrade in https://github.com/aws/aws-parallelcluster/pull/6932. In fact, before that change we used to constraint to the minor (flask>=2.2.5,<2.3).

### Tests
This change does not alter the version of Flask tested in https://github.com/aws/aws-parallelcluster/pull/6932 (i.e. 3.1.2), but simply limit future updates within the same minor. No additional test required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
