### PR TITLE
Increase sleep time in test_update_rollback_failure to ensure the rollback recipe has started

### DIFF
--- a/tests/integration-tests/tests/update/test_update_rollback_failure.py
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure.py
@@ -140,7 +140,7 @@ def test_update_rollback_failure(
     # Wait for head node rollback to complete
     # Note: CFN stack reaches UPDATE_ROLLBACK_COMPLETE before head node finishes rollback recipe
     # Sleep briefly to ensure rollback recipe has started writing to chef-client.log
-    time.sleep(10)
+    time.sleep(20)
     logger.info("Waiting for head node rollback recipe to complete...")
     _wait_for_head_node_rollback_complete(remote_command_executor)
 


### PR DESCRIPTION
### Description of changes
* Increase sleep time in `test_update_rollback_failure` to ensure the rollback recipe has started
* Test was intermittently failing because the stack would be in a `UPDATE_ROLLBACK_COMPLETE` state and then the test would check that the logs ended with a cluster readiness check but the rollback recipe had not yet started. So the checking that logs ended with a cluster readiness check succeeded because it was see the old readiness check rather than the one related to the rollback
* The extra sleep ensures that the update recipe starts before we check that the readiness check has completed.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
