### PR TITLE
[integ-tests-3.14.0 branch only] Remove Ubuntu2404 build image test

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -84,7 +84,7 @@ test-suites:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
-          oss: ["ubuntu2404", "alinux2", "alinux2023"]
+          oss: ["alinux2", "alinux2023"]
         - regions: ["us-east-1"] # This region has to have first stage AMIs.
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Remove Ubuntu2404 build image test for release test which is affected by systemd reloading sssm-agent (which becomes un-responsive) during ubuntu-desktop installation



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
