### PR TITLE
[Test] Add automated root cause analysis for cluster creation failure.

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -12,13 +12,13 @@
 import functools
 import json
 import logging
-import re
 import subprocess
 import time
 
 import boto3
 import yaml
 from assertpy import assert_that
+from diagnosis_utils import retrieve_rca_details
 from framework.credential_providers import run_pcluster_command
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
@@ -567,7 +567,13 @@ class ClustersFactory:
                         # in the case where the stack has been deleted.
                         stack_id = response.get("cloudformationStackArn")
                         events = get_cfn_events(stack_name=stack_id, region=cluster.region)
-                        raise ClusterCreationError(error, stack_events=events, cluster_details=response)
+                        rca_details = retrieve_rca_details(cluster)
+                        raise ClusterCreationError(
+                            error,
+                            stack_events=events,
+                            cluster_details=response,
+                            rca_details=rca_details,
+                        )
                 else:
                     logging.info("Cluster {0} created successfully".format(name))
                     end_time = time.time()

--- a/tests/integration-tests/diagnosis_utils.py
+++ b/tests/integration-tests/diagnosis_utils.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import re
+
+from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+from time_utils import seconds
+from utils import find_all_matches_in_log
+
+RCA_LOG_FILES = [
+    "/var/log/chef-client.log",
+    "/var/log/parallelcluster/clustermgtd",
+    "/var/log/cfn-init.log",
+    "/var/log/cloud-init-output.log",
+    "/var/log/parallelcluster/slurmctld.log",
+]
+PATTERN_GENERIC_FAILURE = r"error|fail|fatal|exception|critical"
+PATTERN_CHEF_ERROR = r"ERROR:"
+PATTERN_ICE_ERROR = r"InsufficientInstanceCapacity.*?sufficient\s+(\S+)\s+capacity"
+
+
+def extract_ice_from_rca_details(rca_details):
+    """Extract unique InsufficientInstanceCapacity errors from RCA details."""
+    instance_types = set()
+    clustermgtd_log = rca_details.get("/var/log/parallelcluster/clustermgtd", "")
+    for match in re.finditer(PATTERN_ICE_ERROR, clustermgtd_log):
+        instance_types.add(match.group(1))
+    return [f"InsufficientInstanceCapacity on {it}" for it in sorted(instance_types)]
+
+
+@retry(stop_max_attempt_number=3, wait_fixed=seconds(5))
+def retrieve_rca_details(cluster, num_errors=10):
+    """
+    Retrieve diagnostic info from cluster logs for root cause analysis.
+
+    :param cluster: Cluster object with SSH access info.
+    :param num_errors: Max error lines per log file.
+    :return: Dict mapping log paths to error content, plus "SUMMARY" with conclusions.
+    """
+    logging.info("Retrieving RCA details")
+
+    rca_details = {}
+
+    rce = RemoteCommandExecutor(cluster)
+
+    rca_details["SUMMARY"] = ["No root cause found"]
+    for log_path in RCA_LOG_FILES:
+        try:
+            if log_path == "/var/log/chef-client.log":
+                matches = find_all_matches_in_log(rce, log_path, PATTERN_CHEF_ERROR, num_errors, case_sensitive=True)
+            else:
+                matches = find_all_matches_in_log(rce, log_path, PATTERN_GENERIC_FAILURE, num_errors)
+            rca_details[log_path] = "\n".join(matches) if matches else "No error found"
+        except Exception as e:
+            logging.warning("Failed to retrieve RCA details from log %s: %s", log_path, e)
+
+    rce.close_connection()
+
+    rca_details["SUMMARY"] = [
+        *extract_ice_from_rca_details(rca_details),
+    ]
+
+    return rca_details

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -124,9 +124,15 @@ class StackSetupError(SetupError):
 class ClusterCreationError(SetupError):
     """Exception to throw when cluster creation fails during test setup."""
 
-    def __init__(self, message, stack_events=None, cluster_details=None):
+    def __init__(self, message, stack_events=None, cluster_details=None, rca_details=None):
         message = message if message else "ClusterCreationError has been raised"
-        super().__init__(_format_stack_error(message, stack_events=stack_events, cluster_details=cluster_details))
+        formatted_message = _format_stack_error(message, stack_events=stack_events, cluster_details=cluster_details)
+        if rca_details:
+            formatted_message += "\n\n=== ROOT CAUSE ANALYSIS ==="
+            for item, content in rca_details.items():
+                formatted_message += f"\n\n--- {item} ---\n{content}"
+        super().__init__(formatted_message)
+        self.diagnosis_info = rca_details
 
     def __str__(self):
         return f"ClusterCreationError: {self.message}"
@@ -1148,3 +1154,27 @@ def match_regex_in_log(rce, log_file: str, pattern: str, nlines: int = 50) -> tu
     else:
         last_lines = "\n".join(log_content.splitlines()[-nlines:])
         return False, last_lines
+
+
+def find_all_matches_in_log(
+    rce, log_file: str, pattern: str, nlines: int = 10, case_sensitive: bool = False
+) -> list[str]:
+    """
+    Find lines matching a regex pattern in a remote log file.
+
+    :param rce: Remote command executor instance.
+    :param log_file: Path to the log file on the remote host.
+    :param pattern: Regex pattern to search for.
+    :param nlines: Max matching lines to return.
+    :param case_sensitive: If True, match case-sensitively.
+    :return: Last `nlines` matches, or empty list if none found.
+    """
+    result = rce.run_remote_command(f"sudo cat {log_file}", raise_on_error=False, log_error=False)
+    if result.failed:
+        return []
+
+    log_content = result.stdout
+    flags = 0 if case_sensitive else re.IGNORECASE
+    matching_lines = [line for line in log_content.splitlines() if re.search(pattern, line, flags)]
+
+    return matching_lines[-nlines:]


### PR DESCRIPTION
### Description of changes
Add automated root cause analysis for cluster creation failure.
If cluster creation fails, the test now prints out the last 10 errors from the most critical logs and attempt to identify a root cause from them.
For the time being, the only root cause that we extract is the ICE.

Here is the sample diagnosis report printed by a test failure:

```
=== ROOT CAUSE ANALYSIS ===

--- SUMMARY ---
['InsufficientInstanceCapacity on p4d.24xlarge']

--- /var/log/chef-client.log ---
[2026-02-26T19:59:41+00:00] ERROR: shard_seed: Failed to get dmi property serial_number: is dmidecode installed?
... other 10 errors ...

--- /var/log/parallelcluster/clustermgtd ---
2026-02-26 20:25:14,163 - [slurm_plugin.fleet_manager:_launch_instances] - ERROR - Failed RunInstances request (3fd67297-4cbc-4d20-94b3-370e060495a6): InsufficientInstanceCapacity - We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-east-1a). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1b, us-east-1c, us-east-1d.
... other 10 errors ...

--- /var/log/cfn-init.log ---
DEBUG:root:CustomActionsConfig(stack_name='integ-tests-u8lflx6fp7yct6bp-integ-mg', cluster_name='integ-tests-u8lflx6fp7yct6bp-integ-mg', region_name='us-east-1', node_type='HeadNode', queue_name='', pool_name='', resource_name='', instance_id='i-0c94f0e998cdd9f63', instance_type='c5.18xlarge', ip_address='192.168.3.21', hostname='ip-192-168-3-21.ec2.internal', availability_zone='us-east-1a', scheduler='slurm', event_name='OnNodeStart', legacy_event=<LegacyEventName.ON_NODE_START: 'preinstall'>, can_execute=False, dry_run=False, script_sequence=[], script_sequences_per_event={<LegacyEventName.ON_NODE_START: 'preinstall'>: [], <LegacyEventName.ON_NODE_CONFIGURED: 'postinstall'>: [], 
... other 10 errors ...

--- /var/log/cloud-init-output.log ---
2026-02-26 19:59:05,767 - util.py[WARNING]: Running module selinux (<module 'cloudinit.config.cc_selinux' from '/usr/lib/python3.9/site-packages/cloudinit/config/cc_selinux.py'>) failed
... other 10 errors ...

--- /var/log/parallelcluster/slurmctld.log ---
No error found
```

### Tests
Executed integ test `test_efa` known that it is going to face ICE. The test report shows the expected diagnosis (see above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
