### PR TITLE
Revert "[StarCCM] Update test_starccm performance test to use in_place_update_on_fleet_enabled"

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -32,6 +32,7 @@ OSU_BENCHMARKS_INSTANCES = ["c5n.18xlarge", "p5en.48xlarge", "p6-b200.48xlarge"]
 
 
 @pytest.mark.usefixtures("serial_execution_by_instance")
+@pytest.mark.flaky(reruns=0)
 def test_osu(
     os,
     region,

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -58,13 +58,12 @@ def calculate_observed_value(result, remote_command_executor, scheduler_commands
 
 
 @pytest.mark.usefixtures("serial_execution_by_instance")
-@pytest.mark.parametrize("in_place_update_on_fleet_enabled", ["true", "false"])
+@pytest.mark.flaky(reruns=0)
 def test_starccm(
     vpc_stack,
     instance,
     os,
     region,
-    in_place_update_on_fleet_enabled,
     scheduler,
     pcluster_config_reader,
     clusters_factory,
@@ -83,14 +82,10 @@ def test_starccm(
     s3 = boto3.client("s3")
     s3.upload_file(str(test_datadir / "dependencies.install.sh"), bucket_name, "scripts/dependencies.install.sh")
 
-    chef_attributes_dict = {"cluster": {"in_place_update_on_fleet_enabled": in_place_update_on_fleet_enabled}}
-    extra_chef_attributes = json.dumps(chef_attributes_dict)
-
     cluster_config = pcluster_config_reader(
         bucket_name=bucket_name,
         install_extra_deps=os in OSS_REQUIRING_EXTRA_DEPS,
         number_of_nodes=max(number_of_nodes),
-        extra_chef_attributes=extra_chef_attributes,
     )
     cluster = clusters_factory(cluster_config)
     logging.info("Cluster Created")
@@ -119,8 +114,9 @@ def test_starccm(
         instance_slots = fetch_instance_slots(region, instance, multithreading_disabled=True)
         run_command = f'sbatch --ntasks={num_of_nodes * instance_slots} starccm.slurm.sh "{podkey}" "{licpath}"'
         multiple_runs = []
-        # Run at least twice up to whatever parallelism allows to maximize usage of available nodes
-        number_of_runs = max(parallelism, 2)
+        # Run at least four times up to whatever parallelism allows to maximize usage of available nodes
+        # Running the test multiple times reduces and get the average value improves stability of the result.
+        number_of_runs = max(parallelism, 4)
         for _ in range(number_of_runs):
             multiple_runs.append(remote_command_executor.run_remote_command(run_command))
         for run in multiple_runs:

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -62,6 +62,3 @@ SharedStorage:
       DeploymentType: PERSISTENT_1
       PerUnitStorageThroughput: 100
       StorageType: SSD
-DevSettings:
-  Cookbook:
-    ExtraChefAttributes: '{{ extra_chef_attributes }}'


### PR DESCRIPTION
### Description of changes
This reverts commit 67d69893. We don't need in_place_update_on_fleet_enabled because [the long term solution](https://github.com/aws/aws-parallelcluster-cookbook/pull/3070) is work in progress 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
