### PR TITLE
[DevSettings] Add support for selective Chef Attributes updates + mark `cluster/slurm/reconfigure_timeout` as updatable

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -20,6 +20,7 @@ from pcluster.constants import (
     SLURM,
     STORAGE_TYPES_SUPPORTING_LIVE_UPDATES,
 )
+from pcluster.utils import get_dictionary_diff, parse_json_string
 
 
 class UpdatePolicy:
@@ -510,6 +511,38 @@ def get_pool_name_from_change_paths(change):
     return ""
 
 
+# ExtraChefAttributes update policy helpers
+# Define which paths within ExtraChefAttributes JSON are updatable (dot-notation)
+# IMPORTANT: We assume this set to contain the path to leaf fields.
+EXTRA_CHEF_ATTRIBUTES_UPDATABLE_PATHS: set[str] = {
+    "cluster.slurm.reconfigure_timeout",
+}
+
+
+def _get_non_updatable_changes(old_value: str, new_value: str) -> list[str]:
+    """Parse and compare two ExtraChefAttributes JSON strings, returning paths that are not updatable."""
+    old_attrs = parse_json_string(old_value, raise_on_error=False, default={}) if old_value else {}
+    new_attrs = parse_json_string(new_value, raise_on_error=False, default={}) if new_value else {}
+
+    return [p for p in get_dictionary_diff(old_attrs, new_attrs) if p not in EXTRA_CHEF_ATTRIBUTES_UPDATABLE_PATHS]
+
+
+def condition_checker_extra_chef_attributes(change, _) -> bool:
+    """
+    Check if ExtraChefAttributes changes are allowed.
+
+    Only changes to paths defined in EXTRA_CHEF_ATTRIBUTES_UPDATABLE_PATHS are allowed.
+    """
+    return len(_get_non_updatable_changes(change.old_value, change.new_value)) == 0
+
+
+def fail_reason_extra_chef_attributes(change, _) -> str:
+    """Generate fail reason for ExtraChefAttributes update."""
+    non_updatable_changes = _get_non_updatable_changes(change.old_value, change.new_value)
+    paths_str = ", ".join(sorted(non_updatable_changes))
+    return f"The following ExtraChefAttributes fields cannot be updated: {paths_str}"
+
+
 # Common fail_reason messages
 UpdatePolicy.FAIL_REASONS = {
     "ebs_volume_resize": "Updating the file system after a resize operation requires commands specific to your "
@@ -526,6 +559,7 @@ UpdatePolicy.FAIL_REASONS = {
     "compute_or_login_nodes_running": lambda change, patch: (
         "The update is not supported when compute or login nodes are running"
     ),
+    "extra_chef_attributes_update": fail_reason_extra_chef_attributes,
 }
 
 # Common action_needed messages
@@ -548,6 +582,9 @@ UpdatePolicy.ACTIONS_NEEDED = {
         "Stop the login nodes by setting Count parameter to 0 "
         "and update the cluster with the pcluster update-cluster command"
     ),
+    "extra_chef_attributes_update": lambda change, patch: (
+        "Revert the non-updatable ExtraChefAttributes fields to their original values."
+    ),
 }
 
 # Base policies
@@ -565,6 +602,15 @@ UpdatePolicy.IGNORED = UpdatePolicy(
 # Update supported
 UpdatePolicy.SUPPORTED = UpdatePolicy(
     name="SUPPORTED", level=0, fail_reason="-", condition_checker=(lambda change, patch: True)
+)
+
+# Update policy for ExtraChefAttributes - allows updates to specific fields only
+UpdatePolicy.EXTRA_CHEF_ATTRIBUTES = UpdatePolicy(
+    name="EXTRA_CHEF_ATTRIBUTES",
+    level=5,
+    fail_reason=UpdatePolicy.FAIL_REASONS["extra_chef_attributes_update"],
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["extra_chef_attributes_update"],
+    condition_checker=condition_checker_extra_chef_attributes,
 )
 
 # Checks resize of max_vcpus in Batch Compute Environment

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -216,13 +216,7 @@ class CookbookSchema(BaseSchema):
             )
         }
     )
-    extra_chef_attributes = fields.Str(
-        metadata={
-            "update_policy": UpdatePolicy(
-                UpdatePolicy.UNSUPPORTED, fail_reason=UpdatePolicy.FAIL_REASONS["cookbook_update"]
-            )
-        }
-    )
+    extra_chef_attributes = fields.Str(metadata={"update_policy": UpdatePolicy.EXTRA_CHEF_ATTRIBUTES})
 
     @post_load()
     def make_resource(self, data, **kwargs):
@@ -275,7 +269,7 @@ class BaseDeploymentSettingsSchema(BaseSchema):
 class BaseDevSettingsSchema(BaseSchema):
     """Represent the common schema of Dev Setting for ImageBuilder and Cluster."""
 
-    cookbook = fields.Nested(CookbookSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    cookbook = fields.Nested(CookbookSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     node_package = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     aws_batch_cli_package = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -614,3 +614,79 @@ def get_needed_ultraserver_capacity_block_statuses(statuses, capacity_reservatio
         ):
             needed_capacity_block_statuses.append(status)
     return needed_capacity_block_statuses
+
+
+def parse_json_string(value: str, raise_on_error: bool = False, default: any = None) -> any:
+    """
+    Parse a JSON string into a Python object.
+
+    :param value: JSON string to parse
+    :param raise_on_error: If True, raises exception on parse failure; if False, returns default
+    :param default: Value to return on parse failure when raise_on_error is False
+    :return: Parsed JSON object or default value on failure
+    """
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError) as e:
+        LOGGER.error("Failed to parse JSON string: %s. Error: %s", value, e)
+        if raise_on_error:
+            raise e
+        return default
+
+
+def _collect_leaves(d: dict, prefix: str) -> set[str]:
+    """Collect all leaf paths from a dict."""
+    leaves = set()
+    for k, v in d.items():
+        key_path = f"{prefix}.{k}" if prefix else str(k)
+        if isinstance(v, dict) and v:
+            leaves.update(_collect_leaves(v, key_path))
+        else:
+            leaves.add(key_path)
+    return leaves if leaves else {prefix} if prefix else set()
+
+
+def _collect_diff_for_key(d: dict, key: str, path: str) -> set[str]:
+    """Collect leaf paths for a key that exists only in one dictionary."""
+    key_path = f"{path}.{key}" if path else str(key)
+    if isinstance(d[key], dict) and d[key]:
+        return _collect_leaves(d[key], key_path)
+    return {key_path}
+
+
+def get_dictionary_diff(d1: dict, d2: dict, path: str = "") -> set[str]:
+    """
+    Recursively find all leaf paths where two dictionaries differ.
+
+    Returns a set of dot-notation paths (e.g., "cluster.settings.enabled") where
+    the dictionaries have different values, including added or removed keys.
+    Always returns leaf paths, never intermediate dict paths.
+
+    :param d1: First dictionary to compare (if None, treated as empty dict)
+    :param d2: Second dictionary to compare (if None, treated as empty dict)
+    :param path: Current path prefix (used for recursion)
+    :return: Set of dot-notation paths where dictionaries differ.
+             If no differences detected return empoty set.
+    """
+    d1 = d1 or {}
+    d2 = d2 or {}
+
+    diffs: set[str] = set()
+    keys1, keys2 = set(d1.keys()), set(d2.keys())
+
+    # Collect paths that are added or remove
+    for k in keys1 - keys2:
+        diffs.update(_collect_diff_for_key(d1, k, path))
+
+    for k in keys2 - keys1:
+        diffs.update(_collect_diff_for_key(d2, k, path))
+
+    # Compare paths
+    for k in keys1 & keys2:
+        key_path = f"{path}.{k}" if path else str(k)
+        if isinstance(d1[k], dict) and isinstance(d2[k], dict):
+            diffs.update(get_dictionary_diff(d1[k], d2[k], key_path))
+        elif d1[k] != d2[k]:
+            diffs.add(key_path)
+
+    return diffs

--- a/cli/src/pcluster/validators/dev_settings_validators.py
+++ b/cli/src/pcluster/validators/dev_settings_validators.py
@@ -15,6 +15,8 @@ from pcluster.validators.utils import dig, is_boolean_string, str_to_bool
 
 EXTRA_CHEF_ATTRIBUTES_PATH = "DevSettings/Cookbook/ExtraChefAttributes"
 ATTR_IN_PLACE_UPDATE_ON_FLEET_ENABLED = "in_place_update_on_fleet_enabled"
+ATTR_RECONFIGURE_TIMEOUT = "cluster.slurm.reconfigure_timeout"
+MIN_SLURM_RECONFIGURE_TIMEOUT = 300
 
 
 class ExtraChefAttributesValidator(Validator):
@@ -29,8 +31,10 @@ class ExtraChefAttributesValidator(Validator):
         """
         if not extra_chef_attributes:
             return
-        else:
-            self._validate_in_place_update_on_fleet_enabled(json.loads(extra_chef_attributes))
+
+        attrs = json.loads(extra_chef_attributes)
+        self._validate_in_place_update_on_fleet_enabled(attrs)
+        self._validate_slurm_reconfigure_timeout(attrs)
 
     def _validate_in_place_update_on_fleet_enabled(self, extra_chef_attributes: dict = None):
         """Validate attribute cluster.in_place_update_on_fleet_enabled.
@@ -59,4 +63,34 @@ class ExtraChefAttributesValidator(Validator):
                 "When in-place updates are disabled, cluster updates are applied "
                 "by replacing compute and login nodes according to the selected QueueUpdateStrategy.",
                 FailureLevel.WARNING,
+            )
+
+    def _validate_slurm_reconfigure_timeout(self, extra_chef_attributes: dict = None):
+        """Validate attribute cluster.slurm.reconfigure-timeout.
+
+        Must be an integer greater than 300.
+
+        Args:
+            extra_chef_attributes: Dictionary of Chef attributes to validate.
+        """
+        reconfigure_timeout = dig(extra_chef_attributes, *ATTR_RECONFIGURE_TIMEOUT.split("."))
+
+        if reconfigure_timeout is None:
+            return
+
+        # Reject booleans explicitly (bool is subclass of int in Python)
+        if isinstance(reconfigure_timeout, bool) or not isinstance(reconfigure_timeout, int):
+            self._add_failure(
+                f"Invalid value in {EXTRA_CHEF_ATTRIBUTES_PATH}: "
+                f"attribute '{ATTR_RECONFIGURE_TIMEOUT}' must be an integer.",
+                FailureLevel.ERROR,
+            )
+            return
+
+        if reconfigure_timeout <= MIN_SLURM_RECONFIGURE_TIMEOUT:
+            self._add_failure(
+                f"Invalid value in {EXTRA_CHEF_ATTRIBUTES_PATH}: "
+                f"attribute '{ATTR_RECONFIGURE_TIMEOUT}' "
+                f"must be greater than {MIN_SLURM_RECONFIGURE_TIMEOUT}.",
+                FailureLevel.ERROR,
             )

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -2758,3 +2758,181 @@ def test_home_change_policy(
         assert_that(UpdatePolicy.SHARED_STORAGE_UPDATE_POLICY.action_needed(change_mock, patch_mock)).is_equal_to(
             expected_action_needed
         )
+
+
+# Tests for EXTRA_CHEF_ATTRIBUTES update policy
+@pytest.mark.parametrize(
+    "old_value, new_value, expected_result",
+    [
+        # No change - should succeed
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            True,
+            id="no change to updatable field",
+        ),
+        # Change only updatable field - should succeed
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}}}',
+            True,
+            id="change updatable field from 300 to 600",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            True,
+            id="change updatable field from 600 to 300",
+        ),
+        pytest.param(
+            None,
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            True,
+            id="add updatable field when none existed",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            None,
+            True,
+            id="remove updatable field",
+        ),
+        pytest.param(
+            "{}",
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            True,
+            id="add updatable field to empty json",
+        ),
+        # Change non-updatable field - should fail
+        pytest.param(
+            '{"cluster": {"some_other_field": "value1"}}',
+            '{"cluster": {"some_other_field": "value2"}}',
+            False,
+            id="change non-updatable field",
+        ),
+        pytest.param(
+            '{"other_key": "value1"}',
+            '{"other_key": "value2"}',
+            False,
+            id="change top-level non-updatable field",
+        ),
+        pytest.param(
+            None,
+            '{"cluster": {"some_other_field": "value"}}',
+            False,
+            id="add non-updatable field",
+        ),
+        pytest.param(
+            '{"cluster": {"some_other_field": "value"}}',
+            None,
+            False,
+            id="remove non-updatable field",
+        ),
+        # Mixed changes - should fail (non-updatable field changed)
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}, "other_field": "value1"}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}, "other_field": "value2"}}',
+            False,
+            id="change both updatable and non-updatable fields",
+        ),
+        # Change updatable field while keeping non-updatable field unchanged - should succeed
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}, "other_field": "same_value"}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}, "other_field": "same_value"}}',
+            True,
+            id="change updatable field while non-updatable field unchanged",
+        ),
+        # Empty to empty - should succeed
+        pytest.param(
+            "{}",
+            "{}",
+            True,
+            id="empty to empty",
+        ),
+        pytest.param(
+            None,
+            None,
+            True,
+            id="none to none",
+        ),
+        # Handle "-" as empty (used in config patch for missing values)
+        pytest.param(
+            "-",
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            True,
+            id="dash to updatable field",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}}}',
+            "-",
+            True,
+            id="updatable field to dash",
+        ),
+    ],
+)
+def test_extra_chef_attributes_condition_checker(mocker, old_value, new_value, expected_result):
+    patch_mock = mocker.MagicMock()
+    change_mock = mocker.MagicMock()
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+    change_mock.key = "ExtraChefAttributes"
+
+    assert_that(UpdatePolicy.EXTRA_CHEF_ATTRIBUTES.condition_checker(change_mock, patch_mock)).is_equal_to(
+        expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "old_value, new_value, expected_fail_reason_contains",
+    [
+        pytest.param(
+            '{"cluster": {"some_other_field": "value1"}}',
+            '{"cluster": {"some_other_field": "value2"}}',
+            "cluster.some_other_field",
+            id="fail reason contains changed field path",
+        ),
+        pytest.param(
+            '{"other_key": "value1"}',
+            '{"other_key": "value2"}',
+            "other_key",
+            id="fail reason contains top-level changed field",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "300"}, "other_field": "value1"}}',
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}, "other_field": "value2"}}',
+            "cluster.other_field",
+            id="fail reason contains only non-updatable changed field",
+        ),
+    ],
+)
+def test_extra_chef_attributes_fail_reason(mocker, old_value, new_value, expected_fail_reason_contains):
+    patch_mock = mocker.MagicMock()
+    change_mock = mocker.MagicMock()
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+    change_mock.key = "ExtraChefAttributes"
+
+    fail_reason = UpdatePolicy.EXTRA_CHEF_ATTRIBUTES.fail_reason(change_mock, patch_mock)
+    assert_that(fail_reason).contains(expected_fail_reason_contains)
+    assert_that(fail_reason).contains("cannot be updated")
+
+
+@pytest.mark.parametrize(
+    "old_value, new_value",
+    [
+        pytest.param(
+            '{"cluster": {"some_other_field": "value1"}}',
+            '{"cluster": {"some_other_field": "value2"}}',
+            id="action needed for non-updatable field change",
+        ),
+    ],
+)
+def test_extra_chef_attributes_action_needed(mocker, old_value, new_value):
+    patch_mock = mocker.MagicMock()
+    change_mock = mocker.MagicMock()
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+    change_mock.key = "ExtraChefAttributes"
+
+    action_needed = UpdatePolicy.EXTRA_CHEF_ATTRIBUTES.action_needed(change_mock, patch_mock)
+    assert_that(action_needed).contains("Revert")
+    assert_that(action_needed).contains("non-updatable")

--- a/cli/tests/pcluster/schemas/test_common_schema.py
+++ b/cli/tests/pcluster/schemas/test_common_schema.py
@@ -13,8 +13,11 @@ from assertpy import assert_that
 from marshmallow import ValidationError
 
 from pcluster.config.common import BaseTag
+from pcluster.config.update_policy import UpdatePolicy
 from pcluster.constants import PCLUSTER_PREFIX
 from pcluster.schemas.common_schema import (
+    BaseDevSettingsSchema,
+    CookbookSchema,
     ImdsSchema,
     LambdaFunctionsVpcConfigSchema,
     validate_json_format,
@@ -138,3 +141,32 @@ def test_validate_no_duplicate_tag(tags, failure_message):
             validate_no_duplicate_tag(tags)
     else:
         validate_no_duplicate_tag(tags)
+
+
+@pytest.mark.parametrize(
+    "schema_class, field_name, expected_update_policy",
+    [
+        pytest.param(
+            BaseDevSettingsSchema,
+            "cookbook",
+            UpdatePolicy.IGNORED,
+            id="Cookbook field in BaseDevSettingsSchema has IGNORED update policy",
+        ),
+        pytest.param(
+            CookbookSchema,
+            "extra_chef_attributes",
+            UpdatePolicy.EXTRA_CHEF_ATTRIBUTES,
+            id="ExtraChefAttributes field in CookbookSchema has EXTRA_CHEF_ATTRIBUTES update policy",
+        ),
+    ],
+)
+def test_cookbook_update_policy(schema_class, field_name, expected_update_policy):
+    """Test that Cookbook and ExtraChefAttributes fields have the correct update policies.
+
+    The Cookbook field update policy was changed from UNSUPPORTED to IGNORED to allow
+    the update policy to be determined by nested fields (e.g., ExtraChefAttributes).
+    """
+    schema = schema_class()
+    field = schema.fields[field_name]
+    actual_update_policy = field.metadata.get("update_policy")
+    assert_that(actual_update_policy).is_equal_to(expected_update_policy)

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -1036,3 +1036,181 @@ def test_get_needed_ultraserver_capacity_block_statuses(statuses, capacity_reser
     """Test get_needed_ultraserver_capacity_block_statuses function."""
     result = utils.get_needed_ultraserver_capacity_block_statuses(statuses, capacity_reservation_ids)
     assert_that(result).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "value, raise_on_error, default, expected, raises",
+    [
+        # Valid JSON parsing
+        pytest.param('{"key": "value"}', False, None, {"key": "value"}, None, id="valid simple object"),
+        pytest.param(
+            '{"nested": {"a": 1, "b": 2}}', False, None, {"nested": {"a": 1, "b": 2}}, None, id="valid nested object"
+        ),
+        pytest.param("[1, 2, 3]", False, None, [1, 2, 3], None, id="valid array"),
+        pytest.param('"string"', False, None, "string", None, id="valid string value"),
+        pytest.param("123", False, None, 123, None, id="valid number value"),
+        pytest.param("true", False, None, True, None, id="valid boolean value"),
+        pytest.param("null", False, None, None, None, id="valid null value"),
+        # Invalid JSON with raise_on_error=False returns default
+        pytest.param("invalid json", False, None, None, None, id="invalid json returns None default"),
+        pytest.param("invalid json", False, {}, {}, None, id="invalid json returns empty dict default"),
+        pytest.param("invalid json", False, [], [], None, id="invalid json returns empty list default"),
+        pytest.param(
+            "{missing: quotes}", False, "default", "default", None, id="malformed json returns string default"
+        ),
+        pytest.param("", False, None, None, None, id="empty string returns None default"),
+        pytest.param(None, False, {}, {}, None, id="none value returns default"),
+        # Invalid JSON with raise_on_error=True raises exception
+        pytest.param("invalid json", True, None, None, Exception, id="invalid json raises when configured"),
+        pytest.param(None, True, None, None, TypeError, id="none value raises when configured"),
+    ],
+)
+def test_parse_json_string(value, raise_on_error, default, expected, raises):
+    if raises:
+        with pytest.raises(raises):
+            utils.parse_json_string(value, raise_on_error=raise_on_error, default=default)
+    else:
+        assert_that(utils.parse_json_string(value, raise_on_error=raise_on_error, default=default)).is_equal_to(
+            expected
+        )
+
+
+@pytest.mark.parametrize(
+    "d1, d2, expected",
+    [
+        pytest.param(
+            {"a": 1, "b": {"c": 2}},
+            {"a": 1, "b": {"c": 2}},
+            set(),
+            id="identical dicts returns empty",
+        ),
+        pytest.param(
+            {},
+            {},
+            set(),
+            id="empty dicts returns empty",
+        ),
+        pytest.param(
+            {"a": 1},
+            {"a": 1, "b": 2},
+            {"b"},
+            id="added key",
+        ),
+        pytest.param(
+            {"a": 1, "b": 2},
+            {"a": 1},
+            {"b"},
+            id="removed key",
+        ),
+        pytest.param(
+            {"a": 1, "b": 2},
+            {"a": 1, "b": 3},
+            {"b"},
+            id="changed value",
+        ),
+        pytest.param(
+            {"a": {"x": 1}},
+            {"a": {"x": 1, "y": 2}},
+            {"a.y"},
+            id="nested added key",
+        ),
+        pytest.param(
+            {"a": {"x": 1, "y": 2}},
+            {"a": {"x": 1}},
+            {"a.y"},
+            id="nested removed key",
+        ),
+        pytest.param(
+            {"a": {"x": 1}},
+            {"a": {"x": 2}},
+            {"a.x"},
+            id="nested changed value",
+        ),
+        pytest.param(
+            {"a": {"b": {"c": {"d": 1}}}},
+            {"a": {"b": {"c": {"d": 2}}}},
+            {"a.b.c.d"},
+            id="deeply nested change",
+        ),
+        pytest.param(
+            {"a": 1, "b": {"x": 10, "y": 20}, "c": 3},
+            {"a": 1, "b": {"x": 10, "y": 25}, "d": 4},
+            {"b.y", "c", "d"},
+            id="multiple changes",
+        ),
+        pytest.param(
+            {"a": {"nested": 1}},
+            {"a": "string"},
+            {"a"},
+            id="type change dict to value",
+        ),
+        pytest.param(
+            {"a": "string"},
+            {"a": {"nested": 1}},
+            {"a"},
+            id="type change value to dict",
+        ),
+        pytest.param(
+            {"a": 1, "b": 2},
+            {},
+            {"a", "b"},
+            id="compare with empty dict",
+        ),
+        pytest.param(
+            {},
+            {"a": 1, "b": 2},
+            {"a", "b"},
+            id="compare empty with populated",
+        ),
+        pytest.param(
+            None,
+            None,
+            set(),
+            id="none inputs returns empty set",
+        ),
+        pytest.param(
+            None,
+            {"a": 1, "b": 2},
+            {"a", "b"},
+            id="none first dict",
+        ),
+        pytest.param(
+            {"a": 1, "b": 2},
+            None,
+            {"a", "b"},
+            id="none second dict",
+        ),
+        pytest.param(
+            {},
+            {"cluster": {"slurm": {"timeout": 300}}},
+            {"cluster.slurm.timeout"},
+            id="added nested dict returns leaf paths",
+        ),
+        pytest.param(
+            {"cluster": {"slurm": {"timeout": 300}}},
+            {},
+            {"cluster.slurm.timeout"},
+            id="removed nested dict returns leaf paths",
+        ),
+        pytest.param(
+            {},
+            {"cluster": {"slurm": {"timeout": 300, "enabled": True}}},
+            {"cluster.slurm.timeout", "cluster.slurm.enabled"},
+            id="added nested dict with multiple leaves",
+        ),
+        pytest.param(
+            {"cluster": {"slurm": {"timeout": 300, "enabled": True}}},
+            {},
+            {"cluster.slurm.timeout", "cluster.slurm.enabled"},
+            id="removed nested dict with multiple leaves",
+        ),
+        pytest.param(
+            {},
+            {"cluster": {}},
+            {"cluster"},
+            id="added empty nested dict returns parent path",
+        ),
+    ],
+)
+def test_get_dictionary_diff(d1, d2, expected):
+    assert_that(utils.get_dictionary_diff(d1, d2)).is_equal_to(expected)

--- a/cli/tests/pcluster/validators/test_dev_settings_validators.py
+++ b/cli/tests/pcluster/validators/test_dev_settings_validators.py
@@ -62,7 +62,103 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         ),
     ],
 )
-def test_extra_chef_attributes_validator(extra_chef_attributes, expected_message, expected_failure_level):
+def test_extra_chef_attributes_validator_in_place_update(
+    extra_chef_attributes, expected_message, expected_failure_level
+):
+    actual_failures = ExtraChefAttributesValidator().execute(extra_chef_attributes=extra_chef_attributes)
+    assert_failure_messages(actual_failures, expected_message)
+    if expected_failure_level:
+        assert_failure_level(actual_failures, expected_failure_level)
+
+
+@pytest.mark.parametrize(
+    "extra_chef_attributes, expected_message, expected_failure_level",
+    [
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 600}}}',
+            None,
+            None,
+            id="reconfigure_timeout valid integer > 300",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 301}}}',
+            None,
+            None,
+            id="reconfigure_timeout valid integer just above 300",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 300}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be greater than 300.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout equal to 300 throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 100}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be greater than 300.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout less than 300 throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 0}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be greater than 300.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout zero throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": -100}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be greater than 300.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout negative throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": "600"}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be an integer.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout string throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": true}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be an integer.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout boolean true throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": false}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be an integer.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout boolean false throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"reconfigure_timeout": 3.14}}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.slurm.reconfigure_timeout' must be an integer.",
+            FailureLevel.ERROR,
+            id="reconfigure_timeout float throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"slurm": {"other-setting": "value"}}}',
+            None,
+            None,
+            id="reconfigure_timeout not set passes",
+        ),
+        pytest.param(
+            '{"cluster": {"other": "value"}}',
+            None,
+            None,
+            id="slurm section not present passes",
+        ),
+    ],
+)
+def test_extra_chef_attributes_validator_reconfigure_timeout(
+    extra_chef_attributes, expected_message, expected_failure_level
+):
     actual_failures = ExtraChefAttributesValidator().execute(extra_chef_attributes=extra_chef_attributes)
     assert_failure_messages(actual_failures, expected_message)
     if expected_failure_level:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
@@ -53,4 +53,8 @@ DevSettings:
   Timeouts:
     HeadNodeBootstrapTimeout: 1700
     ComputeNodeBootstrapTimeout: {{compute_node_bootstrap_timeout}}
+  Cookbook:
+    # This DevSettings is here just to verify that the Slurm reconfigure timeout can be updated.
+    ExtraChefAttributes: |
+      { "cluster" : { "slurm" : { "reconfigure_timeout": 600 } } }
 


### PR DESCRIPTION
### Description of changes
Add support for selective ExtraChefAttributes updates.
Accept updates for the Chef attribute `cluster/slurm/reconfigure_timeout`.
The new Chef attribute is introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/3087.

Use the new attribute in the existing cluster update executed by `test_slurm`, to validate that the update would succeed.

### User Experience

#### [UC1] Setting `reconfigure_timeout > 300`, should succeed

```
# From
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"

# To
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"
  Cookbook:
    ExtraChefAttributes: |
      { "cluster" : { "slurm" : { "reconfigure_timeout": 600 } } }

# Result
{
  "cluster": {
    "clusterName": "simple-0107-3",
    "cloudformationStackStatus": "UPDATE_IN_PROGRESS",
    "cloudformationStackArn": "arn:aws:cloudformation:us-east-1:319414405305:stack/simple-0107-3/a00668f0-ec0d-11f0-b576-0affc7d57d0d",
    "region": "us-east-1",
    "version": "3.15.0",
    "clusterStatus": "UPDATE_IN_PROGRESS",
    "scheduler": {
      "type": "slurm"
    }
  },
  "changeSet": [
    {
      "parameter": "DevSettings.Cookbook.ExtraChefAttributes",
      "requestedValue": "{ \"cluster\" : { \"slurm\" : { \"reconfigure_timeout\": 600 } } }\n",
      "currentValue": "-"
    }
  ]
}
```

#### [UC2]  Setting `reconfigure_timeout` to non integer value, should fail

```
# From
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"

# To
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"
  Cookbook:
    ExtraChefAttributes: |
      { "cluster" : { "slurm" : { "reconfigure_timeout":"xyz" } } }

# Result
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ExtraChefAttributesValidator",
      "message": "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: attribute 'cluster/slurm/reconfigure_timeout' must be an integer."
    }
  ],
  "message": "Invalid cluster configuration."
}
```

#### [UC3]  Setting `reconfigure_timeout < 300`, should fail

```
# From
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"

# To
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"
  Cookbook:
    ExtraChefAttributes: |
      { "cluster" : { "slurm" : { "reconfigure_timeout": 200 } } }

# Result
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ExtraChefAttributesValidator",
      "message": "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: attribute 'cluster/slurm/reconfigure_timeout' must be greater than 300."
    }
  ],
  "message": "Invalid cluster configuration."
}
```

#### [UC4]  Setting a non existing attribute, should fail

```
# From
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"

# To
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"
  Cookbook:
    ExtraChefAttributes: |
      { "cluster" : { "slurm" : { "reconfigure_timeoutX": 600 } } }

# Result
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "DevSettings.Cookbook.ExtraChefAttributes",
      "requestedValue": "{ \"cluster\" : { \"slurm\" : { \"reconfigure-timeoutX\": 600 } } }",
      "message": "The following ExtraChefAttributes fields cannot be updated: cluster.slurm.reconfigure_timeoutX. Revert the non-updatable ExtraChefAttributes fields to their original values.",
      "currentValue": "-"
    }
  ],
  "changeSet": [
    {
      "parameter": "DevSettings.Cookbook.ExtraChefAttributes",
      "requestedValue": "{ \"cluster\" : { \"slurm\" : { \"reconfigure_timeoutX\": 600 } } }",
      "currentValue": "-"
    }
 
```

#### [UC5]  Setting a non updatable attribute, should fail

```
# From
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"

# To
DevSettings:
  AmiSearchFilters:
    Owner: "447714826191"
  Cookbook:
    ExtraChefAttributes: |
      { "cluster" : { "slurm" : { "reconfigure_timeout": 600 }, "in_place_update_on_fleet_enabled" : "false"} }

# Result
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "DevSettings.Cookbook.ExtraChefAttributes",
      "requestedValue": "{ \"cluster\" : { \"slurm\" : { \"reconfigure_timeout\": 600 }, \"in_place_update_on_fleet_enabled\" : \"false\"} }\n",
      "message": "The following ExtraChefAttributes fields cannot be updated: cluster.in_place_update_on_fleet_enabled. Revert the non-updatable ExtraChefAttributes fields to their original values.",
      "currentValue": "-"
    }
  ],
  "changeSet": [
    {
      "parameter": "DevSettings.Cookbook.ExtraChefAttributes",
      "requestedValue": "{ \"cluster\" : { \"slurm\" : { \"reconfigure_timeout\": 600 }, \"in_place_update_on_fleet_enabled\" : \"false\"} }\n",
      "currentValue": "-"
    }
  ]
}
```

### Tests
* Unit tests (they cover the changes)
* Manually verified the user experience (see above UX)
* [ONGOING] E2E test `test_slurm` (using custom cookbook with changes from https://github.com/aws/aws-parallelcluster-cookbook/pull/3087), where we update the attribute `cluster/slurm/reconfigure_timeout`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
