### PR TITLE
[develop][cli] Use retry loop with curl as `--retry-all-errors` is not available for old curl versions

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -137,7 +137,12 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        delays=(1 2 4 8 16 32 64 128 256)
+        for i in {0..8}; do
+          curl -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} && break
+          echo "Curl attempt $((i+1)) failed, retrying in ${!delays[$i]}s..."
+          sleep ${!delays[$i]}
+        done
         vendor_cookbook
       fi
       cd /tmp

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -123,7 +123,12 @@ else
   error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
 fi
 if [ "${!custom_cookbook}" != "NONE" ]; then
-  curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+  delays=(1 2 4 8 16 32 64 128 256)
+  for i in {0..8}; do
+    curl -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} && break
+    echo "Curl attempt $((i+1)) failed, retrying in ${!delays[$i]}s..."
+    sleep ${!delays[$i]}
+  done
   vendor_cookbook
 fi
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -219,7 +219,12 @@ phases:
               
               # Download cookbook
               mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
-              curl --retry 9 --retry-all-errors -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
+              delays=(1 2 4 8 16 32 64 128 256)
+              for i in {0..8}; do
+                curl -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL" && break
+                echo "Curl attempt $((i+1)) failed, retrying in ${!delays[$i]}s..."
+                sleep ${!delays[$i]}
+              done
               
               cd /etc/chef && tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz --strip-components 1 && rm -f aws-parallelcluster-cookbook.tgz
 

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -120,7 +120,12 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 9 --retry-all-errors -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        delays=(1 2 4 8 16 32 64 128 256)
+        for i in {0..8}; do
+          curl -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} && break
+          echo "Curl attempt $((i+1)) failed, retrying in ${!delays[$i]}s..."
+          sleep ${!delays[$i]}
+        done
         vendor_cookbook
       fi
       cd /tmp


### PR DESCRIPTION
### Description of changes

Use retry loop with curl as `--retry-all-errors` is not available in curl v7.71+

* curl 7.71 is available in all OS except rhel8 and rocky8
* applying the same exponential backoff as with previous change where we wait at max (1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 = 511 seconds) of 8.51 minutes


Following the same logic as https://github.com/aws/aws-parallelcluster/pull/7180 

Without this change the failure is 
```

curl --retry 9 --retry-all-errors -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL"
curl: option --retry-all-errors: is unknown
curl: try 'curl --help' or 'curl --manual' for more information

cd /etc/chef && tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz --strip-components 1 && rm -f aws-parallelcluster-cookbook.tgz
```

### Tests
* BUILD IMAGE for rhel8/9 and rocky8/9

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
