### PR TITLE
Add idle~ to expected states for test_dynamic_file_systems_update

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1364,7 +1364,7 @@ def test_dynamic_file_systems_update(
     # or under replacement (drained, draining).
     queue2_nodes = scheduler_commands.get_compute_nodes("queue2")
     assert_compute_node_states(
-        scheduler_commands, queue2_nodes, expected_states=["idle", "drained", "idle%", "drained*", "draining"]
+        scheduler_commands, queue2_nodes, expected_states=["idle", "drained", "idle%", "drained*", "draining", "idle~"]
     )
 
     logging.info("Checking that shared storage is visible on the head node")


### PR DESCRIPTION
### Description of changes
* Add idle~ to expected states for test_dynamic_file_systems_update
* The idle~ state means the node is idle and powered down. This could be the state of the dynamic node because it had no jobs running on it.

### Tests
* Ran `test_dynamic_file_systems_update`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
