### PR TITLE
[integ-tests-framework] Dump job output when job state assertion fails

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -385,7 +385,7 @@ class SlurmCommands(SchedulerCommands):
         else:
             return self._remote_command_executor.run_remote_command(submission_command, raise_on_error=raise_on_error)
 
-    def _dump_job_output(self, job_info):
+    def _dump_job_output(self, job_id, job_info):
         params = re.split(r"\s+", job_info)
         stderr = None
         stdout = None
@@ -411,19 +411,17 @@ class SlurmCommands(SchedulerCommands):
                     stdout_result = self._remote_command_executor.run_remote_command(f'echo "stdout" && cat {stdout}')
                     logging.error(stdout_result.stdout)
         else:
-            logging.error("Unable to retrieve job output.")
+            logging.info("No stdout or stderr for job %s.", job_id)
 
     def assert_job_succeeded(self, job_id, children_number=0):  # noqa: D102
         self.assert_job_state(job_id, "COMPLETED")
 
     def assert_job_state(self, job_id, expected_state):  # noqa: D102
         result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
-        try:
-            assert_that(result.stdout).contains(f"JobState={expected_state}")
-        except AssertionError:
+        if f"JobState={expected_state}" not in result.stdout:
             logging.error("JobState of jobid %s not in %s:\n%s", job_id, expected_state, result.stdout)
-            self._dump_job_output(result.stdout)
-            raise
+            self._dump_job_output(job_id, result.stdout)
+        assert_that(result.stdout).contains(f"JobState={expected_state}")
 
     def compute_nodes_count(self, filter_by_partition=None):  # noqa: D102
         return len(self.get_compute_nodes(filter_by_partition))


### PR DESCRIPTION
### Description of changes
The `_dump_job_output` has been there in the codebase without anyone using it. This commit uses it. This commit also change an ERROR meesage in the function to INFO to avoid polluting logs with too many ERRORs

### Tests
When `test_starccm` fails, the job stdout and stderr is in the console output

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
