### PR TITLE
Upgrade test requirements to be compatible with python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - Upgrade jmespath to ~=1.0 (from ~=0.10).
 - Upgrade tabulate to <=0.9.0 (from <=0.8.10).
 
+**BUG FIXES**
+- Add validation to block updates that change tag order.
+
 3.14.1
 ------
 

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -176,19 +176,50 @@ class ConfigPatch:
     def _compare_list(self, base_section, target_section, param_path, data_key, field_obj, change_update_policy):
         """
         Compare list of nested section (e.g. list of queues) by comparing the items with the same update_key.
-
-        If update_key is not set we're considering Name as identifier.
         """
         update_key = field_obj.metadata.get("update_key")
 
+        # Get the lists
+        base_list = base_section.get(data_key, []) if base_section else []
+        target_list = target_section.get(data_key, []) if target_section else []
+
+        # For Tags, check if this is ONLY an order change (same content, different order)
+        if data_key == "Tags" and base_list != target_list:
+            # Check if it's an order-only change
+            try:
+                base_set = {frozenset(item.items()) for item in base_list}
+                target_set = {frozenset(item.items()) for item in target_list}
+                is_order_only_change = (base_set == target_set)
+            except (TypeError, AttributeError):
+                is_order_only_change = False
+
+            # If it's ONLY an order change, block it here and return
+            if is_order_only_change:
+                self.changes.append(
+                    Change(
+                        param_path,
+                        data_key,
+                        base_list,
+                        target_list,
+                        change_update_policy,
+                        is_list=True,
+                    )
+                )
+                return  # Don't process individual items
+            # Otherwise, fall through to item-by-item comparison below
+            # The reason I check if it is an order only change first is because if I just do I order dependent
+            # comparison and fail if there is a difference, then we don't get the item by item comparison in the
+            # change set if the modification was not the order.
+
+
         # Compare items in the list by searching the right item to compare through update_key value
         # First, compare all sections from target vs base config and mark visited base sections.
-        for target_nested_section in target_section.get(data_key, []):
+        for target_nested_section in target_list:  # Changed from target_section.get(data_key, [])
             update_key_value = target_nested_section.get(update_key)
             base_nested_section = next(
                 (
                     nested_section
-                    for nested_section in base_section.get(data_key, [])
+                    for nested_section in base_list  # Changed from base_section.get(data_key, [])
                     if nested_section.get(update_key) == update_key_value
                 ),
                 None,

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -176,6 +176,8 @@ class ConfigPatch:
     def _compare_list(self, base_section, target_section, param_path, data_key, field_obj, change_update_policy):
         """
         Compare list of nested section (e.g. list of queues) by comparing the items with the same update_key.
+
+        If update_key is not set we're considering Name as identifier.
         """
         update_key = field_obj.metadata.get("update_key")
 

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -86,7 +86,12 @@ def _compare_changes(changes, expected_changes):
     def _sorting_func(change):
         if change.is_list:
             if isinstance(change.new_value, dict):
-                return change.new_value["Name"]
+                if "Key" in change.new_value:
+                    return change.new_value["Key"]
+                elif "Name" in change.new_value:
+                    return change.new_value["Name"]
+                else:
+                    return "-"
             else:
                 return "-"
         else:
@@ -1133,3 +1138,111 @@ def test_patch_check_cluster_resource_bucket(
         line = ["{0}".format(element) if isinstance(element, str) else element for element in line]
         assert_that(expected_message_rows).contains(line)
     assert_that(patch_allowed).is_equal_to(not expected_error_row)
+
+@pytest.mark.parametrize(
+    "base_tags, target_tags, expected_changes, expected_policy",
+    [
+        pytest.param(
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [{"Key": "test2", "Value": "val2"}, {"Key": "test1", "Value": "val1"}],
+            [
+                Change(
+                    [],
+                    "Tags",
+                    [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+                    [{"Key": "test2", "Value": "val2"}, {"Key": "test1", "Value": "val1"}],
+                    UpdatePolicy.UNSUPPORTED,
+                    is_list=True,
+                )
+            ],
+            UpdatePolicy.UNSUPPORTED,
+            id="order_only_change",
+        ),
+        pytest.param(
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}, {"Key": "test3", "Value": "val3"}],
+            [
+                Change(
+                    [],
+                    "Tags",
+                    None,
+                    {"Key": "test3", "Value": "val3"},
+                    UpdatePolicy.UNSUPPORTED,
+                    is_list=True,
+                )
+            ],
+            UpdatePolicy.UNSUPPORTED,
+            id="tag_addition",
+        ),
+        pytest.param(
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [{"Key": "test1", "Value": "val1"}],
+            [
+                Change(
+                    [],
+                    "Tags",
+                    {"Key": "test2", "Value": "val2"},
+                    None,
+                    UpdatePolicy.UNSUPPORTED,
+                    is_list=True,
+                )
+            ],
+            UpdatePolicy.UNSUPPORTED,
+            id="tag_removal",
+        ),
+        pytest.param(
+            [{"Key": "test1", "Value": "old_value"}],
+            [{"Key": "test1", "Value": "new_value"}],
+            [
+                Change(
+                    ["Tags[test1]"],
+                    "Value",
+                    "old_value",
+                    "new_value",
+                    UpdatePolicy.UNSUPPORTED,
+                    is_list=False,
+                )
+            ],
+            UpdatePolicy.UNSUPPORTED,
+            id="tag_value_modification",
+        ),
+        pytest.param(
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [{"Key": "test3", "Value": "val3"}, {"Key": "test2", "Value": "val2"}, {"Key": "test1", "Value": "val1"}],
+            [
+                Change(
+                    [],
+                    "Tags",
+                    None,
+                    {"Key": "test3", "Value": "val3"},
+                    UpdatePolicy.UNSUPPORTED,
+                    is_list=True,
+                )
+            ],
+            UpdatePolicy.UNSUPPORTED,
+            id="order_change_plus_addition",
+        ),
+        pytest.param(
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [{"Key": "test1", "Value": "val1"}, {"Key": "test2", "Value": "val2"}],
+            [],
+            UpdatePolicy.SUPPORTED,
+            id="no_change_identical_tags",
+        ),
+    ],
+)
+def test_tag_updates(mocker, test_datadir, pcluster_config_reader, base_tags, target_tags, expected_changes, expected_policy):
+    """Test various tag update scenarios including order changes, additions, and modifications."""
+    mock_aws_api(mocker)
+    dst_config_file = "pcluster.config.dst.yaml"
+    _duplicate_config_file(dst_config_file, test_datadir)
+
+    src_dict = {"tags": base_tags}
+    src_config_file = pcluster_config_reader(**src_dict)
+    src_conf = _load_config(src_config_file)
+
+    dst_dict = {"tags": target_tags}
+    dst_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
+    dst_conf = _load_config(dst_config_file)
+
+    _check_patch(src_conf.source_config, dst_conf.source_config, expected_changes, expected_policy)

--- a/cli/tests/pcluster/config/test_config_patch/test_tag_updates/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_tag_updates/pcluster.config.yaml
@@ -1,0 +1,28 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t3.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: test-key
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: t3.micro
+          MinCount: 1
+          MaxCount: 10
+  {% if tags %}
+Tags:
+  {% for tag in tags %}
+- Key: {{ tag.Key }}
+  Value: {{ tag.Value }}
+  {% endfor %}
+  {% endif %}
+


### PR DESCRIPTION
### Description of changes
* Add invoke to test requirements
  * Fixes this error: `ModuleNotFoundError: No module named 'imp'`
  * imp was removed in python 3.12, but the older version of invoke still tries to import it
* Upgrade fabric to >=3.2.2
  * fabric 2.6.0 requires invoke<2.0
  * 3.2.2 has the fix for the github issue commented
 * Remove pytest.mark.usefixtures because it is a deprecated feature in python 3.12
  * https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

### Tests
* Ran integration test using a python 3.12 environment

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
