### PR TITLE
[Test] When test_createami fails, print the recent log lines rather than cloudwatch events for better readability.

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -651,5 +651,9 @@ def _test_build_image_failed(image):
 def _keep_recent_logs(image):
     """Keep several lines of recent log to the console when creating an image fails."""
     log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
-    failure_logs = image.get_log_events(log_stream_name, start_from_head=False, query="events[*]", limit=200)
-    logging.info(f"Image built failed for {image.image_id}, the last 200 lines of the log are: {failure_logs}")
+    nlines = 200
+    log_events = image.get_log_events(log_stream_name, start_from_head=False, query="events[*]", limit=nlines)
+    log_messages = [event["message"] for event in log_events]
+    logging.info(
+        f"Image built failed for {image.image_id}, the last {nlines} lines of the log are:\n" + "\n".join(log_messages)
+    )


### PR DESCRIPTION
### Description of changes
When `test_createami` fails, print the recent log lines rather than cloudwatch events for better readability.
Example
```
2025-11-14 05:14:44,942 - INFO - 18800 - test_build_image[us-west-2-g4dn.2xlarge-rhel9-slurm-None] - test_createami - Image built failed for integ-tests-build-image-4fw40f1u2q1obm9x-develop-develop, the last 200 lines of the log are:
Stdout:   lksctp-tools-1.0.19-3.el9_4.x86_64                                            
...
Stdout: Nothing to do.
Stdout: Complete!
Stdout: SYNTHETIC FAILURE INJECTED FOR TESTING
CmdExecution: Command execution has been completed
CmdExecution: [ ERROR ] Command execution has resulted in an error
```

### Tests
Injected failure in the test and verified that the printed lines are now plain logs rather than cloudwatch events

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
