### PR TITLE
[develop][cli] Improve curl retry for GitHub package downloads

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -137,7 +137,7 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
         vendor_cookbook
       fi
       cd /tmp

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -123,7 +123,7 @@ else
   error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
 fi
 if [ "${!custom_cookbook}" != "NONE" ]; then
-  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+  curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
   vendor_cookbook
 fi
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -219,7 +219,7 @@ phases:
               
               # Download cookbook
               mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
-              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
+              curl --retry 10 --retry-all-errors -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
               
               cd /etc/chef && tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz --strip-components 1 && rm -f aws-parallelcluster-cookbook.tgz
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -219,7 +219,7 @@ phases:
               
               # Download cookbook
               mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
-              curl --retry 10 --retry-all-errors -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
+              curl --retry 9 --retry-all-errors -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
               
               cd /etc/chef && tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz --strip-components 1 && rm -f aws-parallelcluster-cookbook.tgz
 

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -120,7 +120,7 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
         vendor_cookbook
       fi
       cd /tmp


### PR DESCRIPTION
### Description of changes
- Increase retry count from 3 to 9
- Add `--retry-all-errors` to retry on SSL and HTTP/2 errors

If we retry 9 times, it will wait:
1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 = 511 seconds = 8.51 minutes
It should can handle the China region network issue.

This fixes intermittent download failures in China regions caused by network instability when accessing GitHub.

### Tests
* build-image E2E test in China region ongoing

### References
* Cookbook PR for improving node package downloading: https://github.com/aws/aws-parallelcluster-cookbook/pull/3085

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
