### PR TITLE
[3.14] Replace pipes with shlex

### DIFF
--- a/awsbatch-cli/src/awsbatch/awsbsub.py
+++ b/awsbatch-cli/src/awsbatch/awsbsub.py
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import os
-import pipes
 import re
+import shlex
 import shutil
 import sys
 import tempfile
@@ -391,7 +391,7 @@ def _add_env_var_to_list(key_value_list, var_name, log):
         and "()" not in var  # functions
     ):
         var_value = os.environ[var_name]
-        key_value_list.append("export %s=%s;" % (var_name, pipes.quote(var_value)))
+        key_value_list.append("export %s=%s;" % (var_name, shlex.quote(var_value)))
         log.info("Exporting environment variable: (%s=%s).", var_name, var_value)
     else:
         log.warn("Excluded variable: (%s).", var_name)

--- a/awsbatch-cli/src/awsbatch/utils.py
+++ b/awsbatch-cli/src/awsbatch/utils.py
@@ -10,8 +10,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-import pipes
 import re
+import shlex
 import sys
 from datetime import datetime
 from typing import NoReturn
@@ -73,7 +73,7 @@ def shell_join(array):
     :param array: input array
     :return: the shell-quoted string
     """
-    return " ".join(pipes.quote(item) for item in array)
+    return " ".join(shlex.quote(item) for item in array)
 
 
 def is_job_array(job):


### PR DESCRIPTION
### Description of changes
pipes is removed from 3.13 so replacing with shlex to support python 3.14 https://docs.python.org/sv/3.14/library/pipes.html


### Tests
* Unit tests 
* Kitchen tests for awsbatch
* Manual test 
```
 sudo -u ec2-user bash -c '[ -f /etc/profile.d/pcluster_awsbatchcli.sh ] && . /etc/profile.d/pcluster_awsbatchcli.sh; awsbkill -h'
/opt/parallelcluster/pyenv/versions/3.14.2/envs/awsbatch_virtualenv/lib/python3.14/site-packages/awsbatch/common.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import packaging
usage: awsbkill [-h] [-c CLUSTER] [-r REASON] job_ids [job_ids ...]

Cancels/terminates jobs submitted in the cluster.

positional arguments:
  job_ids               A space separated list of job IDs to cancel/terminate

options:
  -h, --help            show this help message and exit
  -c, --cluster CLUSTER
                        Cluster to use
  -r, --reason REASON   A message to attach to the job that explains the reason for canceling it
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
