### PR TITLE
Fix test_update_rollback_failure test by disabling the pcluster-check-update.timer on the CN instead of cfn-hup

### DIFF
--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -79,15 +79,13 @@ class SshCommand(CliCommand):
         "Run ssh command with the cluster username and IP address pre-populated. "
         "Arbitrary arguments are appended to the end of the ssh command."
     )
-    epilog = textwrap.dedent(
-        """Example:
+    epilog = textwrap.dedent("""Example:
 
   pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa
 
 Returns an ssh command with the cluster username and IP address pre-populated:
 
-  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa"""
-    )
+  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa""")
 
     def __init__(self, subparsers):
         super().__init__(

--- a/cli/tests/pcluster/models/test_s3_bucket.py
+++ b/cli/tests/pcluster/models/test_s3_bucket.py
@@ -245,15 +245,13 @@ def test_get_resource_url(region, bucket_name, cluster_name, resource_name, expe
                 "B": {"B1": "M"},
             },
             S3FileFormat.YAML,
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 A:
                   A1: X
                   A2: Y
                 B:
                   B1: M
-                """
-            ),
+                """),
         ),
         (
             {

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -129,7 +129,7 @@ deps =
 commands =
     bandit -r \
         -c .bandit.ini \
-        --exclude ../tests,tests,../cloudformation/tests \
+        --exclude ../tests,tests,../cloudformation/tests,src/pcluster/api/models \
         {[vars]code_dirs} \
         {posargs}
 

--- a/tests/integration-tests/tests/update/test_update_rollback_failure.py
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure.py
@@ -104,10 +104,10 @@ def test_update_rollback_failure(
     logger.info("Injecting cfn-signal failure on head node...")
     _inject_cfn_signal_failure(remote_command_executor)
 
-    # Step 3: Disable cfn-hup on CN1 BEFORE update
+    # Step 3: Disable pcluster-check-update timer on CN1 BEFORE update
     # This ensures CN1 won't apply the update, causing cluster readiness check to fail
-    logger.info(f"Disabling cfn-hup on CN1 ({cn1}) before update...")
-    _disable_cfn_hup_on_compute_node(remote_command_executor, cn1)
+    logger.info(f"Disabling the pcluster-check-update timer on CN1 ({cn1}) before update...")
+    _disable_check_update_timer_on_compute_node(remote_command_executor, cn1)
 
     # Step 4: Trigger cluster update with wait=False (non-blocking)
     logger.info("Triggering cluster update (non-blocking)...")
@@ -126,8 +126,8 @@ def test_update_rollback_failure(
         region, cluster.name, cn2_instance_id, initial_config_version, timeout_minutes=15
     )
 
-    logger.info(f"CN2 has applied the update. Disabling cfn-hup on CN2 ({cn2}) to inject rollback failure...")
-    _disable_cfn_hup_on_compute_node(remote_command_executor, cn2)
+    logger.info(f"CN2 has applied the update. Disabling pcluster-check-update timer on CN2 ({cn2}) to inject rollback failure...")
+    _disable_check_update_timer_on_compute_node(remote_command_executor, cn2)
 
     # Wait for stack to reach UPDATE_ROLLBACK_COMPLETE state
     logger.info("Waiting for stack to reach UPDATE_ROLLBACK_COMPLETE...")
@@ -269,27 +269,26 @@ exit 1
     logger.info("cfn-signal wrapper installed")
 
 
-def _disable_cfn_hup_on_compute_node(remote_command_executor, node_name):
+def _disable_check_update_timer_on_compute_node(remote_command_executor, node_name):
     """
-    Disable cfn-hup on a compute node using srun.
+    Disable pcluster-check-update on a compute node using srun.
 
-    Uses supervisorctl to stop cfn-hup service on the compute node.
+    Uses systemctl to stop the pcluster-check-update.timer on the compute node.
     """
-    logger.info(f"Disabling cfn-hup on compute node {node_name}...")
+    logger.info(f"Disabling pcluster-check-update on compute node {node_name}...")
 
-    supervisorctl_path = _get_supervisorctl_path(remote_command_executor)
+    # Stop pcluster-check-update.timer using srun
+    remote_command_executor.run_remote_command(
+        f"srun -w {node_name} sudo systemctl stop pcluster-check-update.timer"
+    )
 
-    # Stop cfn-hup using srun
-    remote_command_executor.run_remote_command(f"srun -w {node_name} sudo {supervisorctl_path} stop cfn-hup")
-
-    # Verify cfn-hup is stopped
-    # Note: supervisorctl status returns exit code 3 when process is STOPPED, so we use raise_on_error=False
+    # Verify pcluster-check-update.timer is stopped
     result = remote_command_executor.run_remote_command(
-        f"srun -w {node_name} sudo {supervisorctl_path} status cfn-hup",
+        f"srun -w {node_name} systemctl is-active pcluster-check-update.timer",
         raise_on_error=False,
     )
-    assert_that(result.stdout).contains("STOPPED")
-    logger.info(f"cfn-hup stopped on {node_name} ✓")
+    assert_that(result.stdout.strip()).contains("inactive")
+    logger.info(f"pcluster-check-update.timer stopped on {node_name} ✓")
 
 
 @retry(wait_fixed=seconds(30), stop_max_delay=minutes(60))

--- a/tests/integration-tests/tests/update/test_update_rollback_failure.py
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure.py
@@ -126,7 +126,10 @@ def test_update_rollback_failure(
         region, cluster.name, cn2_instance_id, initial_config_version, timeout_minutes=15
     )
 
-    logger.info(f"CN2 has applied the update. Disabling pcluster-check-update timer on CN2 ({cn2}) to inject rollback failure...")
+    logger.info(
+        f"CN2 has applied the update. Disabling pcluster-check-update timer on CN2 "
+        f"({cn2}) to inject rollback failure..."
+    )
     _disable_check_update_timer_on_compute_node(remote_command_executor, cn2)
 
     # Wait for stack to reach UPDATE_ROLLBACK_COMPLETE state
@@ -278,9 +281,7 @@ def _disable_check_update_timer_on_compute_node(remote_command_executor, node_na
     logger.info(f"Disabling pcluster-check-update on compute node {node_name}...")
 
     # Stop pcluster-check-update.timer using srun
-    remote_command_executor.run_remote_command(
-        f"srun -w {node_name} sudo systemctl stop pcluster-check-update.timer"
-    )
+    remote_command_executor.run_remote_command(f"srun -w {node_name} sudo systemctl stop pcluster-check-update.timer")
 
     # Verify pcluster-check-update.timer is stopped
     result = remote_command_executor.run_remote_command(


### PR DESCRIPTION
### Description of changes
* Fix test_update_rollback_failure test by disabling the pcluster-check-update.timer on the CN instead of cfn-hup
* We are no longer using cfn-hup on compute nodes, which is why this test started to fail

### Tests
* Ran test_update_rollback_failure

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
