### PR TITLE
[Test][Isolated Regions] Restrict tests running in us-iso-east-1 to use AZs "usie1-az1", "usie1-az2"

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -54,6 +54,7 @@ AVAILABLE_AVAILABILITY_ZONE = {
     "cn-north-1": ["cnn1-az1", "cnn1-az2"],
     # Should only consider supported AZs
     "us-isob-east-1": ["usibe1-az2", "usibe1-az3"],
+    "us-iso-east-1": ["usie1-az1", "usie1-az2"],
 }
 
 # used to map a ZoneId to the corresponding region


### PR DESCRIPTION
### Description of changes
* FSx Lustre Scratch_2 is not supported in other AZs

### Tests
* Tests will be done after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
