### PR TITLE
[Logging] Add ISO 8601 timestamp with milliseconds precision to chef-client.log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Add validator that warns against the downsides of disabling in-place updates on compute and login nodes through DevSettings.
 - Upgrade jmespath to ~=1.0 (from ~=0.10).
 - Upgrade tabulate to <=0.9.0 (from <=0.8.10).
+- Add ISO 8601 timestamp with milliseconds precision to chef-client.log.
 
 **BUG FIXES**
 - Add validation to block updates that change tag order. Blocking such change prevents update failures.

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -234,6 +234,7 @@ phases:
           - path: /etc/chef/client.rb
             content: |
               cookbook_path ['/etc/chef/cookbooks']
+              require '/etc/chef/cookbooks/aws-parallelcluster-shared/libraries/log_formatter'
             overwrite: true
           - path: /etc/parallelcluster/image_dna.json
             content: |


### PR DESCRIPTION
### Description of changes
Add ISO 8601 timestamp with milliseconds precision to chef-client.log.
This PR depends on https://github.com/aws/aws-parallelcluster-cookbook/pull/3071, where the chef log formatter is introduced.

### Tests
* Manually verified that logs in `che-client.log` now has logs with millisecond precision:
```
[2026-01-05T19:41:12.265+0000] INFO: {:system=>"ohai", :version=>"18.2.5", :resource=>"load cluster configuration"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
