### PR TITLE
Adding kernel-devel-matched to the OS in which it exists

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -95,7 +95,7 @@ phases:
                 
                 PACKAGE_LIST="${!KERNEL_PACKAGES_PREFIX}-headers-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-devel-$(uname -r) ${!KERNEL_PACKAGES_PREFIX}-modules-extra-$(uname -r)"
                 Repository="BaseOS"
-                [[ ! $OS =~ (rocky8|rhel8) ]] && PACKAGE_LIST+=" ${!KERNEL_PACKAGES_PREFIX}-devel-matched-$(uname -r)" && Repository="AppStream"
+                [[ $OS =~ (rocky9|rhel9) ]] && PACKAGE_LIST+=" ${!KERNEL_PACKAGES_PREFIX}-devel-matched-$(uname -r)" && Repository="AppStream"
                 
                 if [[ $OS =~ rocky ]]; then
                   for PACKAGE in ${!PACKAGE_LIST}


### PR DESCRIPTION
### Description of changes

Adding kernel-devel-matched to the OS in which it exists

* the package dose not exist in Amazon Linux and Rocky/Rhel 8 AMI's; we avoid errors like Error: Unable to find a match: kernel6.12-devel-matched-6.12.58-82.121.amzn2023.aarch64


* this package exists only for rocky/rhel 9  https://github.com/aws/aws-parallelcluster/pull/6866
* Ref for Al2023: https://docs.aws.amazon.com/linux/al2023/release-notes/new-AL2023.6-AL2023.9.html



### Tests
* Manual tests on Al2023 and AL2

```
 yum list kernel-devel-matched
Last metadata expiration check: 18:27:03 ago on Tue Dec 16 04:07:45 2025.
Error: No matching Packages to list
[root@ip-172-31-35-69 ~]# yum list kernel6.12-devel-matched
Last metadata expiration check: 18:27:09 ago on Tue Dec 16 04:07:45 2025.
Error: No matching Packages to list
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]# yum list available 'kernel6.12-devel*'
Last metadata expiration check: 18:45:06 ago on Tue Dec 16 04:07:45 2025.
Error: No matching Packages to list
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]# yum list available 'kernel-devel*'
Last metadata expiration check: 18:45:15 ago on Tue Dec 16 04:07:45 2025.
Available Packages
kernel-devel.aarch64                                                                                                                                  1:6.1.158-180.294.amzn2023                                                                                                                                   amazonlinux
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]# yum --enablerepo='*' list available 'kernel-devel*'
Amazon Linux 2023 repository - Source packages                                                                                                                                                                                                                                                4.2 MB/s | 1.7 MB     00:00
Amazon Linux 2023 repository - Debug                                                                                                                                                                                                                                                           69 MB/s |  27 MB     00:00
Amazon Linux 2023 Kernel Livepatch repository - Source packages                                                                                                                                                                                                                               161 kB/s |  20 kB     00:00
Available Packages
kernel-devel.aarch64                                                                                                                                  1:6.1.158-180.294.amzn2023                                                                                                                                   amazonlinux
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]#
[root@ip-172-31-35-69 ~]# yum --showduplicates list 'kernel6.12-devel-matched*'
Last metadata expiration check: 18:45:51 ago on Tue Dec 16 04:07:45 2025.
Error: No matching Packages to list
[root@ip-172-31-35-69 ~]# yum --showduplicates list 'kernel-devel-matched*'
Last metadata expiration check: 18:45:58 ago on Tue Dec 16 04:07:45 2025.
Error: No matching Packages to list
[root@ip-172-31-35-69 ~]#
```

```
[root@ip-172-31-14-250 ~]# yum list kernel6.12-devel-matched
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Error: No matching Packages to list
[root@ip-172-31-14-250 ~]# yum list kernel6-devel-matched
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Error: No matching Packages to list
[root@ip-172-31-14-250 ~]# yum list kernel-devel-matched
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Error: No matching Packages to list
[root@ip-172-31-14-250 ~]# yum --enablerepo='*' list available 'kernel-devel*'
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core-debuginfo                                                                                                                                                                                                                                                                                   | 2.6 kB  00:00:00
amzn2-core-source                                                                                                                                                                                                                                                                                      | 2.6 kB  00:00:00
amzn2extra-docker-debuginfo                                                                                                                                                                                                                                                                            | 2.6 kB  00:00:00
amzn2extra-docker-source                                                                                                                                                                                                                                                                               | 2.6 kB  00:00:00
amzn2extra-kernel-5.10-debuginfo                                                                                                                                                                                                                                                                       | 2.6 kB  00:00:00
amzn2extra-kernel-5.10-source                                                                                                                                                                                                                                                                          | 2.6 kB  00:00:00
(1/6): amzn2-core-debuginfo/2/aarch64/primary_db                                                                                                                                                                                                                                                       | 1.8 MB  00:00:00
(2/6): amzn2extra-docker-debuginfo/2/aarch64/primary_db                                                                                                                                                                                                                                                |  31 kB  00:00:00
(3/6): amzn2extra-docker-source/2/primary_db                                                                                                                                                                                                                                                           |  50 kB  00:00:00
(4/6): amzn2extra-kernel-5.10-source/2/primary_db                                                                                                                                                                                                                                                      |  92 kB  00:00:00
(5/6): amzn2-core-source/2/primary_db                                                                                                                                                                                                                                                                  | 3.0 MB  00:00:00
(6/6): amzn2extra-kernel-5.10-debuginfo/2/aarch64/primary_db                                                                                                                                                                                                                                           | 141 kB  00:00:00
Available Packages
kernel-devel.aarch64                                                                                                                               5.10.245-245.983.amzn2                                                                                                                               amzn2extra-kernel-5.10
[root@ip-172-31-14-250 ~]# yum --showduplicates list 'kernel6.12-devel-matched*'
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Error: No matching Packages to list
[root@ip-172-31-14-250 ~]# yum --showduplicates list 'kernel-devel-matched*'
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Error: No matching Packages to list
[root@ip-172-31-14-250 ~]#

```
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
