### PR TITLE
[integ-tests] In OSU test, use the same instance type for head node and compute nodes

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -53,11 +53,6 @@ def test_osu(
             f"Only these instances are supported: {OSU_BENCHMARKS_INSTANCES}"
         )
 
-    if architecture == "x86_64":
-        head_node_instance = "c5.18xlarge"
-    else:
-        head_node_instance = "c6g.16xlarge"
-
     max_queue_size = 32
     capacity_type = "ONDEMAND"
     capacity_reservation_id = None
@@ -78,7 +73,6 @@ def test_osu(
 
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(
-        head_node_instance=head_node_instance,
         max_queue_size=max_queue_size,
         capacity_type=capacity_type,
         capacity_reservation_id=capacity_reservation_id,

--- a/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ head_node_instance }}
+  InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:


### PR DESCRIPTION
### Description of changes
Prior to this commit, there were intermittent failures of insufficient capacity of the head node instance type.

Although the head node is not in the placement group, which is used by the integration tests framework to make the capacity reservation, this commit "hopes" that the AZ has adequate capacity of the instance type. In other words, if the integration test framework can make a capacity reservation of 35 instances in a placement group in the AZ, this commit hopes there will be an additional 1 instance anywhere in the AZ.

### Tests
Changes are in test code. Test will run after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
