### PR TITLE
[integration-test-framework] Add Deep Learning AMI support in integration test

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -310,8 +310,10 @@ class Ec2Client(Boto3Client):
         """Return the id of the current official image, for the provided os-architecture combination."""
         owner = filters.owner if filters and filters.owner else "amazon"
         tags = filters.tags if filters and filters.tags else []
+        name_prefix = filters.name_prefix if filters and filters.name_prefix else ""
+        name = name_prefix + "{0}*".format(self._get_official_image_name_prefix(os, architecture))
 
-        filters = [{"Name": "name", "Values": ["{0}*".format(self._get_official_image_name_prefix(os, architecture))]}]
+        filters = [{"Name": "name", "Values": [name]}]
         filters.extend([{"Name": f"tag:{tag.key}", "Values": [tag.value]} for tag in tags])
         images = self._describe_images_with_pagination(Owners=[owner], Filters=filters, IncludeDeprecated=True)
         if not images:

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1199,10 +1199,11 @@ class AdditionalPackages(Resource):
 class AmiSearchFilters(Resource):
     """Represent the configuration for AMI search filters."""
 
-    def __init__(self, tags: List[Tag] = None, owner: str = None):
+    def __init__(self, tags: List[Tag] = None, owner: str = None, name_prefix: str = None):
         super().__init__()
         self.tags = tags
         self.owner = owner
+        self.name_prefix = name_prefix
 
 
 class Timeouts(Resource):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1088,6 +1088,7 @@ class AmiSearchFiltersSchema(BaseSchema):
         TagSchema, many=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED, "update_key": "Key"}
     )
     owner = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    name_prefix = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
     @post_load()
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -325,6 +325,7 @@ DevSettings:
     - Key: tag2
       Value: value2
     Owner: self
+    NamePrefix: dlami-
   Timeouts:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -611,7 +611,7 @@ def file_reader(test_datadir, request, vpc_stack):
 
 
 @pytest.fixture()
-def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, architecture):
+def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, architecture, ami_type):
     """
     Define a fixture to render pcluster config templates associated to the running test.
 
@@ -641,7 +641,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, a
         rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
         output_file_path.write_text(rendered_template)
         if not config_file.endswith("image.config.yaml"):
-            inject_additional_config_settings(output_file_path, request, region, architecture, benchmarks)
+            inject_additional_config_settings(output_file_path, request, region, architecture, ami_type, benchmarks)
         else:
             inject_additional_image_configs_settings(output_file_path, request)
         return output_file_path
@@ -722,7 +722,9 @@ def _inject_additional_iam_policies_for_nodes(
             _inject_additional_iam_policies(pool, policies)
 
 
-def inject_additional_config_settings(cluster_config, request, region, architecture, benchmarks=None):  # noqa C901
+def inject_additional_config_settings(  # noqa C901
+    cluster_config, request, region, architecture, ami_type, benchmarks=None
+):
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 
@@ -788,6 +790,8 @@ def inject_additional_config_settings(cluster_config, request, region, architect
             dict_add_nested_key(
                 config_content, request.config.getoption("ami_owner"), ("DevSettings", "AmiSearchFilters", "Owner")
             )
+        if ami_type == "DLAMI":
+            dict_add_nested_key(config_content, "dlami-", ("DevSettings", "AmiSearchFilters", "NamePrefix"))
 
     # Additional instance types data is copied it into config files to make it available at cluster creation
     instance_types_data = request.config.getoption("instance_types_data", None)

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -148,6 +148,36 @@ def unmarshal_az_override(az_override):
     return az_override
 
 
+DLAMI_PREFIX = "DLAMI_"
+
+
+def unmarshal_os_params(argvalues, argnames):
+    """
+    Extract ami_type from os values with DLAMI_ prefix.
+
+    E.g. "DLAMI_ubuntu2204" -> os="ubuntu2204", ami_type="DLAMI"
+    """
+    if "os" not in argnames:
+        return argvalues, argnames
+
+    os_index = argnames.index("os")
+    unmarshalled = []
+    for params in argvalues:
+        param_list = list(params)
+        os_value = param_list[os_index]
+
+        if os_value and os_value.startswith(DLAMI_PREFIX):
+            # strip prefix
+            param_list[os_index] = os_value[len(DLAMI_PREFIX) :]  # noqa: E203
+            param_list.append("DLAMI")
+        else:
+            param_list.append("official")
+
+        unmarshalled.append(tuple(param_list))
+
+    return unmarshalled, argnames + ["ami_type"]
+
+
 def unmarshal_az_params(argvalues, argnames):
     """
     Given the list of tuple parameters defining the configured test dimensions, when an az-override is specified

--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -3,7 +3,7 @@ import os
 from itertools import product
 
 from conftest_markers import DIMENSIONS_MARKER_ARGS
-from conftest_networking import unmarshal_az_override, unmarshal_az_params
+from conftest_networking import unmarshal_az_override, unmarshal_az_params, unmarshal_os_params
 from framework.tests_configuration.config_utils import get_enabled_tests
 from xdist import get_xdist_worker_id
 
@@ -60,6 +60,7 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
         argvalues.extend(list(product(*dimensions_values)))
 
     argvalues, argnames = unmarshal_az_params(argvalues, argnames)  # adds 'az_id' extra fixture
+    argvalues, argnames = unmarshal_os_params(argvalues, argnames)  # adds 'ami_type' extra fixture
 
     return argnames, argvalues
 


### PR DESCRIPTION
### Description of changes
AMI naming convention:
- Official ParallelCluster: aws-parallelcluster-3.15.0-ubuntu-2404-lts-hvm-x86_64-202510062220
- ParallelCluster Deep Learning AMI: dlami-aws-parallelcluster-3.15.0-ubuntu-2404-lts-hvm-x86_64-202601062229 (Note: ParallelCluster does not release deep learning AMI publicly)

Test config usage:

Official ParallelCluster ubuntu2404:
```
  dimensions:
    - regions: ["use1-az6"]
      instances: ["g4dn.2xlarge"]
      oss: ["ubuntu2404"]
      schedulers: ["slurm"]
```

ParallelCluster Deep Learning ubuntu2404:
```
  dimensions:
    - regions: ["use1-az6"]
      instances: ["g4dn.2xlarge"]
      oss: ["DLAMI_ubuntu2404"]
      schedulers: ["slurm"]
 ```

 To make the integration test framework change concise, this commit adds `NamePrefix` in `DevSettings` of cluster configuration:
 ```
 ...
 DevSettings:
   ...
   AmiSearchFilters:
     ...
     NamePrefix: dlami-
 ```

### Tests
The following integration test has passed. I checked the Deep Learning AMI is correctly used
```
test-suites:
  multiple_nics:
    test_multiple_nics.py::test_multiple_nics:
      dimensions:
        - regions: [{{ c6in_32xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
          instances: ["c6in.32xlarge"]
          oss: ["DLAMI_ubuntu2404"]
          schedulers: ["slurm"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
