### PR TITLE
[Test][Isolated Region] Reduce memory usage in test_slurm_memory_based_scheduling

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -2594,7 +2594,7 @@ def _test_slurm_behavior_when_updating_schedulable_memory_with_already_running_j
         submit_command_args={
             "nodes": 1,
             "slots": 1,
-            "command": "srun ./a.out 2800000000 390",
+            "command": "srun ./a.out 2000000000 390",
             "other_options": "-w queue1-st-ondemand1-i1-1",
             "raise_on_error": False,
         }


### PR DESCRIPTION
### Description of changes
* The changed line is running on c5.large, which has 4GB of physical memory, when running with 3GB of program, it failed in isolated region on RHEL8. Reduce the memory usage to 2GB to make the test pass. ParallelCluster test shouldn't check too strictly about memory usage because it is managed by operating systems.

### Tests
* The change is test only. It will be tested after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
