### PR TITLE
Remove g6f from instance types to be tested

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -147,7 +147,7 @@ def _get_instance_type_parameters():  # noqa: C901
             paginator = ec2_client.get_paginator("describe_instance_types")
             for page in paginator.paginate(InstanceTypes=xlarge_instances):
                 for instance_type in page["InstanceTypes"]:
-                    if _is_nvidia_gpu_instance_type(instance_type):
+                    if _is_nvidia_gpu_instance_type(instance_type) and "g6f" not in instance_type["InstanceType"]:
                         gpu_instances.append(instance_type["InstanceType"])
 
             for page in paginator.paginate():


### PR DESCRIPTION
### Description of changes
* Remove g6f from instance types to be tested
* g6f instance types causes cluster creation failures because gdr copy is not able to be configured - I think we should not support it

### Tests
* Ran test_gpu_health_checks to ensure it did not break the instance type generation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
