### PR TITLE
[Test] Use t3.medium for spot test instances

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -83,10 +83,10 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     ]:
         bucket.upload_file(str(test_datadir / script), f"scripts/{script}")
 
-    spot_instance_types = ["t3.small", "t3.medium"]
+    spot_instance_types = ["t3.medium"]
     try:
-        boto3.client("ec2").describe_instance_types(InstanceTypes=["t3a.small"])
-        spot_instance_types.extend(["t3a.small", "t3a.medium"])
+        boto3.client("ec2").describe_instance_types(InstanceTypes=["t3a.medium"])
+        spot_instance_types.extend(["t3a.medium"])
     except Exception:
         pass
 


### PR DESCRIPTION
### Description of changes
* Use t3.medium for spot test instances as t3.small has less memory. 



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
