### PR TITLE
Add GetFunction and GetPolicy permissions to the build image cleanup role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Reduce EFA installation time for Ubuntu by ~20 minutes by only holding kernel packages for the installed kernel.
+- Add GetFunction and GetPolicy permissions to PClusterBuildImageCleanupRole to prevent AccessDenied errors during build image stack deletion.
 
 3.14.1
 ------

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -343,7 +343,7 @@ PCLUSTER_BUCKET_REQUIRED_BOOTSTRAP_FEATURES = ["basic", "export-logs"]
 
 PCLUSTER_BUILD_IMAGE_CLEANUP_ROLE_PREFIX = "PClusterBuildImageCleanupRole"
 # Tag key & expected revision (increment when policy widens)
-PCLUSTER_BUILD_IMAGE_CLEANUP_ROLE_REVISION = 1
+PCLUSTER_BUILD_IMAGE_CLEANUP_ROLE_REVISION = 2
 PCLUSTER_BUILD_IMAGE_CLEANUP_ROLE_BOOTSTRAP_TAG_KEY = "parallelcluster:build-image-cleanup-role-bootstrapped"
 
 P6E_GB200 = "p6e-gb200"

--- a/cli/src/pcluster/imagebuilder_utils.py
+++ b/cli/src/pcluster/imagebuilder_utils.py
@@ -140,7 +140,7 @@ def _expected_inline_policy(account_id: str, partition: str):
                 {"Action": "ec2:CreateTags", "Resource": f"arn:{partition}:ec2:*::image/*", "Effect": "Allow"},
                 {"Action": "tag:TagResources", "Resource": "*", "Effect": "Allow"},
                 {
-                    "Action": ["lambda:DeleteFunction", "lambda:RemovePermission"],
+                    "Action": ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"],
                     "Resource": f"arn:{partition}:lambda:*:{account_id}:function:ParallelClusterImage-*",
                     "Effect": "Allow",
                 },

--- a/cli/src/pcluster/imagebuilder_utils.py
+++ b/cli/src/pcluster/imagebuilder_utils.py
@@ -140,7 +140,12 @@ def _expected_inline_policy(account_id: str, partition: str):
                 {"Action": "ec2:CreateTags", "Resource": f"arn:{partition}:ec2:*::image/*", "Effect": "Allow"},
                 {"Action": "tag:TagResources", "Resource": "*", "Effect": "Allow"},
                 {
-                    "Action": ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"],
+                    "Action": [
+                        "lambda:DeleteFunction",
+                        "lambda:RemovePermission",
+                        "lambda:GetFunction",
+                        "lambda:GetPolicy",
+                    ],
                     "Resource": f"arn:{partition}:lambda:*:{account_id}:function:ParallelClusterImage-*",
                     "Effect": "Allow",
                 },

--- a/cli/tests/pcluster/cli/test_build_image.py
+++ b/cli/tests/pcluster/cli/test_build_image.py
@@ -285,8 +285,16 @@ class TestBuildImageCommand:
     @pytest.mark.parametrize(
         "account_id, partition, actions",
         [
-            ("123456789012", "aws", ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"]),
-            ("000000000000", "aws-us-gov", ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"]),
+            (
+                "123456789012",
+                "aws",
+                ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"],
+            ),
+            (
+                "000000000000",
+                "aws-us-gov",
+                ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"],
+            ),
         ],
     )
     def test_expected_inline_policy_dynamic_fields(self, account_id, partition, actions):
@@ -310,7 +318,7 @@ class TestBuildImageCommand:
                 if not res == f"arn:{partition}:ec2:*::image/*":
                     assert f":{account_id}:" in res
         if len(actions) != 0:
-            assert False, f"Actions {actions} are not in the policy"
+            raise AssertionError(f"Actions {actions} are not in the policy")
 
     def _build_args(self, args):
         args = [[k, v] if v is not None else [k] for k, v in args.items()]

--- a/cli/tests/pcluster/cli/test_build_image.py
+++ b/cli/tests/pcluster/cli/test_build_image.py
@@ -283,19 +283,25 @@ class TestBuildImageCommand:
         aws_api_mock.iam.tag_role.assert_not_called()
 
     @pytest.mark.parametrize(
-        "account_id, partition",
+        "account_id, partition, actions",
         [
-            ("123456789012", "aws"),
-            ("000000000000", "aws-us-gov"),
+            ("123456789012", "aws", ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"]),
+            ("000000000000", "aws-us-gov", ["lambda:DeleteFunction", "lambda:RemovePermission", "lambda:GetFunction", "lambda:GetPolicy"]),
         ],
     )
-    def test_expected_inline_policy_dynamic_fields(self, account_id, partition):
+    def test_expected_inline_policy_dynamic_fields(self, account_id, partition, actions):
         raw = _expected_inline_policy(account_id, partition)
         policy = json.loads(raw)
         assert policy["Version"] == "2012-10-17"
         assert len(policy["Statement"]) == 13
         for statement in policy["Statement"]:
             resources = statement["Resource"]
+            action = statement["Action"]
+            action = action if isinstance(action, list) else [action]
+            for act in action:
+                if act in actions:
+                    actions.remove(act)
+
             resources = resources if isinstance(resources, list) else [resources]
             for res in resources:
                 if res == "*":
@@ -303,6 +309,8 @@ class TestBuildImageCommand:
                 assert f"arn:{partition}" in res
                 if not res == f"arn:{partition}:ec2:*::image/*":
                     assert f":{account_id}:" in res
+        if len(actions) != 0:
+            assert False, f"Actions {actions} are not in the policy"
 
     def _build_args(self, args):
         args = [[k, v] if v is not None else [k] for k, v in args.items()]


### PR DESCRIPTION
### Description of changes
* Add GetFunction and GetPolicy permissions to the build image cleanup role
* AccessDenied Errors were encountered when trying to delete the DeleteFunction Lambda function
* Cloudtrail events were encountering the following error:
```
User: arn:aws:sts::<ACCOUNT_ID>:assumed-role/PClusterBuildImageCleanupRole-*-v1/ParallelClusterImage-* is not authorized to perform: lambda:GetFunction on resource: arn:aws:lambda:us-west-2:<ACCOUNT_ID>:function:ParallelClusterImage-* because no identity-based policy allows the lambda:GetFunction action
```
```
User: arn:aws:sts::<ACCOUNT_ID>:assumed-role/PClusterBuildImageCleanupRole-*-v1/ParallelClusterImage-* is not authorized to perform: lambda:GetPolicy on resource: arn:aws:lambda:us-west-2:<ACCOUNT_ID>:function:ParallelClusterImage-* because no identity-based policy allows the lambda:GetPolicy action
```

### Tests
* Running test_build_image and checked CloudTrail to validate that `GetFunction` and `GetPolicy` actions no longer had AccessDenied errors.


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
