### PR TITLE
Revert "Do not use older generation instance types when retrieving similar instance types (#7226)"

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -354,28 +354,3 @@ ULTRASERVER_CAPACITY_BLOCK_ALLOWED_SIZE_DICT = {
 }
 # Capacity Block states that are considered inactive (cannot check health status)
 CAPACITY_BLOCK_INACTIVE_STATES = ["scheduled", "payment-pending", "assessing", "delayed"]
-
-# Older generation instance types
-EXCLUDED_INSTANCE_TYPE_PREFIXES = (
-    "m1",
-    "m2",
-    "m3",
-    "m4",
-    "t1",
-    "t2",
-    "c1",
-    "c3",
-    "c4",
-    "r3",
-    "r4",
-    "x1",
-    "x1e",
-    "d2",
-    "h1",
-    "i2",
-    "i3",
-    "f1",
-    "g3",
-    "p2",
-    "p3",
-)

--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -19,6 +19,30 @@ REPOSITORY_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."
 
 UNSUPPORTED_OSES_FOR_DCV = []
 
+EXCLUDED_INSTANCE_TYPE_PREFIXES = (
+    "m1",
+    "m2",
+    "m3",
+    "m4",
+    "t1",
+    "t2",
+    "c1",
+    "c3",
+    "c4",
+    "r3",
+    "r4",
+    "x1",
+    "x1e",
+    "d2",
+    "h1",
+    "i2",
+    "i3",
+    "f1",
+    "g3",
+    "p2",
+    "p3",
+)
+
 
 class NodeType(Enum):
     """Categories of nodes."""

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -22,7 +22,6 @@ from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
 from pcluster.constants import (
-    EXCLUDED_INSTANCE_TYPE_PREFIXES,
     SUPPORTED_OSES,
     SUPPORTED_OSES_FOR_SCHEDULER,
     UNSUPPORTED_ARM_OSES_FOR_DCV,
@@ -97,6 +96,29 @@ def _get_instance_type_parameters():  # noqa: C901
         return _get_instance_type_parameters._cache
 
     result = {}
+    excluded_instance_type_prefixes = (
+        "m1",
+        "m2",
+        "m3",
+        "m4",
+        "t1",
+        "t2",
+        "c1",
+        "c3",
+        "c4",
+        "r3",
+        "r4",
+        "x1",
+        "x1e",
+        "d2",
+        "h1",
+        "i2",
+        "i3",
+        "f1",
+        "g3",
+        "p2",
+        "p3",
+    )
 
     for region in ["us-east-1", "us-west-2"]:  # Only populate instance type for big regions
         ec2_client = boto3.client("ec2", region_name=region)
@@ -115,13 +137,13 @@ def _get_instance_type_parameters():  # noqa: C901
                     instance_type_availability_zones[instance_type_name].append(offering["Location"])
                     # Check if instance type ends with '.xlarge'
                     if instance_type_name.endswith(".xlarge") and _is_current_instance_type_generation(
-                        EXCLUDED_INSTANCE_TYPE_PREFIXES, offering
+                        excluded_instance_type_prefixes, offering
                     ):
                         xlarge_instances.add(instance_type_name)
                     # Get a list of only GPU instances of any size available in the region
                     if (
                         instance_type_name.startswith("p") or instance_type_name.startswith("g")
-                    ) and _is_current_instance_type_generation(EXCLUDED_INSTANCE_TYPE_PREFIXES, offering):
+                    ) and _is_current_instance_type_generation(excluded_instance_type_prefixes, offering):
                         all_gpu_instances.add(instance_type_name)
 
             # Get GPU instance details in batches of 100
@@ -139,7 +161,7 @@ def _get_instance_type_parameters():  # noqa: C901
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
                             ) >= 4 and _is_current_instance_type_generation(
-                                EXCLUDED_INSTANCE_TYPE_PREFIXES, instance_type
+                                excluded_instance_type_prefixes, instance_type
                             ):
                                 # Find instance types with 4 or more GPUs. Number of GPUs can change test behavior.
                                 # For example, it takes longer for DCGM health check to diagnose multiple GPUs.

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -17,6 +17,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import boto3
 import yaml
+from constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
 from jinja2 import FileSystemLoader, meta
 from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
@@ -96,29 +97,6 @@ def _get_instance_type_parameters():  # noqa: C901
         return _get_instance_type_parameters._cache
 
     result = {}
-    excluded_instance_type_prefixes = (
-        "m1",
-        "m2",
-        "m3",
-        "m4",
-        "t1",
-        "t2",
-        "c1",
-        "c3",
-        "c4",
-        "r3",
-        "r4",
-        "x1",
-        "x1e",
-        "d2",
-        "h1",
-        "i2",
-        "i3",
-        "f1",
-        "g3",
-        "p2",
-        "p3",
-    )
 
     for region in ["us-east-1", "us-west-2"]:  # Only populate instance type for big regions
         ec2_client = boto3.client("ec2", region_name=region)
@@ -137,13 +115,13 @@ def _get_instance_type_parameters():  # noqa: C901
                     instance_type_availability_zones[instance_type_name].append(offering["Location"])
                     # Check if instance type ends with '.xlarge'
                     if instance_type_name.endswith(".xlarge") and _is_current_instance_type_generation(
-                        excluded_instance_type_prefixes, offering
+                        EXCLUDED_INSTANCE_TYPE_PREFIXES, offering
                     ):
                         xlarge_instances.add(instance_type_name)
                     # Get a list of only GPU instances of any size available in the region
                     if (
                         instance_type_name.startswith("p") or instance_type_name.startswith("g")
-                    ) and _is_current_instance_type_generation(excluded_instance_type_prefixes, offering):
+                    ) and _is_current_instance_type_generation(EXCLUDED_INSTANCE_TYPE_PREFIXES, offering):
                         all_gpu_instances.add(instance_type_name)
 
             # Get GPU instance details in batches of 100
@@ -161,7 +139,7 @@ def _get_instance_type_parameters():  # noqa: C901
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
                             ) >= 4 and _is_current_instance_type_generation(
-                                excluded_instance_type_prefixes, instance_type
+                                EXCLUDED_INSTANCE_TYPE_PREFIXES, instance_type
                             ):
                                 # Find instance types with 4 or more GPUs. Number of GPUs can change test behavior.
                                 # For example, it takes longer for DCGM health check to diagnose multiple GPUs.

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -29,8 +29,6 @@ from jinja2.sandbox import SandboxedEnvironment
 from retrying import retry
 from time_utils import minutes, seconds
 
-from pcluster.constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
-
 DEFAULT_PARTITION = "aws"
 PARTITION_MAP = {
     "cn": "aws-cn",
@@ -1030,13 +1028,11 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
-            instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
             instance_has_gpu = "GpuInfo" in instance
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
-                instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
-                and instance_has_efa == target_has_efa
+                instance_has_efa == target_has_efa
                 and instance_has_gpu == target_has_gpu
                 and instance_inference_accelerators == target_inference_accelerators
             ):

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -24,6 +24,7 @@ from hashlib import sha1
 import boto3
 import requests
 from assertpy import assert_that
+from constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from retrying import retry
@@ -1028,11 +1029,13 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     ):
         # Filter for EFA support, GPU presence, and inference accelerator types
         for instance in page["InstanceTypes"]:
+            instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
             instance_has_gpu = "GpuInfo" in instance
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
-                instance_has_efa == target_has_efa
+                instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
+                and instance_has_efa == target_has_efa
                 and instance_has_gpu == target_has_gpu
                 and instance_inference_accelerators == target_inference_accelerators
             ):


### PR DESCRIPTION
### Description of changes
This reverts commit f00f46cfaa489651f305f1f286ed9fdeaa4e0322.
The commit per se is correct and functional in develop branch.
However, it causes failures in the `integ-tests-3.14.2` the test code refers a constant defined in the pcluster source code. When we execute the integ tests for 3.14.2 we take the source code from pcluster 3.14.2, where the new constant is not defined.

The fixed error is:

```
    from pcluster.constants import EXCLUDED_INSTANCE_TYPE_PREFIXES
ImportError: cannot import name 'EXCLUDED_INSTANCE_TYPE_PREFIXES' from 'pcluster.constants' (/usr/local/bin/.pyenv/versions/integration-tests-23361/lib/python3.9/site-packages/pcluster/constants.py)
```

Moved the definition of the constant to test code so that we can still avoid old generatio of insteance types

### Tests
SUCCESS `test_ebs_single` on branch `integ-tests-3.14.2` (this test makes use of the function `get_similar _instance_types` involved in this PR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
