### PR TITLE
[IntegTest][develop] For RHEL8, in test_slurm_memory_based_scheduling allocate more memory to avoid OOM kills in isolated regions

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -724,13 +724,15 @@ def test_slurm_custom_config_parameters(
     assert "4100" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory")
 
 
-@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+@pytest.mark.usefixtures("instance", "scheduler")
 @pytest.mark.slurm_memory_based_scheduling
 def test_slurm_memory_based_scheduling(
     pcluster_config_reader,
     clusters_factory,
     test_datadir,
     scheduler_commands_factory,
+    os,
+    region,
 ):
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
@@ -757,6 +759,8 @@ def test_slurm_memory_based_scheduling(
         remote_command_executor,
         slurm_commands,
         test_datadir,
+        os,
+        region,
     )
 
     _test_memory_based_scheduling_with_multiple_instance_types(slurm_commands)
@@ -2448,6 +2452,8 @@ def _test_memory_based_scheduling_enabled_true(
     remote_command_executor,
     slurm_commands,
     test_datadir,
+    os,
+    region,
 ):
     """Test Slurm with memory-based scheduling feature enabled"""
 
@@ -2517,12 +2523,16 @@ def _test_memory_based_scheduling_enabled_true(
             "raise_on_error": False,
         }
     )
+
+    # FIXME: This is a short term way to unblock the test in isolated regions under conditions we do not fully get.
+    # For RHEL8, allocate more memory to avoid OOM kills in isolated regions
+    mem_allocation = "3000" if os == "rhel8" and "us-iso" in region else "2500"
     job_id_2 = slurm_commands.submit_command_and_assert_job_accepted(
         submit_command_args={
             "nodes": 1,
             "slots": 1,
             "command": "srun ./a.out 2000000000",
-            "other_options": "--mem=2500 -w queue1-st-ondemand1-i1-1",
+            "other_options": f"--mem={mem_allocation} -w queue1-st-ondemand1-i1-1",
             "raise_on_error": False,
         }
     )


### PR DESCRIPTION
### Description of changes
* For RHEL8, in isolated regions, allocate more memory to avoid OOM kills
* Add a FIXME comment specifying it's a short term solution.

### Tests
* Test passed in commercial

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
