### PR TITLE
[AWSBatch CLI] Replace deprecated use of pkg_resources with packaging and importlib

### DIFF
--- a/awsbatch-cli/requirements.txt
+++ b/awsbatch-cli/requirements.txt
@@ -1,2 +1,3 @@
 boto3>=1.39.4
+packaging~=25.0
 tabulate>=0.8.8,<=0.8.10

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -24,6 +24,7 @@ VERSION = "1.5.0"
 REQUIRES = [
     "setuptools",
     "boto3>=1.39.4",
+    "packaging~=25.0",
     "tabulate>=0.8.8,<=0.8.10",
 ]
 

--- a/awsbatch-cli/src/awsbatch/common.py
+++ b/awsbatch-cli/src/awsbatch/common.py
@@ -22,7 +22,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, ParamValidationError
 from configparser import ConfigParser, NoOptionError, NoSectionError
-from pkg_resources import packaging
+from packaging import version as packaging_version
 from tabulate import tabulate
 
 from awsbatch.utils import fail, get_installed_version, get_region_by_stack_id
@@ -147,8 +147,8 @@ class CliRequirementsMatcher:
         """Verify if CLI requirements are satisfied."""
         for req in self.requirements:
             if not self.COMPARISON_OPERATORS[req.operator](
-                packaging.version.parse(get_installed_version(req.package)),
-                packaging.version.parse(req.version),
+                packaging_version.parse(get_installed_version(req.package)),
+                packaging_version.parse(req.version),
             ):
                 fail(f"The cluster requires {req.package}{req.operator}{req.version}")
 

--- a/awsbatch-cli/src/awsbatch/utils.py
+++ b/awsbatch-cli/src/awsbatch/utils.py
@@ -14,9 +14,9 @@ import re
 import shlex
 import sys
 from datetime import datetime
+from importlib.metadata import version as get_package_version
 from typing import NoReturn
 
-import pkg_resources
 from dateutil import tz
 
 
@@ -112,7 +112,7 @@ def get_job_type(job):
 
 def get_installed_version(package_name="aws-parallelcluster-awsbatch-cli"):
     """Get the version of the installed package."""
-    return pkg_resources.get_distribution(package_name).version
+    return get_package_version(package_name)
 
 
 class S3Uploader:


### PR DESCRIPTION
### Description of changes
In AWS Batch CLI, replace deprecated use of pkg_resources with packaging and importlib.
This change is required because pkg_resources has been removed from Python 3.12+.

See https://setuptools.pypa.io/en/latest/pkg_resources.html

We applied the same change to PC CLI as well, ref https://github.com/aws/aws-parallelcluster/pull/6913/changes/1ca759e36385332179ff39243fe906f9200a101b

### Tests
* Unit Tests (the unit test on Python 3.12+ are able to spot failures related to this change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
