### PR TITLE
[release-3.11] Fix README using the correct GitHub closed issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Issues
 ------
 
 [![GitHub issues](https://img.shields.io/github/issues/aws/aws-parallelcluster.svg)](https://github.com/aws/aws-parallelcluster/issues)
-[![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/aws/aws-parallelcluster.svg)](https://github.com/aws-parallelcluster/issues?q=is%3Aissue+is%3Aclosed)
+[![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/aws/aws-parallelcluster.svg)](https://github.com/aws/aws-parallelcluster/issues?q=is%3Aissue+is%3Aclosed)
 
 Please open a GitHub issue for any feedback or issues:
 https://github.com/aws/aws-parallelcluster/issues.  There is also an active AWS


### PR DESCRIPTION
### Description of changes
* Fix README using the correct GitHub closed issues link in release-3.11 branch

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
