### PR TITLE
[IntegTest][Release-3.14] Remove multiple subnet, use t3 instead of c6i in test_slurm_accounting

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -33,9 +33,7 @@ Scheduling:
           MaxCount: 10
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -28,7 +28,7 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
-            - InstanceType: c6i.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
@@ -29,7 +29,7 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
-            - InstanceType: c6i.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 12
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
@@ -34,9 +34,7 @@ Scheduling:
           MaxCount: 12
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
-            - InstanceType: c6i.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -26,9 +26,7 @@ Scheduling:
           MaxCount: 10
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore


### PR DESCRIPTION
### Description of changes
* This PR revert commit https://github.com/aws/aws-parallelcluster/commit/92c0f719d986cb391a59c821e8e01b2887372fe3
* Plus use t3 instead of c6i in test_slurm_accounting

### Tests
* Passed in commercial

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
