### PR TITLE
[integ-tests-3.14.0 branch only] Create a script to enable DCV GL offline installation

### DIFF
--- a/cli/src/pcluster/resources/patches/fix_dcv_gl_offline_installation.sh
+++ b/cli/src/pcluster/resources/patches/fix_dcv_gl_offline_installation.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Script to patch ParallelCluster AMI for DCV GL offline installation
+
+set -ex
+
+SOURCES_DIR="/opt/parallelcluster/sources"
+DCV_GL_DEPS_DIR="${SOURCES_DIR}/dcv-gl-deps"
+COOKBOOK_DIR="/etc/chef/cookbooks"
+RHEL_COMMON="${COOKBOOK_DIR}/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb"
+
+# Find the nice-dcv-gl RPM
+DCV_GL_RPM=$(find "${SOURCES_DIR}" -name "nice-dcv-gl-*.rpm" 2>/dev/null | head -1)
+if [[ -z "${DCV_GL_RPM}" ]]; then
+    echo "ERROR: nice-dcv-gl RPM not found in ${SOURCES_DIR}"
+    exit 1
+fi
+echo "Found DCV GL package: ${DCV_GL_RPM}"
+
+echo "=== Step 1: Download missing dependencies for nice-dcv-gl ==="
+mkdir -p "${DCV_GL_DEPS_DIR}"
+
+# Use dnf to download only packages that would be installed (excludes already installed)
+dnf download --destdir="${DCV_GL_DEPS_DIR}" --resolve "${DCV_GL_RPM}" 2>/dev/null || true
+
+# Remove the dcv-gl package itself if downloaded (we only want dependencies)
+rm -f "${DCV_GL_DEPS_DIR}"/nice-dcv-gl-*.rpm 2>/dev/null || true
+
+if [[ -n "$(ls -A ${DCV_GL_DEPS_DIR} 2>/dev/null)" ]]; then
+    echo "Downloaded dependencies:"
+    ls -la "${DCV_GL_DEPS_DIR}"
+else
+    echo "All dependencies already installed"
+fi
+
+echo "=== Step 2: Patch cookbook ==="
+cp "${RHEL_COMMON}" "${RHEL_COMMON}.bak"
+
+/opt/cinc/embedded/bin/ruby << 'RUBY_SCRIPT'
+file_path = '/etc/chef/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb'
+patch_content = <<~'PATCH'
+  def install_dcv_gl
+    dcv_gl_deps_dir = "#{node['cluster']['sources_dir']}/dcv-gl-deps"
+    execute 'install dcv-gl dependencies offline' do
+      command "rpm -ivh #{dcv_gl_deps_dir}/*.rpm"
+      only_if { ::Dir.exist?(dcv_gl_deps_dir) && !::Dir.empty?(dcv_gl_deps_dir) }
+    end
+
+    package = "#{node['cluster']['sources_dir']}/#{dcv_package}/#{dcv_gl}"
+    package package do
+      action :install
+      source package
+      options '--disablerepo=*'
+    end
+  end
+PATCH
+content = File.read(file_path)
+pattern = /^  def install_dcv_gl\n.*?^  end\n/m
+if content.match?(pattern)
+  File.write(file_path, content.gsub(pattern, patch_content))
+  puts "Patched successfully"
+else
+  abort "ERROR: Could not find install_dcv_gl function"
+end
+RUBY_SCRIPT
+
+echo "=== Done! Create AMI from this instance ==="


### PR DESCRIPTION
## Problem
ParallelCluster clusters should be able to be created in a network without Internet access. However, when the following items are all true, cluster creation fails:
1. RHEL/Rocky
2. x86 GPU instances for head node and/or login nodes
3. DCV enabled

The failure can be seen in chef-client log:
```
      ================================================================================
      Error executing action `install` on resource 'dnf_package[/opt/parallelcluster/sources/nice-dcv-2024.0-19030-el9-x86_64/nice-dcv-gl-2024.0.1096-1.el9.x86_64.rpm]'
      ================================================================================

      RuntimeError
      ------------
      dnf-helper.py had stderr/stdout output:

      Errors during downloading metadata for repository 'epel':
        - Curl error (28): Timeout was reached for https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=x86_64 [Failed to connect to mirrors.fedoraproject.org port 443: Connection timed out]
      Error: Failed to download metadata for repo 'epel': Cannot prepare internal mirrorlist: Curl error (28): Timeout was reached for https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=x86_64 [Failed to connect to mirrors.fedoraproject.org port 443: Connection timed out]
      Errors during downloading metadata for repository 'rhel-9-appstream-rhui-rpms':
        - Curl error (28): Timeout was reached for https://rhui.us-east-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel9/rhui/9/x86_64/appstream/os [Failed to connect to rhui.us-east-1.aws.ce.redhat.com port 443: Connection timed out]
      Error: Failed to download metadata for repo 'rhel-9-appstream-rhui-rpms': Cannot prepare internal mirrorlist: Curl error (28): Timeout was reached for https://rhui.us-east-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel9/rhui/9/x86_64/appstream/os [Failed to connect to rhui.us-east-1.aws.ce.redhat.com port 443: Connection timed out]
```

## Workaround
This commit creates a script to download any missing transitive dependencies of DCV GL. This commit modifies the cookbook to install the transitive dependencies, and use `--disablerepo=*` to avoid yum/dnf contacting Internet for repo Metadata

### How to use the script:
1. Launch an instance with official ParallelCluster RHEL/Rocky AMI
2. On the instance, run the script as root (e.g. `./fix_dcv_gl_offline_installation.gl`)
3. Create an image from the instance
4. Use the created image as the [CustomAmi](https://docs.aws.amazon.com/parallelcluster/latest/ug/Image-v3.html#yaml-Image-CustomAmi) when creating clusters

## Testing

The following test is successful, using the outcome AMI as CustomAmi from step 1-3:
```
test-suites:
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["g5.xlarge"]
          oss: ["rhel9"]
          schedulers: ["slurm"]
```

## Note
This commit should only be merged in integ-tests-3.14.0. Long term fix will be done in the future for other branches

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
