### PR TITLE
[Validators] Remove `features` from SlurmSettings deny list. 

### DIFF
--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -50,7 +50,7 @@ SLURM_SETTINGS_DENY_LIST = {
         "Global": ["nodes", "partitionname", "resumetimeout", "state", "suspendtime", "oversubscribe"],
     },
     "ComputeResource": {
-        "Global": ["cpus", "features", "gres", "nodeaddr", "nodehostname", "nodename", "state", "weight"],
+        "Global": ["cpus", "gres", "nodeaddr", "nodehostname", "nodename", "state", "weight"],
     },
 }
 


### PR DESCRIPTION
### Description of changes
Remove `features` from SlurmSettings deny list. 
That property name was wrong: the correct one is `feature`, not `features`. We do not fix the typo because there is no reason to block the customization of `feature`.

Notes:
1. No entry in changelog for this fix because it is not changing the user experience. The correct config name was already allowed. 
2. No need to modify the existing unit test because the test is meant to covers a generic denylist, not the specific content of the constant https://github.com/aws/aws-parallelcluster/blob/develop/cli/tests/pcluster/validators/test_cluster_validators.py#L211-L275

### Tests
Manually verified that customizing the list of features for compute resources works as expected. Also checked that overriding the default features does not introduce any side effect because we do not rely on those.

Example:

```
  SlurmQueues:
    - Name: q1
      ComputeResources:
        - Name: cr1
          CustomSlurmSettings:
            Feature: cr1,MyFeature1
          ...
        - Name: cr2
          CustomSlurmSettings:
            Feature: cr2,MyFeature2
          ...
    - Name: q2
      ComputeResources:
        - Name: cr1
          CustomSlurmSettings:
            Feature: cr1,MyFeature1
         ...
```

```
[root@ip-27-6-34-99 ~]# scontrol show nodes --json | jq -r '["NAME", "PARTITIONS", "FEATURES", "ACTIVE_FEATURES"], (.nodes[] | [.name, (.partitions | join(",")), (.features | join(",")), (.active_features | join(","))]) | @tsv'
NAME    PARTITIONS      FEATURES        ACTIVE_FEATURES
q1-dy-cr1-1     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-2     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-3     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-4     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-5     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-6     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-7     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-8     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr1-9     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-dy-cr2-1     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-2     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-3     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-4     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-5     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-6     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-7     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-8     q1      cr2,MyFeature2  cr2,MyFeature2
q1-dy-cr2-9     q1      cr2,MyFeature2  cr2,MyFeature2
q1-st-cr1-1     q1,q3   cr1,MyFeature1  cr1,MyFeature1
q1-st-cr2-1     q1      cr2,MyFeature2  cr2,MyFeature2
q2-dy-cr1-1     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-2     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-3     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-4     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-5     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-6     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-7     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-8     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-dy-cr1-9     q2,q3   cr1,MyFeature1  cr1,MyFeature1
q2-st-cr1-1     q2,q3   cr1,MyFeature1  cr1,MyFeature1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
