### PR TITLE
[Test] Add missing parameter ami_type to `test_pcluster_configure`.

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -57,7 +57,17 @@ PROMPTS = {
 
 
 def test_pcluster_configure(
-    request, vpc_stack, key_name, region, os, instance, scheduler, clusters_factory, test_datadir, architecture
+    request,
+    vpc_stack,
+    key_name,
+    region,
+    os,
+    instance,
+    scheduler,
+    clusters_factory,
+    test_datadir,
+    architecture,
+    ami_type,
 ):
     """Verify that the config file produced by `pcluster configure` can be used to create a cluster."""
     skip_if_unsupported_test_options_were_used(request)
@@ -65,7 +75,7 @@ def test_pcluster_configure(
 
     _create_and_test_standard_configuration(request, config_path, region, key_name, scheduler, os, instance, vpc_stack)
 
-    inject_additional_config_settings(config_path, request, region, architecture)
+    inject_additional_config_settings(config_path, request, region, architecture, ami_type)
     clusters_factory(config_path)
 
 


### PR DESCRIPTION
### Description of changes
 Add missing parameter ami_type to `test_pcluster_configure`.
In https://github.com/aws/aws-parallelcluster/pull/7223/changes we introduced `ami_type` in a way that requires ami_type to be consumed by the test.

This is the quickest solution to unblock the test.
A more clean solution is to refactor the way we inject ami_type in the tests by converting it to a fixture. In this way we do not need to specify it ion the test signature when it is not needed.

### Tests
[SUCCEEDED] `test_pcluster_configure`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
