### PR TITLE
Do not use older generation instance types when retrieving similar instance types

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -367,3 +367,28 @@ ULTRASERVER_CAPACITY_BLOCK_ALLOWED_SIZE_DICT = {
 CAPACITY_BLOCK_INACTIVE_STATES = ["scheduled", "payment-pending", "assessing", "delayed"]
 
 ORDER_SENSITIVE_PARAMETERS = ["Tags"]
+
+# Older generation instance types
+EXCLUDED_INSTANCE_TYPE_PREFIXES = (
+    "m1",
+    "m2",
+    "m3",
+    "m4",
+    "t1",
+    "t2",
+    "c1",
+    "c3",
+    "c4",
+    "r3",
+    "r4",
+    "x1",
+    "x1e",
+    "d2",
+    "h1",
+    "i2",
+    "i3",
+    "f1",
+    "g3",
+    "p2",
+    "p3",
+)

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -22,6 +22,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
 from pcluster.constants import (
+    EXCLUDED_INSTANCE_TYPE_PREFIXES,
     SUPPORTED_OSES,
     SUPPORTED_OSES_FOR_SCHEDULER,
     UNSUPPORTED_ARM_OSES_FOR_DCV,
@@ -96,29 +97,6 @@ def _get_instance_type_parameters():  # noqa: C901
         return _get_instance_type_parameters._cache
 
     result = {}
-    excluded_instance_type_prefixes = (
-        "m1",
-        "m2",
-        "m3",
-        "m4",
-        "t1",
-        "t2",
-        "c1",
-        "c3",
-        "c4",
-        "r3",
-        "r4",
-        "x1",
-        "x1e",
-        "d2",
-        "h1",
-        "i2",
-        "i3",
-        "f1",
-        "g3",
-        "p2",
-        "p3",
-    )
 
     for region in ["us-east-1", "us-west-2"]:  # Only populate instance type for big regions
         ec2_client = boto3.client("ec2", region_name=region)
@@ -137,13 +115,13 @@ def _get_instance_type_parameters():  # noqa: C901
                     instance_type_availability_zones[instance_type_name].append(offering["Location"])
                     # Check if instance type ends with '.xlarge'
                     if instance_type_name.endswith(".xlarge") and _is_current_instance_type_generation(
-                        excluded_instance_type_prefixes, offering
+                        EXCLUDED_INSTANCE_TYPE_PREFIXES, offering
                     ):
                         xlarge_instances.add(instance_type_name)
                     # Get a list of only GPU instances of any size available in the region
                     if (
                         instance_type_name.startswith("p") or instance_type_name.startswith("g")
-                    ) and _is_current_instance_type_generation(excluded_instance_type_prefixes, offering):
+                    ) and _is_current_instance_type_generation(EXCLUDED_INSTANCE_TYPE_PREFIXES, offering):
                         all_gpu_instances.add(instance_type_name)
 
             # Get GPU instance details in batches of 100
@@ -161,7 +139,7 @@ def _get_instance_type_parameters():  # noqa: C901
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
                             ) >= 4 and _is_current_instance_type_generation(
-                                excluded_instance_type_prefixes, instance_type
+                                EXCLUDED_INSTANCE_TYPE_PREFIXES, instance_type
                             ):
                                 # Find instance types with 4 or more GPUs. Number of GPUs can change test behavior.
                                 # For example, it takes longer for DCGM health check to diagnose multiple GPUs.

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -29,6 +29,8 @@ from jinja2.sandbox import SandboxedEnvironment
 from retrying import retry
 from time_utils import minutes, seconds
 
+from pcluster.constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
+
 DEFAULT_PARTITION = "aws"
 PARTITION_MAP = {
     "cn": "aws-cn",
@@ -1028,11 +1030,13 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
+            instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
             instance_has_gpu = "GpuInfo" in instance
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
-                instance_has_efa == target_has_efa
+                instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
+                and instance_has_efa == target_has_efa
                 and instance_has_gpu == target_has_gpu
                 and instance_inference_accelerators == target_inference_accelerators
             ):


### PR DESCRIPTION
### Description of changes
* Do not use older generation instance types when retrieving similar instance types
* We were getting policy engine violations due to c3 instance being launched, this will resolve that issue

### Tests
* ran `test_update_slurm`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
