### PR TITLE
[Validators] Improve warning message returned by EfaPlacementGroupValidator when PG is disabled.

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -387,9 +387,9 @@ class EfaPlacementGroupValidator(Validator):
         # if multi_az is enabled suggestions about PlacementGroups will be suppressed
         if efa_enabled and placement_group_disabled and not multi_az_enabled:
             self._add_failure(
-                f"You may see better performance using a placement group for the queue '{queue_name}'. "
-                "You can ignore this warning if the compute resources in the queue use a capacity reservation "
-                "that provides its own placement group.",
+                f"Placement group is disabled for queue '{queue_name}'. "
+                "This is expected when using a capacity reservation with its own placement group. "
+                "Otherwise, enabling a placement group may improve network performance.",
                 FailureLevel.WARNING,
             )
         elif efa_enabled and placement_group_key is None and not multi_az_enabled:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -777,9 +777,9 @@ def test_efa_validator(
             False,
             CapacityType.ONDEMAND,
             "queue1",
-            "You may see better performance using a placement group for the queue 'queue1'. "
-            "You can ignore this warning if the compute resources in the queue use a capacity reservation "
-            "that provides its own placement group.",
+            "Placement group is disabled for queue 'queue1'. "
+            "This is expected when using a capacity reservation with its own placement group. "
+            "Otherwise, enabling a placement group may improve network performance.",
         ),
         (True, "test", False, False, CapacityType.ONDEMAND, "queue1", None),
         (
@@ -789,9 +789,9 @@ def test_efa_validator(
             False,
             CapacityType.ONDEMAND,
             "queue1",
-            "You may see better performance using a placement group for the queue 'queue1'. "
-            "You can ignore this warning if the compute resources in the queue use a capacity reservation "
-            "that provides its own placement group.",
+            "Placement group is disabled for queue 'queue1'. "
+            "This is expected when using a capacity reservation with its own placement group. "
+            "Otherwise, enabling a placement group may improve network performance.",
         ),
         (
             True,


### PR DESCRIPTION
### Description of changes
Improve warning message returned by EfaPlacementGroupValidator when PG is disabled.

New messsage:

```
Placement group is disabled for queue '{queue_name}'. This is expected when using a capacity reservation with its own placement group. Otherwise, enabling a placement group may improve network performance."

```

old message:

```
You may see better performance using a placement group for the queue '{queue_name}'. You can ignore this warning if the compute resources in the queue use a capacity reservation that provides its own placement group.
```

### Tests
* PR check (unit tests capture this change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
