### PR TITLE
Make HeadNode Local Storage updates UNSUPPORTED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 - Fix intermittent cluster creation failure caused by eventual consistency issues when head, compute and login nodes have the same security group.
 - Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
+- Fix HeadNode/LocalStorage update policy to make updates unsupported.
 
 **DEPRECATIONS**
 - The configuration parameter `LoginNodes/Pools/Ssh/KeyName` is no longer supported.

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1370,7 +1370,7 @@ class HeadNodeSchema(BaseSchema):
         HeadNodeNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )
     ssh = fields.Nested(HeadNodeSshSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    local_storage = fields.Nested(HeadNodeStorageSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    local_storage = fields.Nested(HeadNodeStorageSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     shared_storage_type = fields.Str(
         required=False,
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -276,7 +276,7 @@ class QueueEphemeralVolumeSchema(BaseSchema):
 class HeadNodeStorageSchema(BaseSchema):
     """Represent the schema of storage attached to a node."""
 
-    root_volume = fields.Nested(HeadNodeRootVolumeSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    root_volume = fields.Nested(HeadNodeRootVolumeSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     ephemeral_volume = fields.Nested(
         HeadNodeEphemeralVolumeSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -2936,3 +2936,74 @@ def test_extra_chef_attributes_action_needed(mocker, old_value, new_value):
     action_needed = UpdatePolicy.EXTRA_CHEF_ATTRIBUTES.action_needed(change_mock, patch_mock)
     assert_that(action_needed).contains("Revert")
     assert_that(action_needed).contains("non-updatable")
+
+
+# Tests for HeadNode LocalStorage update policy
+@pytest.mark.parametrize(
+    "base_config, target_config, expected_update_allowed",
+    [
+        pytest.param(
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                },
+            },
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"Size": 100}},
+                },
+            },
+            False,
+            id="Adding LocalStorage to HeadNode is blocked",
+        ),
+        pytest.param(
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"Size": 50}},
+                },
+            },
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"Size": 100}},
+                },
+            },
+            False,
+            id="Changing HeadNode RootVolume Size is blocked",
+        ),
+        pytest.param(
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"Size": 50}},
+                },
+            },
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                },
+            },
+            False,
+            id="Removing LocalStorage from HeadNode is blocked",
+        ),
+    ],
+)
+def test_head_node_local_storage_update_blocked(mocker, base_config, target_config, expected_update_allowed):
+    """Test that adding/changing/removing HeadNode LocalStorage during update is blocked.
+
+    LocalStorage affects the HeadNode launch template and cannot be updated without replacing the HeadNode.
+    """
+    cluster = Cluster(name="mock-name", stack="mock-stack")
+    patch = ConfigPatch(cluster=cluster, base_config=base_config, target_config=target_config)
+
+    # Check that the update is blocked (patch.check() returns False for patch_allowed)
+    patch_allowed, _ = patch.check()
+    assert_that(patch_allowed).is_equal_to(expected_update_allowed)

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -2939,8 +2939,14 @@ def test_extra_chef_attributes_action_needed(mocker, old_value, new_value):
 
 
 # Tests for HeadNode LocalStorage update policy
+EBS_ACTION_NEEDED = (
+    "Follow the instructions at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/"
+    "requesting-ebs-volume-modifications.html#modify-ebs-volume to modify your volume from AWS Console."
+)
+
+
 @pytest.mark.parametrize(
-    "base_config, target_config, expected_update_allowed",
+    "base_config, target_config, expected_update_allowed, expected_action_needed",
     [
         pytest.param(
             {
@@ -2957,7 +2963,26 @@ def test_extra_chef_attributes_action_needed(mocker, old_value, new_value):
                 },
             },
             False,
+            None,
             id="Adding LocalStorage to HeadNode is blocked",
+        ),
+        pytest.param(
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"Size": 50}},
+                },
+            },
+            {
+                "HeadNode": {
+                    "InstanceType": "t3.micro",
+                    "Networking": {"SubnetId": "subnet-12345678"},
+                },
+            },
+            False,
+            None,
+            id="Removing LocalStorage from HeadNode is blocked",
         ),
         pytest.param(
             {
@@ -2975,35 +3000,50 @@ def test_extra_chef_attributes_action_needed(mocker, old_value, new_value):
                 },
             },
             False,
-            id="Changing HeadNode RootVolume Size is blocked",
+            EBS_ACTION_NEEDED,
+            id="Changing HeadNode RootVolume Size shows EBS action_needed",
         ),
         pytest.param(
             {
                 "HeadNode": {
                     "InstanceType": "t3.micro",
                     "Networking": {"SubnetId": "subnet-12345678"},
-                    "LocalStorage": {"RootVolume": {"Size": 50}},
+                    "LocalStorage": {"RootVolume": {"VolumeType": "gp2"}},
                 },
             },
             {
                 "HeadNode": {
                     "InstanceType": "t3.micro",
                     "Networking": {"SubnetId": "subnet-12345678"},
+                    "LocalStorage": {"RootVolume": {"VolumeType": "gp3"}},
                 },
             },
             False,
-            id="Removing LocalStorage from HeadNode is blocked",
+            EBS_ACTION_NEEDED,
+            id="Changing HeadNode RootVolume VolumeType shows EBS action_needed",
         ),
     ],
 )
-def test_head_node_local_storage_update_blocked(mocker, base_config, target_config, expected_update_allowed):
-    """Test that adding/changing/removing HeadNode LocalStorage during update is blocked.
+def test_head_node_local_storage_update_blocked(
+    mocker, base_config, target_config, expected_update_allowed, expected_action_needed
+):
+    """Test that HeadNode LocalStorage changes during update are blocked.
 
     LocalStorage affects the HeadNode launch template and cannot be updated without replacing the HeadNode.
+    When individual RootVolume fields (Size, VolumeType) are changed, the EBS action_needed message is shown.
+    When adding/removing the entire LocalStorage section, a generic "Restore value" message is shown instead.
     """
     cluster = Cluster(name="mock-name", stack="mock-stack")
     patch = ConfigPatch(cluster=cluster, base_config=base_config, target_config=target_config)
 
-    # Check that the update is blocked (patch.check() returns False for patch_allowed)
-    patch_allowed, _ = patch.check()
+    patch_allowed, rows = patch.check()
     assert_that(patch_allowed).is_equal_to(expected_update_allowed)
+
+    # Verify action_needed message
+    # rows format: [["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed", ...], ...]
+    action_needed_index = 6
+    action_needed_messages = [row[action_needed_index] for row in rows[1:] if row[action_needed_index]]
+
+    if expected_action_needed:
+        assert_that(action_needed_messages).is_not_empty()
+        assert_that(action_needed_messages[0]).is_equal_to(expected_action_needed)


### PR DESCRIPTION
### Description of changes
* Make HeadNode LocalStorage updates UNSUPPORTED
* This includes making RootVolume updates UNSUPPORTED
* With the previous behavior, all nested properties did not support an update, so you could not modify the head node local storage during an update, but you could add local storage if it was not there
* Adding local storage to the head node creates a new launch template which causes an update failure

### Tests
* Tried to do a cluster update that added LocalStorage, it failed

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
