### PR TITLE
[Test] In test `test_cluster_in_no_internet_subnet` add VPC endpoint for CloudWatch Metrics

### DIFF
--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -242,6 +242,12 @@ class NetworkTemplateBuilder:
                 enable_private_dns=True,
             ),
             VPCEndpointConfig(
+                name="MonitoringEndpoint",
+                service_name=f"com.amazonaws.{region}.monitoring",
+                type=VPCEndpointConfig.EndpointType.INTERFACE,
+                enable_private_dns=True,
+            ),
+            VPCEndpointConfig(
                 name="CFNEndpoint",
                 service_name=prefix + f"com.amazonaws.{region}.cloudformation",
                 type=VPCEndpointConfig.EndpointType.INTERFACE,


### PR DESCRIPTION
### Description of changes
[Test] In test `test_cluster_in_no_internet_subnet` add VPC endpoint for CloudWatch Metrics (com.amazonaws.$region.monitoring), which is now required by clustermgtd to put metrics.

This is required now because we introduced a cloudwatch put_metric_Data call in clustermgtd in https://github.com/aws/aws-parallelcluster-node/pull/685

### Tests
SUCCEEDED `test_cluster_in_no_internet_subnet `

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
