### PR TITLE
[integ-tests-framework] When generating launch time and performance reports, separate the report according to instance type

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -255,7 +255,7 @@ def generate_performance_report(reports_output_dir):
     )
     all_items.sort(key=lambda x: x["timestamp"]["N"], reverse=True)
     items_by_name = defaultdict(list)
-    category_names = [("name", "S"), ("mpi_variation", "S"), ("num_instances", "N")]
+    category_names = [("name", "S"), ("mpi_variation", "S"), ("num_instances", "N"), ("instance", "S")]
     for item in all_items:
         keys = []
         for category_name, value_type in category_names:


### PR DESCRIPTION
### Description of changes
This commit makes the trend even clearer, because we won't be confused by sudden changes because we test some instance types (e.g. p6-b200) temporarily

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
