### PR TITLE
Make ami_type a fixture

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -134,6 +134,12 @@ def az_id():
     pass
 
 
+@pytest.fixture(autouse=True)
+def ami_type():
+    """Removes the need to declare the fixture in all tests even if not needed."""
+    pass
+
+
 def unmarshal_az_override(az_override):
     for region, regex in ZONE_ID_MAPPING.items():
         pattern = re.compile(regex)


### PR DESCRIPTION
### Description of changes
* Make `ami_type` a fixture in order to fix `function uses no argument 'ami_type'` error

### Tests
* Ran `test_efa_unsupported` and `test_pcluster_configure`

### References
* This PR did not fix the issue because it just started failing for other tests: https://github.com/aws/aws-parallelcluster/pull/7244
* Error introduced through this PR: https://github.com/aws/aws-parallelcluster/pull/7223/changes

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
