### PR TITLE
[Test] Reduce the risk of ICEs in `test_update_slurm` by setting more flexible instance types.

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -33,6 +33,7 @@ from utils import (
     generate_stack_name,
     get_arn_partition,
     get_root_volume_id,
+    get_similar_instance_types,
     is_filecache_supported,
     is_fsx_lustre_supported,
     is_fsx_ontap_supported,
@@ -83,12 +84,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     ]:
         bucket.upload_file(str(test_datadir / script), f"scripts/{script}")
 
-    spot_instance_types = ["t3.medium"]
-    try:
-        boto3.client("ec2").describe_instance_types(InstanceTypes=["t3a.medium"])
-        spot_instance_types.extend(["t3a.medium"])
-    except Exception:
-        pass
+    spot_instance_types = get_similar_instance_types("t3.medium", region, 5)
 
     # Create cluster with initial configuration
     init_config_file = pcluster_config_reader(resource_bucket=bucket_name, spot_instance_types=spot_instance_types)

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1023,6 +1023,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
             {"Name": "processor-info.supported-architecture", "Values": [target_arch]},
             {"Name": "vcpu-info.default-vcpus", "Values": [str(target_vcpus)]},
             {"Name": "vcpu-info.default-threads-per-core", "Values": [str(target_threads)]},
+            {"Name": "supported-usage-class", "Values": ["on-demand", "spot"]},
         ],
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types


### PR DESCRIPTION
### Description of changes
Reduce the risk of ICEs in `test_update_slurm` by setting more flexible instance types.
Before this change the test was using up to 2 instance types, which exposes the test to ICEs.
Wiuth this change we are using 5 different flexible instance types.

### Tests
* SUCCESS `test_update_slurm`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
