### PR TITLE
[Test] In test `test_dcv_with_remote_access`, remove unnecessary log lines printing content of large known_host file.

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -186,13 +186,7 @@ def _test_show_url(cluster, region, dcv_port, access_from, use_login_node=False)
     except Exception as e:
         logging.warning(f"Failed to prepare known_hosts file {host_keys_file}: {e}")
 
-    before_content = _get_known_hosts_content(host_keys_file)
-    logging.info(f"Original content of known hosts file {host_keys_file}: {before_content}")
-
     add_keys_to_known_hosts(node_ip, host_keys_file)
-
-    after_content = _get_known_hosts_content(host_keys_file)
-    logging.info(f"New content of known hosts file {host_keys_file}: {after_content}")
 
     dcv_connect_args = ["pcluster", "dcv-connect", "--cluster-name", cluster.name, "--show-url"]
 


### PR DESCRIPTION
### Description of changes
In test `test_dcv_with_remote_access`, remove unnecessary log lines printing content of large known_host file.

These log lines print a file that reached ~10MB twice, making the test log hard to process.
This is a symptom that the cleanup mechanism for known_host file is not working.
We will focus on the root cause but we first need to remove the huge logging which makes the logging hard to process.

### Test
Not needed, only dropped two logging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
