### PR TITLE
Only run RCA if head node is accessible

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -567,7 +567,15 @@ class ClustersFactory:
                         # in the case where the stack has been deleted.
                         stack_id = response.get("cloudformationStackArn")
                         events = get_cfn_events(stack_name=stack_id, region=cluster.region)
-                        rca_details = retrieve_rca_details(cluster)
+
+                        # Only attempt RCA if head node exists
+                        rca_details = None
+                        try:
+                            _ = cluster.head_node_ip
+                            rca_details = retrieve_rca_details(cluster)
+                        except Exception as e:
+                            logging.warning("Skipping RCA, head node not accessible: %s", e)
+
                         raise ClusterCreationError(
                             error,
                             stack_events=events,


### PR DESCRIPTION
### Description of changes
* Only run RCA if head node is accessible
* Allows cluster creation error message to be clearly shown

### Tests
* Ran test with the following error: `Invalid cluster configuration: Cannot find official ParallelCluster AMI`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
