### PR TITLE
[IntegTest][develop] Enhance test_slurm_accounting by removing mutiple subnet and adding t3.xlarge

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -28,13 +28,12 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update2.yaml
@@ -29,13 +29,12 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 12
       Networking:
         SubnetIds:
-          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
-          {% endfor %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -21,6 +21,7 @@ Scheduling:
             - InstanceType: c5.xlarge
             - InstanceType: m5.xlarge
             - InstanceType: c5d.xlarge
+            - InstanceType: t3.xlarge
           MinCount: 0
           MaxCount: 10
       Networking:


### PR DESCRIPTION
### Description of changes
* This PR is adopting changes in https://github.com/aws/aws-parallelcluster/pull/7100
* Enhance test_slurm_accounting by removing mutiple subnet and adding t3.xlarge

### Tests
* Test passed in commercial

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
