### PR TITLE
[Test] Reduce the risk of ICEs in test_update_slurm by setting more flexible instance types

### DIFF
--- a/cli/src/pcluster/api/models/describe_cluster_instances_response_content.py
+++ b/cli/src/pcluster/api/models/describe_cluster_instances_response_content.py
@@ -32,7 +32,7 @@ class DescribeClusterInstancesResponseContent(Model):
         """
         self.openapi_types = {"instances": List[ClusterInstance], "next_token": str}
 
-        self.attribute_map = {"instances": "instances", "next_token": "nextToken"}
+        self.attribute_map = {"instances": "instances", "next_token": "nextToken"}  # nosec B105
 
         self._instances = instances
         self._next_token = next_token

--- a/cli/src/pcluster/api/models/get_cluster_log_events_response_content.py
+++ b/cli/src/pcluster/api/models/get_cluster_log_events_response_content.py
@@ -28,7 +28,7 @@ class GetClusterLogEventsResponseContent(Model):
         """
         self.openapi_types = {"next_token": str, "prev_token": str, "events": List[LogEvent]}
 
-        self.attribute_map = {"next_token": "nextToken", "prev_token": "prevToken", "events": "events"}
+        self.attribute_map = {"next_token": "nextToken", "prev_token": "prevToken", "events": "events"}  # nosec B105
 
         self._next_token = next_token
         self._prev_token = prev_token

--- a/cli/src/pcluster/api/models/get_cluster_stack_events_response_content.py
+++ b/cli/src/pcluster/api/models/get_cluster_stack_events_response_content.py
@@ -26,7 +26,7 @@ class GetClusterStackEventsResponseContent(Model):
         """
         self.openapi_types = {"next_token": str, "events": List[StackEvent]}
 
-        self.attribute_map = {"next_token": "nextToken", "events": "events"}
+        self.attribute_map = {"next_token": "nextToken", "events": "events"}  # nosec B105
 
         self._next_token = next_token
         self._events = events

--- a/cli/src/pcluster/api/models/get_image_log_events_response_content.py
+++ b/cli/src/pcluster/api/models/get_image_log_events_response_content.py
@@ -28,7 +28,7 @@ class GetImageLogEventsResponseContent(Model):
         """
         self.openapi_types = {"next_token": str, "prev_token": str, "events": List[LogEvent]}
 
-        self.attribute_map = {"next_token": "nextToken", "prev_token": "prevToken", "events": "events"}
+        self.attribute_map = {"next_token": "nextToken", "prev_token": "prevToken", "events": "events"}  # nosec B105
 
         self._next_token = next_token
         self._prev_token = prev_token

--- a/cli/src/pcluster/api/models/get_image_stack_events_response_content.py
+++ b/cli/src/pcluster/api/models/get_image_stack_events_response_content.py
@@ -26,7 +26,7 @@ class GetImageStackEventsResponseContent(Model):
         """
         self.openapi_types = {"next_token": str, "events": List[StackEvent]}
 
-        self.attribute_map = {"next_token": "nextToken", "events": "events"}
+        self.attribute_map = {"next_token": "nextToken", "events": "events"}  # nosec B105
 
         self._next_token = next_token
         self._events = events

--- a/cli/src/pcluster/api/models/list_cluster_log_streams_response_content.py
+++ b/cli/src/pcluster/api/models/list_cluster_log_streams_response_content.py
@@ -26,7 +26,7 @@ class ListClusterLogStreamsResponseContent(Model):
         """
         self.openapi_types = {"log_streams": List[LogStream], "next_token": str}
 
-        self.attribute_map = {"log_streams": "logStreams", "next_token": "nextToken"}
+        self.attribute_map = {"log_streams": "logStreams", "next_token": "nextToken"}  # nosec B105
 
         self._log_streams = log_streams
         self._next_token = next_token

--- a/cli/src/pcluster/api/models/list_clusters_response_content.py
+++ b/cli/src/pcluster/api/models/list_clusters_response_content.py
@@ -32,7 +32,7 @@ class ListClustersResponseContent(Model):
         """
         self.openapi_types = {"next_token": str, "clusters": List[ClusterInfoSummary]}
 
-        self.attribute_map = {"next_token": "nextToken", "clusters": "clusters"}
+        self.attribute_map = {"next_token": "nextToken", "clusters": "clusters"}  # nosec B105
 
         self._next_token = next_token
         self._clusters = clusters

--- a/cli/src/pcluster/api/models/list_image_log_streams_response_content.py
+++ b/cli/src/pcluster/api/models/list_image_log_streams_response_content.py
@@ -26,7 +26,7 @@ class ListImageLogStreamsResponseContent(Model):
         """
         self.openapi_types = {"log_streams": List[LogStream], "next_token": str}
 
-        self.attribute_map = {"log_streams": "logStreams", "next_token": "nextToken"}
+        self.attribute_map = {"log_streams": "logStreams", "next_token": "nextToken"}  # nosec B105
 
         self._log_streams = log_streams
         self._next_token = next_token

--- a/cli/src/pcluster/api/models/list_images_response_content.py
+++ b/cli/src/pcluster/api/models/list_images_response_content.py
@@ -32,7 +32,7 @@ class ListImagesResponseContent(Model):
         """
         self.openapi_types = {"images": List[ImageInfoSummary], "next_token": str}
 
-        self.attribute_map = {"images": "images", "next_token": "nextToken"}
+        self.attribute_map = {"images": "images", "next_token": "nextToken"}  # nosec B105
 
         self._images = images
         self._next_token = next_token

--- a/cli/src/pcluster/api/models/log_stream.py
+++ b/cli/src/pcluster/api/models/log_stream.py
@@ -52,7 +52,7 @@ class LogStream(Model):
             "upload_sequence_token": str,
         }
 
-        self.attribute_map = {
+        self.attribute_map = {  # nosec B105
             "log_stream_arn": "logStreamArn",
             "creation_time": "creationTime",
             "log_stream_name": "logStreamName",

--- a/cli/src/pcluster/api/models/stack_event.py
+++ b/cli/src/pcluster/api/models/stack_event.py
@@ -69,7 +69,7 @@ class StackEvent(Model):
             "timestamp": datetime,
         }
 
-        self.attribute_map = {
+        self.attribute_map = {  # nosec B105
             "event_id": "eventId",
             "physical_resource_id": "physicalResourceId",
             "resource_status": "resourceStatus",

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -177,9 +177,9 @@ def configure(args):  # noqa: C901
     for queue_index in range(number_of_queues):
         while True:
             queue_name = prompt(
-                f"Name of queue {queue_index+1}",
+                f"Name of queue {queue_index + 1}",
                 validator=lambda x: len(NameValidator().execute(x)) == 0,
-                default_value=f"queue{queue_index+1}",
+                default_value=f"queue{queue_index + 1}",
             )
             if queue_name not in queue_names:
                 break
@@ -208,7 +208,7 @@ def configure(args):  # noqa: C901
             if scheduler != "awsbatch":
                 while True:
                     compute_instance_type = prompt(
-                        f"Compute instance type for compute resource {compute_resource_index+1} in {queue_name}",
+                        f"Compute instance type for compute resource {compute_resource_index + 1} in {queue_name}",
                         validator=lambda x: x in AWSApi.instance().ec2.list_instance_types(),
                         default_value=default_instance_type,
                     )

--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -79,15 +79,13 @@ class SshCommand(CliCommand):
         "Run ssh command with the cluster username and IP address pre-populated. "
         "Arbitrary arguments are appended to the end of the ssh command."
     )
-    epilog = textwrap.dedent(
-        """Example:
+    epilog = textwrap.dedent("""Example:
 
   pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa
 
 Returns an ssh command with the cluster username and IP address pre-populated:
 
-  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa"""
-    )
+  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa""")
 
     def __init__(self, subparsers):
         super().__init__(

--- a/cli/src/pcluster/cli/model.py
+++ b/cli/src/pcluster/cli/model.py
@@ -20,12 +20,6 @@ from pcluster.api import encoder, openapi
 from pcluster.cli.exceptions import APIOperationException
 from pcluster.utils import to_kebab_case, to_snake_case, yaml_load
 
-# For importing package resources
-try:
-    import importlib.resources as pkg_resources  # pylint: disable=ungrouped-imports # nosem
-except ImportError:
-    import importlib_resources as pkg_resources
-
 
 def _param_overrides(operation, param):
     """Provide updates to the model that are specific to the CLI."""
@@ -88,7 +82,7 @@ def _resolve_body(spec, operation):
 
 def package_spec():
     """Load the OpenAPI specification from the package."""
-    with pkg_resources.open_text(openapi, "openapi.yaml") as spec_file:  # pylint: disable=deprecated-method
+    with importlib.resources.open_text(openapi, "openapi.yaml") as spec_file:  # pylint: disable=deprecated-method
         return yaml_load(spec_file.read())
 
 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -354,3 +354,28 @@ ULTRASERVER_CAPACITY_BLOCK_ALLOWED_SIZE_DICT = {
 }
 # Capacity Block states that are considered inactive (cannot check health status)
 CAPACITY_BLOCK_INACTIVE_STATES = ["scheduled", "payment-pending", "assessing", "delayed"]
+
+# Older generation instance types
+EXCLUDED_INSTANCE_TYPE_PREFIXES = (
+    "m1",
+    "m2",
+    "m3",
+    "m4",
+    "t1",
+    "t2",
+    "c1",
+    "c3",
+    "c4",
+    "r3",
+    "r4",
+    "x1",
+    "x1e",
+    "d2",
+    "h1",
+    "i2",
+    "i3",
+    "f1",
+    "g3",
+    "p2",
+    "p3",
+)

--- a/cli/tests/pcluster/models/test_s3_bucket.py
+++ b/cli/tests/pcluster/models/test_s3_bucket.py
@@ -245,15 +245,13 @@ def test_get_resource_url(region, bucket_name, cluster_name, resource_name, expe
                 "B": {"B1": "M"},
             },
             S3FileFormat.YAML,
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 A:
                   A1: X
                   A2: Y
                 B:
                   B1: M
-                """
-            ),
+                """),
         ),
         (
             {

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -22,7 +22,6 @@ import tempfile
 from pathlib import Path
 
 import boto3
-import pkg_resources
 import pytest
 import urllib3
 from framework.fixture_utils import xdist_session_fixture
@@ -36,7 +35,7 @@ NODE_VERSION = "v18.20.3"
 def install_pc(basepath, pc_version):
     """Install ParallelCluster to a temporary directory"""
     tempdir = Path(basepath) / "python"
-    root = Path(pkg_resources.resource_filename(__name__, "/../.."))
+    root = Path(__file__).parent.parent
     cli_dir = root / "cli"
     try:
         logger.info("installing ParallelCluster packages...")
@@ -105,7 +104,7 @@ def get_resource_map():
 
 @xdist_session_fixture()
 def resource_bucket_shared(request, s3_bucket_factory_shared, lambda_layer_source):
-    root = Path(pkg_resources.resource_filename(__name__, "/../.."))
+    root = Path(__file__).parent.parent
     if request.config.getoption("resource_bucket"):
         return None  # short-circuit this fixture if a resource-bucket is provided
 

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -22,6 +22,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
 from pcluster.constants import (
+    EXCLUDED_INSTANCE_TYPE_PREFIXES,
     SUPPORTED_OSES,
     SUPPORTED_OSES_FOR_SCHEDULER,
     UNSUPPORTED_ARM_OSES_FOR_DCV,
@@ -96,29 +97,6 @@ def _get_instance_type_parameters():  # noqa: C901
         return _get_instance_type_parameters._cache
 
     result = {}
-    excluded_instance_type_prefixes = (
-        "m1",
-        "m2",
-        "m3",
-        "m4",
-        "t1",
-        "t2",
-        "c1",
-        "c3",
-        "c4",
-        "r3",
-        "r4",
-        "x1",
-        "x1e",
-        "d2",
-        "h1",
-        "i2",
-        "i3",
-        "f1",
-        "g3",
-        "p2",
-        "p3",
-    )
 
     for region in ["us-east-1", "us-west-2"]:  # Only populate instance type for big regions
         ec2_client = boto3.client("ec2", region_name=region)
@@ -137,13 +115,13 @@ def _get_instance_type_parameters():  # noqa: C901
                     instance_type_availability_zones[instance_type_name].append(offering["Location"])
                     # Check if instance type ends with '.xlarge'
                     if instance_type_name.endswith(".xlarge") and _is_current_instance_type_generation(
-                        excluded_instance_type_prefixes, offering
+                        EXCLUDED_INSTANCE_TYPE_PREFIXES, offering
                     ):
                         xlarge_instances.add(instance_type_name)
                     # Get a list of only GPU instances of any size available in the region
                     if (
                         instance_type_name.startswith("p") or instance_type_name.startswith("g")
-                    ) and _is_current_instance_type_generation(excluded_instance_type_prefixes, offering):
+                    ) and _is_current_instance_type_generation(EXCLUDED_INSTANCE_TYPE_PREFIXES, offering):
                         all_gpu_instances.add(instance_type_name)
 
             # Get GPU instance details in batches of 100
@@ -161,7 +139,7 @@ def _get_instance_type_parameters():  # noqa: C901
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
                             ) >= 4 and _is_current_instance_type_generation(
-                                excluded_instance_type_prefixes, instance_type
+                                EXCLUDED_INSTANCE_TYPE_PREFIXES, instance_type
                             ):
                                 # Find instance types with 4 or more GPUs. Number of GPUs can change test behavior.
                                 # For example, it takes longer for DCGM health check to diagnose multiple GPUs.

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -15,11 +15,12 @@ import pathlib
 import random
 import string
 import time
+from importlib.metadata import version as get_package_version
 
 import boto3
-import pkg_resources
 from assertpy import assert_that
 from botocore.exceptions import ClientError
+from packaging import version as packaging_version
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
@@ -263,14 +264,14 @@ def _assert_ami_is_available(region, ami_id):
 def get_installed_parallelcluster_version():
     """Get the version of the installed aws-parallelcluster package."""
     try:
-        return pkg_resources.get_distribution("aws-parallelcluster").version
+        return get_package_version("aws-parallelcluster")
     except Exception:
         logging.info("aws-parallelcluster is not installed through Python. Getting version from `pcluster version`.")
         return json.loads(run_command(["pcluster", "version"]).stdout.strip())["version"]
 
 
 def get_installed_parallelcluster_base_version():
-    return pkg_resources.packaging.version.parse(get_installed_parallelcluster_version()).base_version
+    return packaging_version.parse(get_installed_parallelcluster_version()).base_version
 
 
 CLASSIC_AWS_DOMAIN = "amazonaws.com"

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -159,7 +159,7 @@ def test_cluster_creation_with_problematic_preinstall_script(
     assert_lines_in_logs(
         remote_command_executor,
         ["/var/log/cfn-init.log"],
-        [f"Failed to execute OnNodeStart script 1 s3://{ bucket_name }/scripts/{script_name}"],
+        [f"Failed to execute OnNodeStart script 1 s3://{bucket_name}/scripts/{script_name}"],
     )
     logging.info("Verifying error in cloudformation failure reason")
     stack_events = cluster.get_stack_events().get("events")
@@ -173,7 +173,7 @@ def test_cluster_creation_with_problematic_preinstall_script(
     )
 
     assert_that(cfn_failure_reason).contains(expected_cfn_failure_reason)
-    assert_that(cfn_failure_reason).does_not_contain(f"s3://{ bucket_name }/scripts/{script_name}")
+    assert_that(cfn_failure_reason).does_not_contain(f"s3://{bucket_name}/scripts/{script_name}")
 
     logging.info("Verifying failures in describe-clusters output")
     expected_failures = [

--- a/tests/integration-tests/tests/custom_resource/conftest.py
+++ b/tests/integration-tests/tests/custom_resource/conftest.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 import boto3
 import cfn_tools
-import pkg_resources
 import pytest
 import yaml
 from cfn_stacks_factory import CfnStack
@@ -34,7 +33,7 @@ def cfn_fixture(region):
 
 @pytest.fixture(scope="session", name="resources_dir")
 def resources_dir_fixture():
-    return Path(pkg_resources.resource_filename(__name__, "/../../resources"))
+    return Path(__file__).parent.parent.parent / "resources"
 
 
 @pytest.fixture(scope="session", name="cluster_custom_resource_template")

--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import boto3
 import cfn_tools
-import pkg_resources
 import pytest
 from assertpy import assert_that
 from benchmarks.common.util import get_instance_vcpus
@@ -128,7 +127,7 @@ def _ec2_wait(region, instances, waiter_type):
 
 @pytest.fixture(scope="session", name="resources_dir")
 def resources_dir_fixture():
-    return Path(pkg_resources.resource_filename(__name__, "/../../resources"))
+    return Path(__file__).parent.parent.parent / "resources"
 
 
 @pytest.fixture(scope="session", name="policies_template_path")

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -169,7 +169,7 @@ def test_slurm_ticket_17399(
             "partition": "gpu",
             "test_only": True,
             "other_options": f"--gpus {gpus_per_instance} --nodes 1 --ntasks-per-node 1 "
-            f"--cpus-per-task={cpus_per_instance//gpus_per_instance}",
+            f"--cpus-per-task={cpus_per_instance // gpus_per_instance}",
         }
     )
 
@@ -180,7 +180,7 @@ def test_slurm_ticket_17399(
             "partition": "gpu",
             "test_only": True,
             "other_options": f"--gpus {gpus_per_instance} --nodes 1 --ntasks-per-node 1 "
-            f"--cpus-per-task={cpus_per_instance//gpus_per_instance + 1}",
+            f"--cpus-per-task={cpus_per_instance // gpus_per_instance + 1}",
         }
     )
 

--- a/tests/integration-tests/tests/storage/kms_key_factory.py
+++ b/tests/integration-tests/tests/storage/kms_key_factory.py
@@ -3,9 +3,9 @@ import logging
 import random
 import string
 import time
+from pathlib import Path
 
 import boto3
-import pkg_resources
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from utils import get_arn_partition
@@ -112,7 +112,7 @@ class KMSKeyFactory:
         # create the iam policy
         # for different scheduler, attach different instance policy
         logging.info("Creating iam policy {0} for iam role...".format(iam_policy_name))
-        file_loader = FileSystemLoader(pkg_resources.resource_filename(__name__, "/../../resources"))
+        file_loader = FileSystemLoader(Path(__file__).parent.parent.parent / "resources")
         env = SandboxedEnvironment(loader=file_loader, trim_blocks=True, lstrip_blocks=True)
         policy_filename = (
             "batch_instance_policy.json" if scheduler == "awsbatch" else "traditional_instance_policy.json"
@@ -155,7 +155,7 @@ class KMSKeyFactory:
 
         # create KMS key policy
         logging.info("Attaching key policy...")
-        file_loader = FileSystemLoader(pkg_resources.resource_filename(__name__, "/../../resources"))
+        file_loader = FileSystemLoader(Path(__file__).parent.parent.parent / "resources")
         env = SandboxedEnvironment(loader=file_loader, trim_blocks=True, lstrip_blocks=True)
         key_policy = env.get_template("key_policy.json").render(
             partition=self.partition, account_id=self.account_id, iam_role_name=f"parallelcluster/{self.iam_role_name}"

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -182,7 +182,7 @@ def test_ebs_multiple(
     for i in range(len(volume_ids)):
         # test different volume types
         volume_id = volume_ids[i]
-        ebs_settings = _get_ebs_settings_by_name(cluster.config, f"ebs{i+1}")
+        ebs_settings = _get_ebs_settings_by_name(cluster.config, f"ebs{i + 1}")
         volume_type = ebs_settings["VolumeType"]
         volume = describe_volume(volume_id, region)
         assert_that(volume[0]).is_equal_to(volume_type)

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -33,6 +33,7 @@ from utils import (
     generate_stack_name,
     get_arn_partition,
     get_root_volume_id,
+    get_similar_instance_types,
     is_filecache_supported,
     is_fsx_lustre_supported,
     is_fsx_ontap_supported,
@@ -83,12 +84,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     ]:
         bucket.upload_file(str(test_datadir / script), f"scripts/{script}")
 
-    spot_instance_types = ["t3.medium"]
-    try:
-        boto3.client("ec2").describe_instance_types(InstanceTypes=["t3a.medium"])
-        spot_instance_types.extend(["t3a.medium"])
-    except Exception:
-        pass
+    spot_instance_types = get_similar_instance_types("t3.medium", region, 5)
 
     # Create cluster with initial configuration
     init_config_file = pcluster_config_reader(resource_bucket=bucket_name, spot_instance_types=spot_instance_types)

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -29,6 +29,8 @@ from jinja2.sandbox import SandboxedEnvironment
 from retrying import retry
 from time_utils import minutes, seconds
 
+from pcluster.constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
+
 DEFAULT_PARTITION = "aws"
 PARTITION_MAP = {
     "cn": "aws-cn",
@@ -1028,11 +1030,13 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
+            instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
             instance_has_gpu = "GpuInfo" in instance
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
-                instance_has_efa == target_has_efa
+                instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
+                and instance_has_efa == target_has_efa
                 and instance_has_gpu == target_has_gpu
                 and instance_inference_accelerators == target_inference_accelerators
             ):

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1023,6 +1023,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
             {"Name": "processor-info.supported-architecture", "Values": [target_arch]},
             {"Name": "vcpu-info.default-vcpus", "Values": [str(target_vcpus)]},
             {"Name": "vcpu-info.default-threads-per-core", "Values": [str(target_threads)]},
+            {"Name": "supported-usage-class", "Values": ["on-demand", "spot"]},
         ],
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types


### PR DESCRIPTION
### Description of changes
Cherry-picked:

* https://github.com/aws/aws-parallelcluster/pull/7213 to reduce the risk of ICEs in test_update_slurm by setting more flexible instance types.
Before this change the test was using up to 2 instance types, which exposes the test to ICEs.
With this change we are using 5 different flexible instance types.

* https://github.com/aws/aws-parallelcluster/pull/7235: to address linter failures and prevent to run retired instance types when using the fixture to inject flex instance types.

### Tests
Tested in original PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
