### PR TITLE
[Test] Using self for Owner Filter for patched DLAMI AMI

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -62,7 +62,8 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     # so that it will not conflict with pcluster build image.
     "alinux2": {
         "name": "Deep Learning OSS Nvidia Driver AMI (Amazon Linux 2) Version 83.9 for ParallelCluster*",
-        "owners": ["amazon"],
+        # If you are running in your personal account, then you must have this patched AMI
+        "owners": ["self"],
     },
     "alinux2023": {
         "name": {

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -135,13 +135,9 @@ def test_build_image(
         enable_nvidia = False
 
     # Get base AMI
-    if os in ["alinux2", "ubuntu2004"]:
-        # Using patched DLAMI AMI so it does not conflict with pcluster build image.
-        allow_private_ami = True if os == "alinux2" else False
+    if os in ["alinux2023", "ubuntu2004"]:
         # Test Deep Learning AMIs
-        base_ami = retrieve_latest_ami(
-            region, os, ami_type="remarkable", architecture=architecture, allow_private_ami=allow_private_ami
-        )
+        base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
         enable_nvidia = False  # Deep learning AMIs have Nvidia pre-installed
     elif "rhel" in os or "ubuntu" in os or os == "rocky8":
         # Test AMIs from first stage build. Because RHEL/Rocky and Ubuntu have specific requirement of kernel versions.


### PR DESCRIPTION
### Description of changes
*  Using AL2023 for creating DLAMI AMIs as the AL2 Patched DLAMI is only available in us-east-1
* [Test] Using self for Owner Filter for patched DLAMI AMI



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
