### PR TITLE
[BuildImage] Fix reboot failures on Ubuntu by preventing snap auto-refresh from interfering with build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
 - Reduce EFA installation time for Ubuntu by ~20 minutes by only holding kernel packages for the installed kernel.
 - Add GetFunction and GetPolicy permissions to PClusterBuildImageCleanupRole to prevent AccessDenied errors during build image stack deletion.
 - Fix validation error messages when `DevSettings` is null or `DevSettings/InstanceTypesData` is missing required fields.
+- Disable snap auto-refresh on Ubuntu during build image to prevent intermittent reboot failures.
 
 3.14.0
 ------

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -34,6 +34,19 @@ phases:
                 *) echo "Unsupported OS: $RELEASE" && exit {{ FailExitCode }} ;;
               esac
 
+      # Disable snap refresh to prevent background updates during build (Ubuntu only)
+      - name: DisableSnapRefresh
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              OS="{{ build.OperatingSystemName.outputs.stdout }}"
+              if [[ $OS =~ ^ubuntu ]] && command -v snap &>/dev/null; then
+                snap watch --last=auto-refresh 2>/dev/null || true
+                snap refresh --hold && mkdir -p /opt/parallelcluster && touch /opt/parallelcluster/pcluster_build_image_snap_hold
+              fi
+
       # Initialize system information and URLs
       - name: SystemInfo
         action: ExecuteBash
@@ -258,6 +271,11 @@ phases:
                 rm -rf /tmp/imagebuilder_service/ssm_installed
               else
                  echo "SSM agent is installed by default"
+              fi
+              
+              if [[ -f /opt/parallelcluster/pcluster_build_image_snap_hold ]]; then
+                snap refresh --unhold 2>/dev/null || true
+                rm -rf /opt/parallelcluster/pcluster_build_image_snap_hold
               fi
               
               # Final cleanup


### PR DESCRIPTION
### Description of changes

#### Problem
The build image for Ubuntu 22.04 and 24.04 intermittently fails the reboot step, which is executed before the execution of our cookbook. 

#### Root Cause
Our investigations show that such failure is related to snapd restarting the SSM Agent right before the reboot. snapd does it as part of its auto-refresh mechanism, which for tries to upgrade the packages in the background. We think this may interfere with the ssm agent reporting the successful status of the reboot.

#### Solution
Disable snap refresh for all snap packages during the build process.
Notice that we will do that with the following safe guards:
1. if snap is not installed, we skip the hold/unhold
2. we unhold only if it was us holding. So that if a user was setting a hold in their parent image, we leave it as it is.

This is how snap refresh hold/unhold works:

```
root@ip-172-31-0-49:~# snap refresh --time
timer: 00:00~24:00/4
last: today at 15:59 UTC
next: today at 22:03 UTC

root@ip-172-31-0-49:~# snap refresh --hold
Auto-refresh of all snaps held indefinitely

root@ip-172-31-0-49:~# snap refresh --time
timer: 00:00~24:00/4
last: today at 15:59 UTC
hold: forever
next: today at 22:03 UTC (but held)

root@ip-172-31-0-49:~# snap refresh --unhold
Removed auto-refresh hold on all snaps

root@ip-172-31-0-49:~# snap refresh --time
timer: 00:00~24:00/4
last: today at 15:59 UTC
next: today at 22:03 UTC
```

#### Q&A
1. Why re-enabling after the build process?
Because keeping it disabled would lower the security bar of the product for Ubuntu. Having snap auto-refresh enabled guarantess that packages installed with snap are automatically upgraded in the background

### Tests
* Verified fix on Ubuntu 22.04 and Ubuntu 24.04 builds that were previously failing
* Confirmed snap refresh hold is applied and removed correctly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.