### PR TITLE
[TEST] Use latest RHel8 AMI for testing & remove OpenFoam test

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -859,12 +859,6 @@ test-suites:
           instances: [ "c5n.18xlarge" ]
           oss: [{{ NO_ROCKY_OS_X86_0 }}] # ParallelCluster does not release official Rocky images. Skip the test.
           schedulers: [ "slurm" ]
-    test_openfoam.py::test_openfoam:
-      dimensions:
-        - regions: [ {{ c5n_18xlarge_CAPACITY_RESERVATION_35_INSTANCES_2_HOURS_YESPG_NO_ROCKY_OS_X86_0 }} ]
-          instances: [ "c5n.18xlarge" ]
-          oss: [{{ NO_ROCKY_OS_X86_0 }}] # ParallelCluster does not release official Rocky images. Skip the test.
-          schedulers: [ "slurm" ]
     test_startup_time.py::test_startup_time:
       dimensions:
         - regions: [ "us-east-1" ]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -84,9 +84,7 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
         "owners": ["099720109477"],
     },
     # Simple redhat8 to be able to build in remarkable test
-    # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
-    # the kernel released in 20231127 RHEL 8.8 AMI
-    "rhel8": {"name": "RHEL-8.8*_HVM-202309*", "owners": RHEL_OWNERS},
+    "rhel8": {"name": "RHEL-8.8*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8": {"name": "Rocky-8-EC2-Base-8.10*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts


### PR DESCRIPTION
### Description of changes
* [TEST] Use latest RHel8 AMI for testing
* [TEST] Remove OpenFoam test

### Tests
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - rhel8
        regions:
        - eu-west-3
        schedulers:
        - slurm
 ```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
