### PR TITLE
[DevSettings] Added validation and update support for chef attributes: `cluster.cluster_readiness_check_enabled` and  `cluster.cluster_readiness_check_ignore_failure`.

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -516,6 +516,8 @@ def get_pool_name_from_change_paths(change):
 # IMPORTANT: We assume this set to contain the path to leaf fields.
 EXTRA_CHEF_ATTRIBUTES_UPDATABLE_PATHS: set[str] = {
     "cluster.slurm.reconfigure_timeout",
+    "cluster.cluster_readiness_check_enabled",
+    "cluster.cluster_readiness_check_ignore_failure",
 }
 
 

--- a/cli/src/pcluster/validators/dev_settings_validators.py
+++ b/cli/src/pcluster/validators/dev_settings_validators.py
@@ -16,6 +16,8 @@ from pcluster.validators.utils import dig, is_boolean_string, str_to_bool
 EXTRA_CHEF_ATTRIBUTES_PATH = "DevSettings/Cookbook/ExtraChefAttributes"
 ATTR_IN_PLACE_UPDATE_ON_FLEET_ENABLED = "in_place_update_on_fleet_enabled"
 ATTR_RECONFIGURE_TIMEOUT = "cluster.slurm.reconfigure_timeout"
+ATTR_CLUSTER_READINESS_CHECK_ENABLED = "cluster.cluster_readiness_check_enabled"
+ATTR_CLUSTER_READINESS_CHECK_IGNORE_FAILURE = "cluster.cluster_readiness_check_ignore_failure"
 MIN_SLURM_RECONFIGURE_TIMEOUT = 300
 
 
@@ -35,6 +37,8 @@ class ExtraChefAttributesValidator(Validator):
         attrs = json.loads(extra_chef_attributes)
         self._validate_in_place_update_on_fleet_enabled(attrs)
         self._validate_slurm_reconfigure_timeout(attrs)
+        self._validate_cluster_readiness_check_enabled(attrs)
+        self._validate_cluster_readiness_check_ignore_failure(attrs)
 
     def _validate_in_place_update_on_fleet_enabled(self, extra_chef_attributes: dict = None):
         """Validate attribute cluster.in_place_update_on_fleet_enabled.
@@ -62,6 +66,64 @@ class ExtraChefAttributesValidator(Validator):
             self._add_failure(
                 "When in-place updates are disabled, cluster updates are applied "
                 "by replacing compute and login nodes according to the selected QueueUpdateStrategy.",
+                FailureLevel.WARNING,
+            )
+
+    def _validate_cluster_readiness_check_enabled(self, extra_chef_attributes: dict = None):
+        """Validate attribute cluster.cluster_readiness_check_enabled.
+
+        It returns an error if the attribute is set to a non-boolean value.
+        It returns a warning if the cluster readiness check is disabled.
+
+        Args:
+            extra_chef_attributes: Dictionary of Chef attributes to validate.
+        """
+        value = dig(extra_chef_attributes, *ATTR_CLUSTER_READINESS_CHECK_ENABLED.split("."))
+
+        if value is None:
+            return
+
+        if not is_boolean_string(str(value)):
+            self._add_failure(
+                f"Invalid value in {EXTRA_CHEF_ATTRIBUTES_PATH}: "
+                f"attribute '{ATTR_CLUSTER_READINESS_CHECK_ENABLED}' must be a boolean value.",
+                FailureLevel.ERROR,
+            )
+            return
+
+        if str_to_bool(str(value)) is False:
+            self._add_failure(
+                "Cluster readiness check is disabled. Cluster creation and cluster update can succeed "
+                "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
+                FailureLevel.WARNING,
+            )
+
+    def _validate_cluster_readiness_check_ignore_failure(self, extra_chef_attributes: dict = None):
+        """Validate attribute cluster.cluster_readiness_check_ignore_failure.
+
+        It returns an error if the attribute is set to a non-boolean value.
+        It returns a warning if the cluster readiness check failures are ignored.
+
+        Args:
+            extra_chef_attributes: Dictionary of Chef attributes to validate.
+        """
+        value = dig(extra_chef_attributes, *ATTR_CLUSTER_READINESS_CHECK_IGNORE_FAILURE.split("."))
+
+        if value is None:
+            return
+
+        if not is_boolean_string(str(value)):
+            self._add_failure(
+                f"Invalid value in {EXTRA_CHEF_ATTRIBUTES_PATH}: "
+                f"attribute '{ATTR_CLUSTER_READINESS_CHECK_IGNORE_FAILURE}' must be a boolean value.",
+                FailureLevel.ERROR,
+            )
+            return
+
+        if str_to_bool(str(value)) is True:
+            self._add_failure(
+                "Cluster readiness check failures are ignored. Cluster creation and cluster update can succeed "
+                "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
                 FailureLevel.WARNING,
             )
 

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -2802,6 +2802,44 @@ def test_home_change_policy(
             True,
             id="add updatable field to empty json",
         ),
+        # cluster_readiness_check_enabled - updatable field tests
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": true}}',
+            '{"cluster": {"cluster_readiness_check_enabled": false}}',
+            True,
+            id="change cluster_readiness_check_enabled value",
+        ),
+        pytest.param(
+            None,
+            '{"cluster": {"cluster_readiness_check_enabled": true}}',
+            True,
+            id="add cluster_readiness_check_enabled when none existed",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": true}}',
+            None,
+            True,
+            id="remove cluster_readiness_check_enabled",
+        ),
+        # cluster_readiness_check_ignore_failure - updatable field tests
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": true}}',
+            '{"cluster": {"cluster_readiness_check_ignore_failure": false}}',
+            True,
+            id="change cluster_readiness_check_ignore_failure value",
+        ),
+        pytest.param(
+            None,
+            '{"cluster": {"cluster_readiness_check_ignore_failure": true}}',
+            True,
+            id="add cluster_readiness_check_ignore_failure when none existed",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": true}}',
+            None,
+            True,
+            id="remove cluster_readiness_check_ignore_failure",
+        ),
         # Change non-updatable field - should fail
         pytest.param(
             '{"cluster": {"some_other_field": "value1"}}',

--- a/cli/tests/pcluster/validators/test_dev_settings_validators.py
+++ b/cli/tests/pcluster/validators/test_dev_settings_validators.py
@@ -163,3 +163,115 @@ def test_extra_chef_attributes_validator_reconfigure_timeout(
     assert_failure_messages(actual_failures, expected_message)
     if expected_failure_level:
         assert_failure_level(actual_failures, expected_failure_level)
+
+
+@pytest.mark.parametrize(
+    "extra_chef_attributes, expected_message, expected_failure_level",
+    [
+        pytest.param(None, None, None, id="No extra chef attributes"),
+        pytest.param('{"other_attribute": "value"}', None, None, id="cluster_readiness_check_enabled not set"),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": "true"}}',
+            None,
+            None,
+            id="cluster_readiness_check_enabled 'true' string passes",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": true}}',
+            None,
+            None,
+            id="cluster_readiness_check_enabled true boolean passes",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": "false"}}',
+            "Cluster readiness check is disabled. Cluster creation and cluster update can succeed "
+            "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
+            FailureLevel.WARNING,
+            id="cluster_readiness_check_enabled 'false' string throws warning",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": false}}',
+            "Cluster readiness check is disabled. Cluster creation and cluster update can succeed "
+            "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
+            FailureLevel.WARNING,
+            id="cluster_readiness_check_enabled false boolean throws warning",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": "invalid"}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.cluster_readiness_check_enabled' must be a boolean value.",
+            FailureLevel.ERROR,
+            id="cluster_readiness_check_enabled invalid string throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_enabled": 123}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.cluster_readiness_check_enabled' must be a boolean value.",
+            FailureLevel.ERROR,
+            id="cluster_readiness_check_enabled invalid number throws error",
+        ),
+    ],
+)
+def test_extra_chef_attributes_validator_cluster_readiness_check_enabled(
+    extra_chef_attributes, expected_message, expected_failure_level
+):
+    actual_failures = ExtraChefAttributesValidator().execute(extra_chef_attributes=extra_chef_attributes)
+    assert_failure_messages(actual_failures, expected_message)
+    if expected_failure_level:
+        assert_failure_level(actual_failures, expected_failure_level)
+
+
+@pytest.mark.parametrize(
+    "extra_chef_attributes, expected_message, expected_failure_level",
+    [
+        pytest.param(None, None, None, id="No extra chef attributes"),
+        pytest.param('{"other_attribute": "value"}', None, None, id="cluster_readiness_check_ignore_failure not set"),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": "false"}}',
+            None,
+            None,
+            id="cluster_readiness_check_ignore_failure 'false' string passes",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": false}}',
+            None,
+            None,
+            id="cluster_readiness_check_ignore_failure false boolean passes",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": "true"}}',
+            "Cluster readiness check failures are ignored. Cluster creation and cluster update can succeed "
+            "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
+            FailureLevel.WARNING,
+            id="cluster_readiness_check_ignore_failure 'true' string throws warning",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": true}}',
+            "Cluster readiness check failures are ignored. Cluster creation and cluster update can succeed "
+            "even if there are cluster nodes that did not complete the deployment of the expected configuration.",
+            FailureLevel.WARNING,
+            id="cluster_readiness_check_ignore_failure true boolean throws warning",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": "invalid"}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.cluster_readiness_check_ignore_failure' must be a boolean value.",
+            FailureLevel.ERROR,
+            id="cluster_readiness_check_ignore_failure invalid string throws error",
+        ),
+        pytest.param(
+            '{"cluster": {"cluster_readiness_check_ignore_failure": 123}}',
+            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
+            "attribute 'cluster.cluster_readiness_check_ignore_failure' must be a boolean value.",
+            FailureLevel.ERROR,
+            id="cluster_readiness_check_ignore_failure invalid number throws error",
+        ),
+    ],
+)
+def test_extra_chef_attributes_validator_cluster_readiness_check_ignore_failure(
+    extra_chef_attributes, expected_message, expected_failure_level
+):
+    actual_failures = ExtraChefAttributesValidator().execute(extra_chef_attributes=extra_chef_attributes)
+    assert_failure_messages(actual_failures, expected_message)
+    if expected_failure_level:
+        assert_failure_level(actual_failures, expected_failure_level)


### PR DESCRIPTION
This PR depends on https://github.com/aws/aws-parallelcluster-cookbook/pull/3133

### Description of changes
[DevSettings] Added validation and update support for chef attributes: 
* `cluster.cluster_readiness_check_enabled`
* `cluster.cluster_readiness_check_ignore_failure`.

**Note** we will not add a changelog entry because it is a dev settings.

### Tests
* PR checks (unit tests have been adapted to cover the current chnages)
* ONGOING manual validation with cluster create/update (we will; not create an integ test for this use case)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
