### PR TITLE
[integ-tests] Re-enable DCV installation in integration tests for Ubuntu 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
   See https://github.com/aws/aws-parallelcluster/issues/7173
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 - Fix intermittent cluster creation failure caused by eventual consistency issues when head, compute and login nodes have the same security group.
+- Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
 
 **DEPRECATIONS**
 - The configuration parameter `LoginNodes/Pools/Ssh/KeyName` is no longer supported.

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -165,8 +165,7 @@ def test_build_image(
     if os in ["alinux2", "alinux2023", "rocky9"]:
         update_os_packages = True
 
-    # Disable DCV installation for Ubuntu 24.04 to avoid build failures with DLAMI
-    enable_dcv = os != "ubuntu2404"
+    enable_dcv = True
 
     image_config = pcluster_config_reader(
         config_file="image.config.yaml",


### PR DESCRIPTION
### Description of changes
Re-enable DCV installation in integration tests for Ubuntu 24

### Tests
* With this fix, build-image with "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20251212" succeeds
* With this fix, build-image with "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20250523" succeeds
* Without this fix, build-image with "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20251212" fails 

### References
* Cookbook PR https://github.com/aws/aws-parallelcluster-cookbook/pull/3125

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
