### PR TITLE
[AWSBatch CLI] Replace deprecated use of pkg_resources with packaging and importlib

### DIFF
--- a/awsbatch-cli/CHANGELOG.md
+++ b/awsbatch-cli/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+1.6.0
+------
+
+**BUG FIXES**
+
+- Replace deprecated `pkg_resources` with `packaging` and `importlib` in
+  AWSBatch CLI to fix compatibility with setuptools 82.0+ which removed `pkg_resources` module.
+
 1.5.0
 ------
 
@@ -8,7 +16,7 @@ CHANGELOG
 
 - Fix cluster creation failures in China when the OS is Amazon Linux 2023.
 
-  1.4.0
+1.4.0
 ------
 
 **ENHANCEMENTS**

--- a/awsbatch-cli/requirements.txt
+++ b/awsbatch-cli/requirements.txt
@@ -1,2 +1,3 @@
 boto3>=1.39.4
+packaging~=25.0
 tabulate>=0.8.8,<=0.8.10

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -24,6 +24,7 @@ VERSION = "1.5.0"
 REQUIRES = [
     "setuptools",
     "boto3>=1.39.4",
+    "packaging~=25.0",
     "tabulate>=0.8.8,<=0.8.10",
 ]
 

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -20,7 +20,7 @@ def readme():
         return f.read()
 
 
-VERSION = "1.5.0"
+VERSION = "1.6.0"
 REQUIRES = [
     "setuptools",
     "boto3>=1.39.4",

--- a/awsbatch-cli/src/awsbatch/common.py
+++ b/awsbatch-cli/src/awsbatch/common.py
@@ -22,7 +22,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, ParamValidationError
 from configparser import ConfigParser, NoOptionError, NoSectionError
-from pkg_resources import packaging
+from packaging import version as packaging_version
 from tabulate import tabulate
 
 from awsbatch.utils import fail, get_installed_version, get_region_by_stack_id
@@ -147,8 +147,8 @@ class CliRequirementsMatcher:
         """Verify if CLI requirements are satisfied."""
         for req in self.requirements:
             if not self.COMPARISON_OPERATORS[req.operator](
-                packaging.version.parse(get_installed_version(req.package)),
-                packaging.version.parse(req.version),
+                packaging_version.parse(get_installed_version(req.package)),
+                packaging_version.parse(req.version),
             ):
                 fail(f"The cluster requires {req.package}{req.operator}{req.version}")
 

--- a/awsbatch-cli/src/awsbatch/utils.py
+++ b/awsbatch-cli/src/awsbatch/utils.py
@@ -14,9 +14,9 @@ import pipes
 import re
 import sys
 from datetime import datetime
+from importlib.metadata import version as get_package_version
 from typing import NoReturn
 
-import pkg_resources
 from dateutil import tz
 
 
@@ -112,7 +112,7 @@ def get_job_type(job):
 
 def get_installed_version(package_name="aws-parallelcluster-awsbatch-cli"):
     """Get the version of the installed package."""
-    return pkg_resources.get_distribution(package_name).version
+    return get_package_version(package_name)
 
 
 class S3Uploader:


### PR DESCRIPTION
### Description of changes
Cherry-pick https://github.com/aws/aws-parallelcluster/pull/7222/changes

This change is required because pkg_resources has been removed from Python 3.12+.

See https://setuptools.pypa.io/en/latest/pkg_resources.html

* Version Bump awsbatch-cli

### Tests
* Unit tests
* Launch Ec2 instance and install the awsbatch-cli from the branch
```

[root@ip-172-31-59-82 himani2411-aws-parallelcluster-3d6ce5f]# /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/bin/pip install awsbatch-cli/
Processing ./awsbatch-cli
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: setuptools in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from aws-parallelcluster-awsbatch-cli==1.5.0) (80.9.0)
Requirement already satisfied: boto3>=1.39.4 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from aws-parallelcluster-awsbatch-cli==1.5.0) (1.42.14)
Collecting packaging~=25.0 (from aws-parallelcluster-awsbatch-cli==1.5.0)
  Downloading packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Requirement already satisfied: tabulate<=0.8.10,>=0.8.8 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from aws-parallelcluster-awsbatch-cli==1.5.0) (0.8.10)
Requirement already satisfied: botocore<1.43.0,>=1.42.14 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (1.42.14)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (1.0.1)
Requirement already satisfied: s3transfer<0.17.0,>=0.16.0 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (0.16.0)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from botocore<1.43.0,>=1.42.14->boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (2.9.0.post0)
Requirement already satisfied: urllib3!=2.2.0,<3,>=1.25.4 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from botocore<1.43.0,>=1.42.14->boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (2.6.2)
Requirement already satisfied: six>=1.5 in /opt/parallelcluster/pyenv/versions/3.12.11/envs/awsbatch_virtualenv/lib/python3.12/site-packages (from python-dateutil<3.0.0,>=2.1->botocore<1.43.0,>=1.42.14->boto3>=1.39.4->aws-parallelcluster-awsbatch-cli==1.5.0) (1.17.0)
Downloading packaging-25.0-py3-none-any.whl (66 kB)
Building wheels for collected packages: aws-parallelcluster-awsbatch-cli
  Building wheel for aws-parallelcluster-awsbatch-cli (pyproject.toml) ... done
  Created wheel for aws-parallelcluster-awsbatch-cli: filename=aws_parallelcluster_awsbatch_cli-1.5.0-py3-none-any.whl size=32425 sha256=592da469191710c5869a0b051c0e6a8dda087151abb187adb45d4909a3c846f6
  Stored in directory: /root/.cache/pip/wheels/76/56/4c/7ff6d5aa0ca2feb5da2cbb9289e161f13b55c14ce40a74affc
Successfully built aws-parallelcluster-awsbatch-cli
Installing collected packages: packaging, aws-parallelcluster-awsbatch-cli
  Attempting uninstall: aws-parallelcluster-awsbatch-cli
    Found existing installation: aws-parallelcluster-awsbatch-cli 1.5.0
    Uninstalling aws-parallelcluster-awsbatch-cli-1.5.0:
      Successfully uninstalled aws-parallelcluster-awsbatch-cli-1.5.0
Successfully installed aws-parallelcluster-awsbatch-cli-1.5.0 packaging-25.0

[notice] A new release of pip is available: 25.0.1 -> 26.0.1
[notice] To update, run: pip3.12 install --upgrade pip
....
sudo -u ec2-user bash -c '[ -f /etc/profile.d/pcluster_awsbatchcli.sh ] && . /etc/profile.d/pcluster_awsbatchcli.sh; awsbkill -h'
usage: awsbkill [-h] [-c CLUSTER] [-r REASON] job_ids [job_ids ...]

Cancels/terminates jobs submitted in the cluster.

positional arguments:
  job_ids               A space separated list of job IDs to cancel/terminate

options:
  -h, --help            show this help message and exit
...
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
