### PR TITLE
[integ-tests] Remove hard-coded ARN for AmazonSSMManagedInstanceCore policy

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_startup_time/test_startup_time/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_startup_time/test_startup_time/pcluster.config.yaml
@@ -7,9 +7,6 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
-  Iam:
-    AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -23,9 +20,6 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
     - Name: q2
       ComputeResources:
         - Name: q2
@@ -36,9 +30,6 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
     - Name: q3
       ComputeResources:
         - Name: q3
@@ -49,8 +40,5 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
 DevSettings:
   ComputeStartupTimeMetricEnabled: true

--- a/tests/integration-tests/tests/update/test_update_rollback_failure/test_update_rollback_failure/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure/test_update_rollback_failure/pcluster.config.update.yaml
@@ -6,9 +6,6 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
-  Iam:
-    AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -24,9 +21,6 @@ Scheduling:
           - {{ private_subnet_id }}
     # New queue added to trigger update
     - Name: queue2
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       ComputeResources:
         - Name: queue2-cr1
           Instances:

--- a/tests/integration-tests/tests/update/test_update_rollback_failure/test_update_rollback_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure/test_update_rollback_failure/pcluster.config.yaml
@@ -6,9 +6,6 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
-  Iam:
-    AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmQueues:


### PR DESCRIPTION
### Description of changes
The policy is automatically added as part of integration test framework https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/conftest.py#L863

Hard-coded policy with partition flexibility is not changed by this commit to keep this commit minimal: `arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore`. In other words, this commit only removes hard-coded AmazonSSMManagedInstanceCore policy, where the partition string is hard-coded to commercial

 This commit enables the tests to run in other partitions

### Tests
Tests will run after the PR is merged


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
