### PR TITLE
[Test] Fix flickering failure in `test_dynamic_file_systems_update` + facilitate troubleshooting of failed AMI retrieval

### DIFF
--- a/tests/integration-tests/tests/common/login_nodes_utils.py
+++ b/tests/integration-tests/tests/common/login_nodes_utils.py
@@ -25,9 +25,11 @@ def terminate_login_nodes(cluster):
     """
     logging.info(f"Terminating login nodes for cluster: {cluster.name}")
     instance_ids = cluster.get_cluster_instance_ids(node_type="LoginNode")
-    ec2 = boto3.client("ec2", region_name=cluster.region)
-    ec2.terminate_instances(InstanceIds=instance_ids)
-    ec2.get_waiter("instance_terminated").wait(InstanceIds=instance_ids)
+    logging.info(f"Detected login nodes for cluster {cluster.name}: {instance_ids}")
+    if instance_ids:
+        ec2 = boto3.client("ec2", region_name=cluster.region)
+        ec2.terminate_instances(InstanceIds=instance_ids)
+        ec2.get_waiter("instance_terminated").wait(InstanceIds=instance_ids)
     logging.info(f"Login nodes for cluster {cluster.name} have been terminated: {instance_ids}")
 
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -140,6 +140,10 @@ def retrieve_latest_ami(
     request=None,
     allow_private_ami=False,
 ):
+    logging.info(
+        "Retrieving AMI with ami_type=%s os=%s architecture=%s allow_private_ami=%s"
+        % (ami_type, os, architecture, allow_private_ami)
+    )
     if additional_filters is None:
         additional_filters = []
     try:
@@ -160,19 +164,22 @@ def retrieve_latest_ami(
                 additional_filters.append({"Name": "is-public", "Values": ["true"]})
         else:
             ami_name = _get_ami_for_os(ami_type, os, architecture).get("name")
-        logging.info("Parent image name %s" % ami_name)
-        paginator = boto3.client("ec2", region_name=region).get_paginator("describe_images")
-        page_iterator = paginator.paginate(
-            Filters=[{"Name": "name", "Values": [ami_name]}, {"Name": "architecture", "Values": [architecture]}]
+        describe_images_args = {
+            "Filters": [{"Name": "name", "Values": [ami_name]}, {"Name": "architecture", "Values": [architecture]}]
             + additional_filters,
-            Owners=_get_ami_for_os(ami_type, os, architecture).get("owners"),
-            IncludeDeprecated=_get_ami_for_os(ami_type, os, architecture).get("includeDeprecated", False),
-        )
+            "Owners": _get_ami_for_os(ami_type, os, architecture).get("owners"),
+            "IncludeDeprecated": _get_ami_for_os(ami_type, os, architecture).get("includeDeprecated", False),
+        }
+        logging.info("Retrieving AMI with DescribeImages arguments: %s" % describe_images_args)
+        paginator = boto3.client("ec2", region_name=region).get_paginator("describe_images")
+        page_iterator = paginator.paginate(**describe_images_args)
         images = []
         for page in page_iterator:
             images.extend(page["Images"])
         # Sort on Creation date Desc
-        return sorted(images, key=lambda x: x["CreationDate"], reverse=True)[0]["ImageId"]
+        image_id = sorted(images, key=lambda x: x["CreationDate"], reverse=True)[0]["ImageId"]
+        logging.info("Retrieved AMI: %s" % image_id)
+        return image_id
     except ClientError as e:
         LOGGER.critical(e.response.get("Error").get("Message"))
         raise

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -820,6 +820,7 @@ def _test_update_without_queue_strategy(
     pcluster_config_reader, pcluster_ami_id, pcluster_copy_ami_id, cluster, updated_compute_root_volume_size
 ):
     """Test update without setting queue strategy, update will fail."""
+    logging.info("Updating cluster without strategy. The update is expected to fail")
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
         global_custom_ami=pcluster_ami_id,
@@ -851,7 +852,8 @@ def _test_update_queue_strategy_without_running_job(
     updated_compute_root_volume_size,
     queue_update_strategy,
 ):
-    """Test queue parameter update with drain stragegy without running job in the queue."""
+    """Test queue parameter update with drain strategy without running job in the queue."""
+    logging.info(f"Updating cluster with strategy {queue_update_strategy} without running jobs")
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update_without_running_job.yaml",
         global_custom_ami=pcluster_ami_id,
@@ -896,6 +898,7 @@ def _test_update_queue_strategy_with_running_job(
     region,
     queue_update_strategy,
 ):
+    logging.info("Submitting job to queue1 before cluster update")
     queue1_job_id = scheduler_commands.submit_command_and_assert_job_accepted(
         submit_command_args={
             "command": "srun sleep 3000",
@@ -904,13 +907,17 @@ def _test_update_queue_strategy_with_running_job(
         }
     )
 
+    logging.info("Submitting job to queue2 before cluster update")
     queue2_job_id = scheduler_commands.submit_command_and_assert_job_accepted(
         submit_command_args={"command": "srun sleep 3000", "nodes": 2, "partition": "queue2"}
     )
     # Wait for the job to run
     scheduler_commands.wait_job_running(queue1_job_id)
+    logging.info(f"Job {queue1_job_id} is running on queue1")
     scheduler_commands.wait_job_running(queue2_job_id)
+    logging.info(f"Job {queue2_job_id} is running on queue2")
 
+    logging.info(f"Updating cluster with strategy {queue_update_strategy} with running jobs")
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update_with_running_job.yaml",
         global_custom_ami=pcluster_ami_id,


### PR DESCRIPTION
### Description of changes
1. Fix flickering failure in `test_dynamic_file_systems_update`: in the test we forcefully terminate login node after a cluster update because we expect the login node ASG to take ~3-4min after the update to terminate the login nodes. However, there could be situations where login nodes are terminated within the time frame of cluster update. In that case, the request TerminateInstances would fail because we pass an empty list of nodes to terminate.
2. facilitate troubleshooting of failed AMI retrieval. The test `test_queue_parameters_update` requires the retrieval of pcluster AMIs. However, sometimes the retrieval returns an empty list of AMIs. With this change we log info about the filters used to retrieve the AMIs so it is easier to understand why it does not find them.
3. Add more logs to `test_queue_parameters_update` to faiclitate troubleshooting of failures.

### Tests
SUCCEEDED:
* `test_dynamic_file_system_mounting`
* `test_queue_parameters_update`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
