### PR TITLE
[Dependencies] Upgrade Upgrade jmespath to ~=1.0 (from ~=0.10). Upgrade tabulate to <=0.9.0 (from <=0.8.10).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
 - Upgrade Connexion to ~=2.15.1 (from ~=2.13.0).
 - Upgrade Flask to ~=3.1.0 (from >=2.2.5,<2.3).
 - Upgrade Werkzeug to ~=3.1 (from ~=2.0) to address [CVE-2024-34069](https://nvd.nist.gov/vuln/detail/cve-2024-34069).
+- Upgrade jmespath to ~=1.0 (from ~=0.10).
+- Upgrade tabulate to <=0.9.0 (from <=0.8.10).
 
 **BUG FIXES**
 - Reduce EFA installation time for Ubuntu by ~20 minutes by only holding kernel packages for the installed kernel.

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -17,11 +17,11 @@ aws_cdk.aws-cloudwatch~=1.164
 aws_cdk.aws-lambda~=1.164
 boto3>=1.39.4
 jinja2~=3.0
-jmespath~=0.10
+jmespath~=1.0
 jsii==1.85.0
 marshmallow~=3.10
 PyYAML>=5.3.1,!=5.4
-tabulate>=0.8.8,<=0.8.10
+tabulate>=0.8.8,<=0.9.0
 connexion~=2.15.1
 werkzeug~=3.1
 flask~=3.1.0

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -25,7 +25,7 @@ CDK_VERSION = "1.164"
 REQUIRES = [
     "setuptools",
     "boto3>=1.39.4",
-    "tabulate>=0.8.8,<=0.8.10",
+    "tabulate>=0.8.8,<=0.9.0",
     "PyYAML>=5.3.1,!=5.4",
     "jinja2~=3.0",
     "marshmallow~=3.10",
@@ -48,7 +48,7 @@ REQUIRES = [
     "aws-cdk.aws-sqs~=" + CDK_VERSION,
     "aws-cdk.aws-cloudformation~=" + CDK_VERSION,
     "connexion~=2.15.1",
-    "jmespath~=0.10",
+    "jmespath~=1.0",
     "jsii==1.85.0",
     "werkzeug~=3.1",
     "flask~=3.1.0",


### PR DESCRIPTION
### Description of changes
Upgrade Upgrade jmespath to ~=1.0 (from ~=0.10). Upgrade tabulate to <=0.9.0 (from <=0.8.10).
These upgrades are nice to have suggested by Dependabot.
See https://github.com/aws/aws-parallelcluster/pull/5608 and https://github.com/aws/aws-parallelcluster/pull/5139

### Tests
1. PR checks
2. Manually validated jmespath with a simple query
```
pip freeze | grep jmespath
jmespath==1.0.1

pcluster list-clusters --region us-east-1 --query 'clusters[0].clusterName'
"additionalres-3140-3"
```
3. Manually validated tabulate verifying that `pcluster configure` is able to print allowed values:
```
pip freeze | grep tabulate                      
tabulate==0.9.0

pcluster configure --config ~/sample-config.yaml
INFO: Configuration file /Users/mgiacomo/sample-config.yaml will be written.
Press CTRL-C to interrupt the procedure.


Allowed values for AWS Region ID:
1. af-south-1
2. ap-east-1
3. ap-northeast-1

...omitted values...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
