### PR TITLE
[Validators] Relax validator PlacementGroupCapacityReservationValidator by accepting PG-ODCR when PG is omitted/disabled in cluster config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - Fix intermittent cluster creation failure caused by eventual consistency issues when head, compute and login nodes have the same security group.
 - Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
 - Fix HeadNode/LocalStorage update policy to make updates unsupported.
+- Fix validator `PlacementGroupCapacityReservationValidator` to accept capacity reservations with cross-account placement group.
 
 **DEPRECATIONS**
 - The configuration parameter `LoginNodes/Pools/Ssh/KeyName` is no longer supported.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -3193,7 +3193,6 @@ class SlurmClusterConfig(BaseClusterConfig):
                         subnet=queue.networking.subnet_ids[0],
                         instance_types=compute_resource.instance_types,
                         multi_az_enabled=queue.multi_az_enabled,
-                        subnet_id_az_mapping=queue.networking.subnet_id_az_mapping,
                     )
                 for instance_type in compute_resource.instance_types:
                     if self.scheduling.settings.enable_memory_based_scheduling:

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2695,6 +2695,7 @@ class SlurmQueue(_CommonQueue):
                 is False,
                 multi_az_enabled=self.multi_az_enabled,
                 capacity_type=self.capacity_type,
+                queue_name=self.name,
             )
             self._register_validator(
                 ComputeResourceSizeValidator,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -379,6 +379,7 @@ class EfaPlacementGroupValidator(Validator):
         placement_group_disabled: bool,
         multi_az_enabled: bool,
         capacity_type: str,
+        queue_name: str,
     ):
         # Capacity Blocks do not require the configuration of a Placement Group
         if capacity_type == CapacityType.CAPACITY_BLOCK:
@@ -386,13 +387,17 @@ class EfaPlacementGroupValidator(Validator):
         # if multi_az is enabled suggestions about PlacementGroups will be suppressed
         if efa_enabled and placement_group_disabled and not multi_az_enabled:
             self._add_failure(
-                "You may see better performance using a placement group for the queue.", FailureLevel.WARNING
+                f"You may see better performance using a placement group for the queue '{queue_name}'. "
+                "You can ignore this warning if the compute resources in the queue use a capacity reservation "
+                "that provides its own placement group.",
+                FailureLevel.WARNING,
             )
         elif efa_enabled and placement_group_key is None and not multi_az_enabled:
             self._add_failure(
-                "The placement group for EFA-enabled compute resources must be explicit. "
-                "You may see better performance using a placement group, but if you don't wish to use one please add "
-                "'Enabled: false' to the compute resource's configuration section.",
+                f"The placement group for EFA-enabled compute resources in queue '{queue_name}' must be explicit. "
+                "You may see better performance using a placement group, but if you don't wish to use one or "
+                "the compute resources in the queue use a capacity reservation with its own placement group, "
+                "please add 'Enabled: false' to the compute resource's configuration section.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -787,33 +787,7 @@ class PlacementGroupCapacityReservationValidator(Validator):
                     FailureLevel.WARNING,
                 )
 
-    def _validate_no_pg(
-        self, instance_types, capacity_reservations: List[CapacityReservationInfo], subnet, subnet_id_az_mapping
-    ):
-        for instance_type in instance_types:
-            odcr_without_pg = False
-            for capacity_reservation in capacity_reservations:
-                odcr_pg = get_resource_name_from_resource_arn(capacity_reservation.placement_group_arn())
-                # search for a capacity reservation without a placement group and matching instance type and avail zone
-                if not odcr_pg and (
-                    capacity_reservation_matches_instance(
-                        capacity_reservation=capacity_reservation, instance_type=instance_type
-                    )
-                    and capacity_reservation_matches_avail_zone(
-                        capacity_reservation=capacity_reservation, subnet_id=subnet
-                    )
-                ):
-                    odcr_without_pg = True
-            if not odcr_without_pg:
-                self._add_failure(
-                    f"There are no open or targeted ODCRs that match the instance_type '{instance_type}' in "
-                    f"'{subnet_id_az_mapping[subnet]}' and no placement group provided. Please either provide a "
-                    f"placement group or add an ODCR that does not target a placement group and targets the "
-                    f"instance type.",
-                    FailureLevel.ERROR,
-                )
-
-    def _validate(self, placement_group, odcr, subnet, instance_types, multi_az_enabled, subnet_id_az_mapping):
+    def _validate(self, placement_group, odcr, subnet, instance_types, multi_az_enabled):
         if not multi_az_enabled:
             odcr_id = getattr(odcr, "capacity_reservation_id", None)
             odcr_arn = getattr(odcr, "capacity_reservation_resource_group_arn", None)
@@ -823,6 +797,10 @@ class PlacementGroupCapacityReservationValidator(Validator):
                 capacity_reservations = get_capacity_reservations(odcr_arn)
             else:
                 capacity_reservations = None
+            # If the user provided a placement group and the capacity reservation has a placement group,
+            # then the two placement groups must match.
+            # If the user omitted a placement group and the capacity reservation has a placement group,
+            # then it is ok to rely on the reservation placement group.
             if capacity_reservations:
                 if placement_group:
                     self._validate_chosen_pg(
@@ -830,13 +808,6 @@ class PlacementGroupCapacityReservationValidator(Validator):
                         instance_types=instance_types,
                         capacity_reservations=capacity_reservations,
                         chosen_pg=placement_group,
-                    )
-                else:
-                    self._validate_no_pg(
-                        subnet=subnet,
-                        instance_types=instance_types,
-                        capacity_reservations=capacity_reservations,
-                        subnet_id_az_mapping=subnet_id_az_mapping,
                     )
 
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -748,14 +748,15 @@ def test_efa_validator(
 
 
 @pytest.mark.parametrize(
-    "efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, capacity_type, expected_message",
+    "efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, capacity_type, "
+    "queue_name, expected_message",
     [
         # Efa disabled
-        (False, "test", False, False, CapacityType.ONDEMAND, None),
-        (False, "test", True, False, CapacityType.ONDEMAND, None),
-        (False, None, False, False, CapacityType.ONDEMAND, None),
-        (False, None, True, False, CapacityType.ONDEMAND, None),
-        (False, "test", False, False, CapacityType.CAPACITY_BLOCK, None),
+        (False, "test", False, False, CapacityType.ONDEMAND, "queue1", None),
+        (False, "test", True, False, CapacityType.ONDEMAND, "queue1", None),
+        (False, None, False, False, CapacityType.ONDEMAND, "queue1", None),
+        (False, None, True, False, CapacityType.ONDEMAND, "queue1", None),
+        (False, "test", False, False, CapacityType.CAPACITY_BLOCK, "queue1", None),
         # Efa enabled
         (
             True,
@@ -763,10 +764,11 @@ def test_efa_validator(
             False,
             False,
             CapacityType.ONDEMAND,
-            "The placement group for EFA-enabled compute resources must be explicit. "
-            "You may see better performance using a placement group, "
-            "but if you don't wish to use one please add "
-            "'Enabled: false' to the compute resource's configuration section.",
+            "queue1",
+            "The placement group for EFA-enabled compute resources in queue 'queue1' must be explicit. "
+            "You may see better performance using a placement group, but if you don't wish to use one or "
+            "the compute resources in the queue use a capacity reservation with its own placement group, "
+            "please add 'Enabled: false' to the compute resource's configuration section.",
         ),
         (
             True,
@@ -774,16 +776,22 @@ def test_efa_validator(
             True,
             False,
             CapacityType.ONDEMAND,
-            "You may see better performance using a placement group for the queue.",
+            "queue1",
+            "You may see better performance using a placement group for the queue 'queue1'. "
+            "You can ignore this warning if the compute resources in the queue use a capacity reservation "
+            "that provides its own placement group.",
         ),
-        (True, "test", False, False, CapacityType.ONDEMAND, None),
+        (True, "test", False, False, CapacityType.ONDEMAND, "queue1", None),
         (
             True,
             "test",
             True,
             False,
             CapacityType.ONDEMAND,
-            "You may see better performance using a placement group for the queue.",
+            "queue1",
+            "You may see better performance using a placement group for the queue 'queue1'. "
+            "You can ignore this warning if the compute resources in the queue use a capacity reservation "
+            "that provides its own placement group.",
         ),
         (
             True,
@@ -791,16 +799,23 @@ def test_efa_validator(
             False,
             False,
             CapacityType.CAPACITY_BLOCK,
+            "queue1",
             None,
         ),
         # EFA and MultiAZ enabled
-        (True, "test", False, True, CapacityType.ONDEMAND, None),
-        (True, "test", True, True, CapacityType.ONDEMAND, None),
-        (True, "test", True, True, CapacityType.CAPACITY_BLOCK, None),
+        (True, "test", False, True, CapacityType.ONDEMAND, "queue1", None),
+        (True, "test", True, True, CapacityType.ONDEMAND, "queue1", None),
+        (True, "test", True, True, CapacityType.CAPACITY_BLOCK, "queue1", None),
     ],
 )
 def test_efa_placement_group_validator(
-    efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, capacity_type, expected_message
+    efa_enabled,
+    placement_group_key,
+    placement_group_disabled,
+    multi_az_enabled,
+    capacity_type,
+    queue_name,
+    expected_message,
 ):
     actual_failures = EfaPlacementGroupValidator().execute(
         efa_enabled,
@@ -808,6 +823,7 @@ def test_efa_placement_group_validator(
         placement_group_disabled,
         multi_az_enabled,
         capacity_type,
+        queue_name,
     )
 
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -1376,8 +1376,7 @@ mock_capacity_reservations = [
 
 
 @pytest.mark.parametrize(
-    "placement_group, odcr, subnets, instance_types, capacity_reservations, "
-    "multi_az_enabled, subnet_id_az_mapping, expected_message",
+    "placement_group, odcr, subnets, instance_types, capacity_reservations, " "multi_az_enabled, expected_message",
     [
         (
             None,
@@ -1386,7 +1385,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
             None,
         ),
         (
@@ -1396,7 +1394,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
             None,
         ),
         (
@@ -1406,12 +1403,7 @@ mock_capacity_reservations = [
             ["mock-type", "mock-type-2"],
             mock_capacity_reservations[:3],
             False,
-            {"mock-subnet-1": "us-east-1"},
-            (
-                "There are no open or targeted ODCRs that match the instance_type 'mock-type-2' in 'us-east-1' "
-                "and no placement group provided. Please either provide a placement group or add an ODCR that "
-                "does not target a placement group and targets the instance type"
-            ),
+            None,
         ),
         (
             None,
@@ -1420,7 +1412,6 @@ mock_capacity_reservations = [
             ["mock-type", "mock-type-2"],
             mock_capacity_reservations[:4],
             False,
-            {"mock-subnet-1": "us-east-1"},
             None,
         ),
         (
@@ -1430,10 +1421,7 @@ mock_capacity_reservations = [
             ["mock-type", "mock-type-2"],
             mock_capacity_reservations[:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
-            "There are no open or targeted ODCRs that match the instance_type 'mock-type-2' in 'us-east-1' and "
-            "no placement group provided. Please either provide a placement group or add an ODCR that does not target "
-            "a placement group and targets the instance type.",
+            None,
         ),
         (
             "mock-placement",
@@ -1442,7 +1430,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
             "When using an open or targeted capacity reservation with an unrelated placement group, "
             "insufficient capacity errors may occur due to placement constraints outside of the "
             "reservation even if the capacity reservation has remaining capacity. Please consider either "
@@ -1456,7 +1443,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[1:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
             "The placement group provided 'test' targets the 'mock-type' instance type but there "
             "are no ODCRs included in the resource group that target that instance type.",
         ),
@@ -1467,7 +1453,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[1:2],
             False,
-            {"mock-subnet-1": "us-east-1"},
             "The placement group provided 'test-2' targets the 'mock-type' instance type but there "
             "are no ODCRs included in the resource group that target that instance type.",
         ),
@@ -1478,7 +1463,6 @@ mock_capacity_reservations = [
             ["mock-type", "mock-type-2"],
             mock_capacity_reservations[:3],
             True,
-            {"mock-subnet-1": "us-east-1"},
             None,
         ),
         (
@@ -1488,7 +1472,6 @@ mock_capacity_reservations = [
             ["mock-type"],
             mock_capacity_reservations[:3],
             True,
-            {"mock-subnet-1": "us-east-1"},
             None,
         ),
     ],
@@ -1501,7 +1484,6 @@ def test_placement_group_capacity_reservation_validator(
     instance_types,
     capacity_reservations,
     multi_az_enabled,
-    subnet_id_az_mapping,
     expected_message,
 ):
     mock_aws_api(mocker)
@@ -1517,7 +1499,6 @@ def test_placement_group_capacity_reservation_validator(
         subnet=subnets[0],
         instance_types=instance_types,
         multi_az_enabled=multi_az_enabled,
-        subnet_id_az_mapping=subnet_id_az_mapping,
     )
     assert_failure_messages(actual_failure, expected_message)
 


### PR DESCRIPTION
### Description of changes
Relax validator PlacementGroupCapacityReservationValidator by accepting PG-ODCR when PG is omitted/disabled in cluster config.

This relaxation is safe because, when PG in cluster config is omitted/disabled, the ODCR decides the placement using its own PG. See doc: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-cpg.html
    
This relaxation allows users to consume PG-ODCR having cross-account PG.

### UX

Given a cluster config with a PG-ODCR and omitted/disabled PG, the CLI now succeeds with more helpful warning:

```
{
  "validationMessages": [
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue 'q2'. You can ignore this warning if the compute resources in the queue use a capacity reservation that provides its own placement group."
    },
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue 'q3'. You can ignore this warning if the compute resources in the queue use a capacity reservation that provides its own placement group."
    }
  ],
  "message": "Request would have succeeded, but DryRun flag is set."
}
```

while it used to fail with less helpful messages:

```
{
  "configurationValidationErrors": [
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue."
    },
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue."
    },
    {
      "level": "ERROR",
      "type": "PlacementGroupCapacityReservationValidator",
      "message": "There are no open or targeted ODCRs that match the instance_type 'c5n.9xlarge' in 'us-east-1b' and no placement group provided. Please either provide a placement group or add an ODCR that does not target a placement group and targets the instance type."
    },
    {
      "level": "ERROR",
      "type": "PlacementGroupCapacityReservationValidator",
      "message": "There are no open or targeted ODCRs that match the instance_type 'c5n.9xlarge' in 'us-east-1b' and no placement group provided. Please either provide a placement group or add an ODCR that does not target a placement group and targets the instance type."
    }
  ],
  "message": "Invalid cluster configuration."
}
```

Now:
```
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue 'q2'. You can ignore this warning if the compute resources in the queue use a capacity reservation that provides its own placement group."
    },
    {
      "level": "WARNING",
      "type": "EfaPlacementGroupValidator",
      "message": "You may see better performance using a placement group for the queue 'q3'. You can ignore this warning if the compute resources in the queue use a capacity reservation that provides its own placement group."
    },
```

#### Changes

| Case | PG/Enabled | ODCR has PG? | PG is cross-account? | Current | Proposed | Notes |
|------|------------|--------------|----------------------|---------|----------|-------|
| 2 | omitted | Yes | No | ❌ ERROR | ✅ Pass | Validation skipped |
| 3 | omitted | Yes | Yes | ❌ ERROR | ✅ Pass | Validation skipped |
| 5 | false | Yes | No | ❌ ERROR | ✅ Pass | Validation skipped |
| 6 | false | Yes | Yes | ❌ ERROR | ✅ Pass | Validation skipped |


### Tests
* Unit Tests
* Cluster creation consuming cross-account PG ODCR. Verified that capacity can launch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
