### PR TITLE
[integ-test] Modify test to test cluster without Internet connection using GPU instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 - Fix LoginNodes NLB not being publicly accessible when using public subnet with implicit main route table association. 
   See https://github.com/aws/aws-parallelcluster/issues/7173
 - Fix cluster update failure when changing LoginNodes subnet by including subnet hash in target group logical ID and name.
+- Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 
 3.14.1
 ------

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -373,14 +373,12 @@ test-suites:
         - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
     test_cluster_networking.py::test_cluster_in_no_internet_subnet:
       dimensions:
-        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
-        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: [{{ DCV_OS_ARM_3 }}]
           schedulers: ["slurm"]
-        - regions: ["cn-north-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        - regions: ["cnn1-az1"]
+          instances: ["g4dn.2xlarge"]
           oss: [{{ DCV_OS_X86_3 }}]
           schedulers: ["slurm"]
         - regions: ["us-gov-west-1"]


### PR DESCRIPTION
### Description of changes
This test covers the cookbook fix: https://github.com/aws/aws-parallelcluster-cookbook/pull/3086

This commit also removes a comment that is no longer true

### Tests
The following test has passed:
```
test-suites:
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        - regions: ["use1-az2"]
          instances: ["g5.xlarge"]
          oss: ["rhel9"]
          schedulers: ["slurm"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
