### PR TITLE
[Develop][Bug] Fix cfn-hup endless loop after rollback to cluster state older than 24 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
 - Reduce EFA installation time for Ubuntu by ~20 minutes by only holding kernel packages for the installed kernel.
 - Add GetFunction and GetPolicy permissions to PClusterBuildImageCleanupRole to prevent AccessDenied errors during build image stack deletion.
 - Fix validation error messages when `DevSettings` is null or `DevSettings/InstanceTypesData` is missing required fields.
+- Fix an issue where cfn-hup enters an endless loop on the head node after a rollback to a cluster state older than 24 hours, caused by cfn-signal failing to signal an expired wait condition handle.
 
 3.14.0
 ------

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1496,6 +1496,12 @@ class ClusterCdkStack:
             "chefUpdate": {
                 "commands": {
                     "chef": {
+                        # This command runs the update recipe and signals CloudFormation with the result.
+                        # The trailing "|| exit 0" ensures cfn-hup always updates its local metadata cache
+                        # (metadata_db.json) regardless of whether cfn-signal succeeds or fails.
+                        # Without this, if cfn-signal fails (e.g., due to an expired wait condition handle
+                        # after a rollback to a state older than 24h), cfn-hup would not update its cache
+                        # and would enter an endless loop, re-triggering the update recipe every minute.
                         "command": (
                             ". /etc/parallelcluster/pcluster_cookbook_environment.sh; "
                             "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
@@ -1509,6 +1515,7 @@ class ClusterCdkStack:
                             f" $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-signal --exit-code=1 --reason='Update failed'"
                             f" --region {self.stack.region} --url {cloudformation_url}"
                             f" '{self.wait_condition_handle.ref}'"
+                            " || exit 0"
                         ),
                         "cwd": "/etc/chef",
                     }


### PR DESCRIPTION
### Description of changes
This PR is a cherry-pick of https://github.com/aws/aws-parallelcluster/pull/7146

When a cluster update fails and triggers a rollback to a state older than 24 hours, cfn-hup enters an endless loop on the head node. This happens because:

1. The rollback restores the launch template metadata to reference an expired wait condition handle (wait conditions expire after 24h)
2. cfn-signal fails to signal the expired handle and returns non-zero
3. cfn-hup sees the non-zero exit code and does not update its local metadata cache (metadata_db.json)
4. On the next polling interval, cfn-hup detects the same "change" and re-triggers the update recipe, creating an infinite loop

This fix appends `|| exit 0` to the update command, ensuring cfn-hup always updates its metadata cache regardless of whether cfn-signal succeeds or fails. This prevents the endless loop while still allowing CloudFormation to handle timeouts appropriately.

### Tests
* After 24 hours, manually test passed. 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
