### PR TITLE
[BuildImage] On Ubuntu, disable snap refresh during AMI build process to prevent background updates of SSM agent that could lead to reboot failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
 - Add GetFunction and GetPolicy permissions to PClusterBuildImageCleanupRole to prevent AccessDenied errors during build image stack deletion.
 - Fix validation error messages when `DevSettings` is null or `DevSettings/InstanceTypesData` is missing required fields.
 - Fix an issue where cfn-hup enters an endless loop on the head node after a rollback to a cluster state older than 24 hours, caused by cfn-signal failing to signal an expired wait condition handle.
+- Disable snap auto-refresh on Ubuntu during build image to prevent intermittent reboot failures.
 
 3.14.0
 ------

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -34,6 +34,19 @@ phases:
                 *) echo "Unsupported OS: $RELEASE" && exit {{ FailExitCode }} ;;
               esac
 
+      # Disable snap refresh to prevent background updates during build (Ubuntu only)
+      - name: DisableSnapRefresh
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              OS="{{ build.OperatingSystemName.outputs.stdout }}"
+              if [[ $OS =~ ^ubuntu ]] && command -v snap &>/dev/null; then
+                snap watch --last=auto-refresh 2>/dev/null || true
+                snap refresh --hold && mkdir -p /opt/parallelcluster && touch /opt/parallelcluster/pcluster_build_image_snap_hold
+              fi
+
       # Initialize system information and URLs
       - name: SystemInfo
         action: ExecuteBash
@@ -258,6 +271,11 @@ phases:
                 rm -rf /tmp/imagebuilder_service/ssm_installed
               else
                  echo "SSM agent is installed by default"
+              fi
+              
+              if [[ -f /opt/parallelcluster/pcluster_build_image_snap_hold ]]; then
+                snap refresh --unhold 2>/dev/null || true
+                rm -rf /opt/parallelcluster/pcluster_build_image_snap_hold
               fi
               
               # Final cleanup


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/7159
See description of changes and testing in the original PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
