### PR TITLE
[integ-tests] In EFA test, use the same instance type for head node and compute nodes when possible

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -51,10 +51,15 @@ def test_efa(
 
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
-    if architecture == "x86_64":
-        head_node_instance = "c5.18xlarge"
+    if instance.startswith("p") or instance.startswith("hpc"):
+        if architecture == "x86_64":
+            head_node_instance = "c5.18xlarge"
+        else:
+            head_node_instance = "c6g.16xlarge"
     else:
-        head_node_instance = "c6g.16xlarge"
+        # Use the same instance type for both compute node and head node
+        # when the instance type is available in open capacity pool
+        head_node_instance = instance
     max_queue_size = 2
     p6_b200_capacity_reservation_id = None
     if instance == "p6-b200.48xlarge":


### PR DESCRIPTION
### Description of changes
This commit uses the same instance type for both compute node and head node when the instance type is available in open capacity pool. When the instance type is p4, p5, p6, or hpc which require capacity reservations or capacity blocks, the head node still uses a different instance type as the logic before this commit.

Prior to this commit, there were intermittent failures of insufficient capacity of the head node instance type.

Although the head node is not in the placement group, which is used by the integration tests framework to make the capacity reservation, this commit "hopes" that the AZ has adequate capacity of the instance type. In other words, if the integration test framework can make a capacity reservation of 35 instances in a placement group in the AZ, this commit hopes there will be an additional 1 instance anywhere in the AZ.

### Tests
* The following tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
---
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_OS_X86_0 }}]
          instances: ["c5n.18xlarge"]
          oss: [{{ OS_X86_0 }}]
          schedulers: ["slurm"]
        - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
          instances: ["p4d.24xlarge"]
          oss: [{{ NO_RHEL_OS_X86_1 }}]  # The capacity reservation cannot use RHEL operating system
          schedulers: ["slurm"]
        - regions: [{{ c6gn_16xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_OS_ARM_0 }}]
          instances: ["c6gn.16xlarge"]
          oss: [{{ OS_ARM_0 }}]
          schedulers: ["slurm"]
        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
          instances: ["hpc6id.32xlarge"]
          oss: [{{ OS_X86_4 }}]
          schedulers: [ "slurm" ]
        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
          instances: [{{ common.instance("instance_type_1") }}]
          oss: [{{ OS_X86_6 }}]
          schedulers: [ "slurm" ]
```

### References
* Similar change has been done for test_osu https://github.com/aws/aws-parallelcluster/pull/7129

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
