### PR TITLE
Add LaunchTemplateOverrides to cluster config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Add alarm on missing clustermgtd heartbeat.
 - Support updates of `Tags` during cluster-updates.
 - Add `LaunchSpecificationOverrides` to cluster config to allow network interfaces to be customized by overriding the launch template of a compute resource.
+  - This overrides the parallelcluster default using a shallow merge. 
 
 **BUG FIXES**
 - Add validation to block updates that change tag order. Blocking such change prevents update failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Add support for p6-b300 instances for all OSs except AL2.
 - Add alarm on missing clustermgtd heartbeat.
 - Support updates of `Tags` during cluster-updates.
+- Add `LaunchSpecificationOverrides` to cluster config to allow network interfaces to be customized by overriding the launch template of a compute resource.
 
 **BUG FIXES**
 - Add validation to block updates that change tag order. Blocking such change prevents update failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ CHANGELOG
 - Add support for p6-b300 instances for all OSs except AL2.
 - Add alarm on missing clustermgtd heartbeat.
 - Support updates of `Tags` during cluster-updates.
-- Add `LaunchSpecificationOverrides` to cluster config to allow network interfaces to be customized by overriding the launch template of a compute resource.
+- Add `LaunchTemplateOverrides` to cluster config to allow network interfaces to be customized by overriding the launch template of a compute resource.
   - This overrides the parallelcluster default using a shallow merge.
 
 **BUG FIXES**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 - Add alarm on missing clustermgtd heartbeat.
 - Support updates of `Tags` during cluster-updates.
 - Add `LaunchSpecificationOverrides` to cluster config to allow network interfaces to be customized by overriding the launch template of a compute resource.
-  - This overrides the parallelcluster default using a shallow merge. 
+  - This overrides the parallelcluster default using a shallow merge.
 
 **BUG FIXES**
 - Add validation to block updates that change tag order. Blocking such change prevents update failures.

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -683,3 +683,27 @@ class Ec2Client(Boto3Client):
                 reservation_type = reservation.reservation_type()
 
         return instance_type, reservation_type
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_launch_template_version(self, launch_template_id: str, version: str = "$Default"):
+        """
+        Describe a launch template version and return its data.
+
+        Args:
+            launch_template_id: The launch template ID (e.g., 'lt-0abc123def456')
+            version: The version number or '$Default'/'$Latest'
+
+        Returns:
+            dict: The LaunchTemplateData from the specified version
+        """
+        response = self._client.describe_launch_template_versions(
+            LaunchTemplateId=launch_template_id,
+            Versions=[str(version)],
+        )
+        versions = response.get("LaunchTemplateVersions", [])
+        if versions:
+            return versions[0].get("LaunchTemplateData", {})
+        raise AWSClientError(
+            function_name="describe_launch_template_versions",
+            message=f"Launch template {launch_template_id} version {version} not found",
+        )

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -685,7 +685,7 @@ class Ec2Client(Boto3Client):
         return instance_type, reservation_type
 
     @AWSExceptionHandler.handle_client_exception
-    def describe_launch_template_version(self, launch_template_id: str, version: str = "$Default"):
+    def describe_launch_template_version(self, launch_template_id: str, version: str):
         """
         Describe a launch template version and return its data.
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -878,6 +878,15 @@ class Efa(Resource):
         self.gdr_support = Resource.init_param(gdr_support, default=False)
 
 
+class LaunchSpecificationOverrides(Resource):
+    """Represent the Launch Specification Overrides configuration."""
+
+    def __init__(self, launch_template_id: str = None, version: int = None, **kwargs):
+        super().__init__(**kwargs)
+        self.launch_template_id = Resource.init_param(launch_template_id)
+        self.version = Resource.init_param(version)
+
+
 # ---------------------- Health Checks ---------------------- #
 
 
@@ -2230,6 +2239,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         tags: List[Tag] = None,
         static_node_priority: int = None,
         dynamic_node_priority: int = None,
+        launch_specification_overrides: LaunchSpecificationOverrides = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -2250,6 +2260,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.tags = tags
         self.static_node_priority = Resource.init_param(static_node_priority, default=1)
         self.dynamic_node_priority = Resource.init_param(dynamic_node_priority, default=1000)
+        self.launch_specification_overrides = launch_specification_overrides
 
     @abstractmethod
     def is_flexible(self) -> bool:

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -188,6 +188,7 @@ from pcluster.validators.instances_validators import (
     InstancesEFAValidator,
     InstancesMemorySchedulingWarningValidator,
     InstancesNetworkingValidator,
+    LaunchTemplateValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
 from pcluster.validators.monitoring_validators import DetailedMonitoringValidator, LogRotationValidator
@@ -2368,6 +2369,14 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
             ec2memory=min_memory,
             instance_type=smallest_type,
         )
+        if self.launch_specification_overrides:
+            self._register_validator(
+                LaunchTemplateValidator,
+                compute_resource_name=self.name,
+                launch_template_id=self.launch_specification_overrides.launch_template_id,
+                launch_template_version=self.launch_specification_overrides.version,
+                instance_types=self.instance_types,
+            )
 
     def is_flexible(self):
         """Return True because the ComputeResource can contain multiple instance types."""
@@ -2460,6 +2469,14 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
             ec2memory=self._instance_type_info.ec2memory_size_in_mib(),
             instance_type=self.instance_type,
         )
+        if self.launch_specification_overrides:
+            self._register_validator(
+                LaunchTemplateValidator,
+                compute_resource_name=self.name,
+                launch_template_id=self.launch_specification_overrides.launch_template_id,
+                launch_template_version=self.launch_specification_overrides.version,
+                instance_types=self.instance_types,
+            )
 
     @property
     def architecture(self) -> str:

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2375,7 +2375,6 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
                 compute_resource_name=self.name,
                 launch_template_id=self.launch_specification_overrides.launch_template_id,
                 launch_template_version=self.launch_specification_overrides.version,
-                instance_types=self.instance_types,
             )
 
     def is_flexible(self):
@@ -2475,7 +2474,6 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
                 compute_resource_name=self.name,
                 launch_template_id=self.launch_specification_overrides.launch_template_id,
                 launch_template_version=self.launch_specification_overrides.version,
-                instance_types=self.instance_types,
             )
 
     @property

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -879,8 +879,8 @@ class Efa(Resource):
         self.gdr_support = Resource.init_param(gdr_support, default=False)
 
 
-class LaunchSpecificationOverrides(Resource):
-    """Represent the Launch Specification Overrides configuration."""
+class LaunchTemplateOverrides(Resource):
+    """Represent the Launch Template Overrides configuration."""
 
     def __init__(self, launch_template_id: str = None, version: int = None, **kwargs):
         super().__init__(**kwargs)
@@ -2240,7 +2240,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         tags: List[Tag] = None,
         static_node_priority: int = None,
         dynamic_node_priority: int = None,
-        launch_specification_overrides: LaunchSpecificationOverrides = None,
+        launch_template_overrides: LaunchTemplateOverrides = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -2261,7 +2261,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.tags = tags
         self.static_node_priority = Resource.init_param(static_node_priority, default=1)
         self.dynamic_node_priority = Resource.init_param(dynamic_node_priority, default=1000)
-        self.launch_specification_overrides = launch_specification_overrides
+        self.launch_template_overrides = launch_template_overrides
 
     @abstractmethod
     def is_flexible(self) -> bool:
@@ -2369,12 +2369,12 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
             ec2memory=min_memory,
             instance_type=smallest_type,
         )
-        if self.launch_specification_overrides:
+        if self.launch_template_overrides:
             self._register_validator(
                 LaunchTemplateValidator,
                 compute_resource_name=self.name,
-                launch_template_id=self.launch_specification_overrides.launch_template_id,
-                launch_template_version=self.launch_specification_overrides.version,
+                launch_template_id=self.launch_template_overrides.launch_template_id,
+                launch_template_version=self.launch_template_overrides.version,
             )
 
     def is_flexible(self):
@@ -2468,12 +2468,12 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
             ec2memory=self._instance_type_info.ec2memory_size_in_mib(),
             instance_type=self.instance_type,
         )
-        if self.launch_specification_overrides:
+        if self.launch_template_overrides:
             self._register_validator(
                 LaunchTemplateValidator,
                 compute_resource_name=self.name,
-                launch_template_id=self.launch_specification_overrides.launch_template_id,
-                launch_template_version=self.launch_specification_overrides.version,
+                launch_template_id=self.launch_template_overrides.launch_template_id,
+                launch_template_version=self.launch_template_overrides.version,
             )
 
     @property

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -839,6 +839,7 @@ class LaunchSpecificationOverridesSchema(BaseSchema):
     )
     version = fields.Int(
         validate=validate.Range(min=1),
+        required=True,
         metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
     )
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -64,6 +64,7 @@ from pcluster.config.cluster_config import (
     Image,
     Imds,
     IntelSoftware,
+    LaunchSpecificationOverrides,
     LocalStorage,
     LoginNodes,
     LoginNodesIam,
@@ -829,6 +830,24 @@ class EfaSchema(BaseSchema):
         return Efa(**data)
 
 
+class LaunchSpecificationOverridesSchema(BaseSchema):
+    """Represent the schema of LaunchSpecificationOverrides for a Compute Resource."""
+
+    launch_template_id = fields.Str(
+        required=True,
+        metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
+    )
+    version = fields.Int(
+        validate=validate.Range(min=1),
+        metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
+    )
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return LaunchSpecificationOverrides(**data)
+
+
 # ---------------------- Monitoring ---------------------- #
 
 
@@ -1584,6 +1603,9 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     dynamic_node_priority = fields.Int(
         validate=validate.Range(min=MIN_SLURM_NODE_PRIORITY, max=MAX_SLURM_NODE_PRIORITY),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+    launch_specification_overrides = fields.Nested(
+        LaunchSpecificationOverridesSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
 
     @validates_schema

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -64,7 +64,7 @@ from pcluster.config.cluster_config import (
     Image,
     Imds,
     IntelSoftware,
-    LaunchSpecificationOverrides,
+    LaunchTemplateOverrides,
     LocalStorage,
     LoginNodes,
     LoginNodesIam,
@@ -830,8 +830,8 @@ class EfaSchema(BaseSchema):
         return Efa(**data)
 
 
-class LaunchSpecificationOverridesSchema(BaseSchema):
-    """Represent the schema of LaunchSpecificationOverrides for a Compute Resource."""
+class LaunchTemplateOverridesSchema(BaseSchema):
+    """Represent the schema of LaunchTemplateOverrides for a Compute Resource."""
 
     launch_template_id = fields.Str(
         required=True,
@@ -843,10 +843,16 @@ class LaunchSpecificationOverridesSchema(BaseSchema):
         metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
     )
 
+    @validates_schema
+    def validate_version_required(self, data, **kwargs):
+        """Validate that version is required when launch_template_id is specified."""
+        if data.get("launch_template_id") and not data.get("version"):
+            raise ValidationError("Version is required when LaunchTemplateId is specified.", field_name="Version")
+
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
-        return LaunchSpecificationOverrides(**data)
+        return LaunchTemplateOverrides(**data)
 
 
 # ---------------------- Monitoring ---------------------- #
@@ -1605,8 +1611,8 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
         validate=validate.Range(min=MIN_SLURM_NODE_PRIORITY, max=MAX_SLURM_NODE_PRIORITY),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
-    launch_specification_overrides = fields.Nested(
-        LaunchSpecificationOverridesSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+    launch_template_overrides = fields.Nested(
+        LaunchTemplateOverridesSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
 
     @validates_schema

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -37,6 +37,31 @@ from pcluster.templates.slurm_builder import SlurmConstruct
 from pcluster.utils import get_attr, get_http_tokens_setting
 
 
+def _apply_launch_template_overrides(launch_template, compute_resource):
+    """
+    Apply user-specified launch template overrides to the generated launch template.
+
+    For each property in the user's launch template, applies it using add_property_override.
+    This replaces the specific property while CDK handles the rest normally.
+
+    Args:
+        launch_template: The CDK CfnLaunchTemplate construct
+        compute_resource: The compute resource configuration
+    """
+    launch_spec_overrides = getattr(compute_resource, "launch_specification_overrides", None)
+    if not launch_spec_overrides or not launch_spec_overrides.launch_template_id:
+        return
+
+    version = str(launch_spec_overrides.version)
+    override_lt_data = AWSApi.instance().ec2.describe_launch_template_version(
+        launch_spec_overrides.launch_template_id, version
+    )
+
+    # Apply each property from the override launch template
+    for key, value in override_lt_data.items():
+        launch_template.add_property_override(f"LaunchTemplateData.{key}", value)
+
+
 class QueuesStack(NestedStack):
     """Stack encapsulating a set of queues and the associated resources."""
 
@@ -363,6 +388,8 @@ class QueuesStack(NestedStack):
                 **conditional_template_properties,
             ),
         )
+
+        _apply_launch_template_overrides(launch_template, compute_resource)
 
         return launch_template
 

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -48,13 +48,13 @@ def _apply_launch_template_overrides(launch_template, compute_resource):
         launch_template: The CDK CfnLaunchTemplate construct
         compute_resource: The compute resource configuration
     """
-    launch_spec_overrides = getattr(compute_resource, "launch_specification_overrides", None)
-    if not launch_spec_overrides or not launch_spec_overrides.launch_template_id:
+    launch_template_overrides = getattr(compute_resource, "launch_template_overrides", None)
+    if not launch_template_overrides or not launch_template_overrides.launch_template_id:
         return
 
-    version = str(launch_spec_overrides.version)
+    version = str(launch_template_overrides.version)
     override_lt_data = AWSApi.instance().ec2.describe_launch_template_version(
-        launch_spec_overrides.launch_template_id, version
+        launch_template_overrides.launch_template_id, version
     )
 
     # Apply each property from the override launch template

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -343,17 +343,16 @@ class LaunchTemplateValidator(Validator):
     """Validate that the specified launch template exists, is accessible, and only contains allowed properties."""
 
     # Only these properties are allowed in the launch template
-    ALLOWED_PROPERTIES = {"NetworkInterfaces", "InstanceType"}
+    ALLOWED_PROPERTIES = {"NetworkInterfaces"}
 
     def _validate(
         self,
         compute_resource_name: str,
         launch_template_id: str,
         launch_template_version: int,
-        instance_types: list,
         **kwargs,
     ):
-        """Check if the launch template exists, is valid, and only contains NetworkInterfaces and InstanceType."""
+        """Check if the launch template exists, is valid, and only contains NetworkInterfaces."""
         if not launch_template_id:
             return
 
@@ -374,16 +373,6 @@ class LaunchTemplateValidator(Validator):
             self._add_failure(
                 f"Launch template '{launch_template_id}' in Compute Resource '{compute_resource_name}' contains "
                 f"properties that are not allowed: {', '.join(sorted(disallowed_properties))}. "
-                f"Only NetworkInterfaces and InstanceType are allowed.",
-                FailureLevel.ERROR,
-            )
-
-        # Validate InstanceType matches if specified
-        lt_instance_type = lt_data.get("InstanceType")
-        if lt_instance_type and lt_instance_type not in instance_types:
-            self._add_failure(
-                f"Launch template '{launch_template_id}' in Compute Resource '{compute_resource_name}' specifies "
-                f"InstanceType '{lt_instance_type}' which does not match the compute resource instance type(s): "
-                f"{', '.join(instance_types)}.",
+                f"Only NetworkInterfaces is allowed.",
                 FailureLevel.ERROR,
             )

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -11,6 +11,8 @@
 from enum import Enum
 from typing import Callable, Dict
 
+from pcluster.aws.aws_api import AWSApi
+
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.config import cluster_config
 from pcluster.constants import MIN_MEMORY_ABSOLUTE_DIFFERENCE, MIN_MEMORY_PRECENTAGE_DIFFERENCE
@@ -335,3 +337,53 @@ class InstancesMemorySchedulingWarningValidator(Validator):
         # EC2 API should return valid values, but since it's really cheap better add a check
         available_memory = [value for value in available_memory if value is not None]
         return min(available_memory), max(available_memory)
+
+
+class LaunchTemplateValidator(Validator):
+    """Validate that the specified launch template exists, is accessible, and only contains allowed properties."""
+
+    # Only these properties are allowed in the launch template
+    ALLOWED_PROPERTIES = {"NetworkInterfaces", "InstanceType"}
+
+    def _validate(
+        self,
+        compute_resource_name: str,
+        launch_template_id: str,
+        launch_template_version: int,
+        instance_types: list,
+        **kwargs,
+    ):
+        """Check if the launch template exists, is valid, and only contains NetworkInterfaces and InstanceType."""
+        if not launch_template_id:
+            return
+
+        version = str(launch_template_version)
+        try:
+            lt_data = AWSApi.instance().ec2.describe_launch_template_version(launch_template_id, version)
+        except Exception as e:
+            self._add_failure(
+                f"Launch template '{launch_template_id}' version '{version}' specified in Compute Resource "
+                f"'{compute_resource_name}' could not be found or accessed: {e}",
+                FailureLevel.ERROR,
+            )
+            return
+
+        # Check for disallowed properties
+        disallowed_properties = set(lt_data.keys()) - self.ALLOWED_PROPERTIES
+        if disallowed_properties:
+            self._add_failure(
+                f"Launch template '{launch_template_id}' in Compute Resource '{compute_resource_name}' contains "
+                f"properties that are not allowed: {', '.join(sorted(disallowed_properties))}. "
+                f"Only NetworkInterfaces and InstanceType are allowed.",
+                FailureLevel.ERROR,
+            )
+
+        # Validate InstanceType matches if specified
+        lt_instance_type = lt_data.get("InstanceType")
+        if lt_instance_type and lt_instance_type not in instance_types:
+            self._add_failure(
+                f"Launch template '{launch_template_id}' in Compute Resource '{compute_resource_name}' specifies "
+                f"InstanceType '{lt_instance_type}' which does not match the compute resource instance type(s): "
+                f"{', '.join(instance_types)}.",
+                FailureLevel.ERROR,
+            )

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -12,7 +12,6 @@ from enum import Enum
 from typing import Callable, Dict
 
 from pcluster.aws.aws_api import AWSApi
-
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.config import cluster_config
 from pcluster.constants import MIN_MEMORY_ABSOLUTE_DIFFERENCE, MIN_MEMORY_PRECENTAGE_DIFFERENCE

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -136,6 +136,10 @@ class _DummyEc2Client(Ec2Client):
         }
         self.security_groups_cache = {}
 
+    def describe_launch_template_version(self, launch_template_id, version):
+        """Return mock launch template data."""
+        return {"NetworkInterfaces": [{"DeviceIndex": 0, "SubnetId": "subnet-123"}]}
+
     def get_official_image_id(self, os, architecture, filters=None):
         return "dummy-ami-id"
 
@@ -429,6 +433,10 @@ def mock_aws_api(mocker, mock_instance_type_info=True):
     mocker.patch(
         "pcluster.aws.ec2.Ec2Client.describe_image",
         return_value=ImageInfo({"BlockDeviceMappings": [{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 35}}]}),
+    )
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.describe_launch_template_version",
+        return_value={"NetworkInterfaces": [{"DeviceIndex": 0, "SubnetId": "subnet-123"}]},
     )
     if mock_instance_type_info:
         mocker.patch("pcluster.aws.ec2.Ec2Client.get_instance_type_info", side_effect=_DummyInstanceTypeInfo)

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -188,7 +188,7 @@ Scheduling:
           Efa:
             Enabled: true
             GdrSupport: false
-          LaunchSpecificationOverrides:
+          LaunchTemplateOverrides:
             LaunchTemplateId: lt-01234567890abcdef
             Version: 1
       Iam:

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -188,6 +188,9 @@ Scheduling:
           Efa:
             Enabled: true
             GdrSupport: false
+          LaunchSpecificationOverrides:
+            LaunchTemplateId: lt-01234567890abcdef
+            Version: 1
       Iam:
         InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
       Image:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -168,6 +168,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-00
@@ -246,6 +247,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-10
@@ -324,6 +326,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-20
@@ -402,6 +405,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-30
@@ -480,6 +484,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-40
@@ -558,6 +563,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-50
@@ -636,6 +642,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-60
@@ -714,6 +721,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-70
@@ -792,6 +800,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-80
@@ -870,6 +879,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-90
@@ -948,6 +958,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-100
@@ -1026,6 +1037,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-110
@@ -1104,6 +1116,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-120
@@ -1182,6 +1195,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-130
@@ -1260,6 +1274,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-140
@@ -1338,6 +1353,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-150
@@ -1416,6 +1432,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-160
@@ -1494,6 +1511,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-170
@@ -1572,6 +1590,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-180
@@ -1650,6 +1669,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-190
@@ -1728,6 +1748,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-200
@@ -1806,6 +1827,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-210
@@ -1884,6 +1906,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-220
@@ -1962,6 +1985,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-230
@@ -2040,6 +2064,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 10
       MinCount: 0
       Name: compute-resource-ondemand-240
@@ -2118,6 +2143,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-00
@@ -2186,6 +2212,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-10
@@ -2254,6 +2281,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-20
@@ -2322,6 +2350,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-30
@@ -2390,6 +2419,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-40
@@ -2458,6 +2488,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-50
@@ -2526,6 +2557,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-60
@@ -2594,6 +2626,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-70
@@ -2662,6 +2695,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-80
@@ -2730,6 +2764,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-90
@@ -2798,6 +2833,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-100
@@ -2866,6 +2902,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-110
@@ -2934,6 +2971,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-120
@@ -3002,6 +3040,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-130
@@ -3070,6 +3109,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-140
@@ -3138,6 +3178,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-150
@@ -3206,6 +3247,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-160
@@ -3274,6 +3316,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-170
@@ -3342,6 +3385,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-180
@@ -3410,6 +3454,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-190
@@ -3478,6 +3523,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-200
@@ -3546,6 +3592,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-210
@@ -3614,6 +3661,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-220
@@ -3682,6 +3730,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-230
@@ -3750,6 +3799,7 @@ Scheduling:
         Gpu:
           Enabled: null
       InstanceType: c5.2xlarge
+      LaunchTemplateOverrides: null
       MaxCount: 15
       MinCount: 1
       Name: compute-resource-spot-240

--- a/cli/tests/pcluster/templates/test_queues_stack.py
+++ b/cli/tests/pcluster/templates/test_queues_stack.py
@@ -390,3 +390,39 @@ def render_join(elem: dict):
         else:
             raise ValueError("Found unsupported item type while rendering Fn::Join")
     return sep.join(rendered_body)
+
+
+@pytest.mark.parametrize(
+    "override_lt_data, expected_overrides",
+    [
+        # Override NetworkInterfaces only
+        pytest.param(
+            {"NetworkInterfaces": [{"DeviceIndex": 0, "InterfaceType": "efa", "Groups": ["sg-override"]}]},
+            [("LaunchTemplateData.NetworkInterfaces", [{"DeviceIndex": 0, "InterfaceType": "efa", "Groups": ["sg-override"]}])],
+            id="Override NetworkInterfaces",
+        ),
+    ],
+)
+def test_apply_launch_template_overrides(mocker, override_lt_data, expected_overrides):
+    """Test that _apply_launch_template_overrides calls add_property_override for each property."""
+    from pcluster.templates.queues_stack import _apply_launch_template_overrides
+
+    # Mock the launch template CDK construct
+    mock_launch_template = MagicMock()
+
+    # Mock the compute resource with launch specification overrides
+    mock_compute_resource = MagicMock()
+    mock_compute_resource.launch_specification_overrides.launch_template_id = "lt-12345678901234567"
+    mock_compute_resource.launch_specification_overrides.version = 1
+
+    # Mock the EC2 API call
+    mock_aws_api = mocker.patch("pcluster.templates.queues_stack.AWSApi")
+    mock_aws_api.instance().ec2.describe_launch_template_version.return_value = override_lt_data
+
+    # Call the function
+    _apply_launch_template_overrides(mock_launch_template, mock_compute_resource)
+
+    # Verify the overrides were applied
+    assert mock_launch_template.add_property_override.call_count == len(expected_overrides)
+    for path, value in expected_overrides:
+        mock_launch_template.add_property_override.assert_any_call(path, value)

--- a/cli/tests/pcluster/templates/test_queues_stack.py
+++ b/cli/tests/pcluster/templates/test_queues_stack.py
@@ -415,10 +415,10 @@ def test_apply_launch_template_overrides(mocker, override_lt_data, expected_over
     # Mock the launch template CDK construct
     mock_launch_template = MagicMock()
 
-    # Mock the compute resource with launch specification overrides
+    # Mock the compute resource with launch template overrides
     mock_compute_resource = MagicMock()
-    mock_compute_resource.launch_specification_overrides.launch_template_id = "lt-12345678901234567"
-    mock_compute_resource.launch_specification_overrides.version = 1
+    mock_compute_resource.launch_template_overrides.launch_template_id = "lt-12345678901234567"
+    mock_compute_resource.launch_template_overrides.version = 1
 
     # Mock the EC2 API call
     mock_aws_api = mocker.patch("pcluster.templates.queues_stack.AWSApi")

--- a/cli/tests/pcluster/templates/test_queues_stack.py
+++ b/cli/tests/pcluster/templates/test_queues_stack.py
@@ -398,7 +398,12 @@ def render_join(elem: dict):
         # Override NetworkInterfaces only
         pytest.param(
             {"NetworkInterfaces": [{"DeviceIndex": 0, "InterfaceType": "efa", "Groups": ["sg-override"]}]},
-            [("LaunchTemplateData.NetworkInterfaces", [{"DeviceIndex": 0, "InterfaceType": "efa", "Groups": ["sg-override"]}])],
+            [
+                (
+                    "LaunchTemplateData.NetworkInterfaces",
+                    [{"DeviceIndex": 0, "InterfaceType": "efa", "Groups": ["sg-override"]}],
+                )
+            ],
             id="Override NetworkInterfaces",
         ),
     ],

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -70,6 +70,9 @@ Scheduling:
           CustomSlurmSettings:
             Param1: Value1
             Param2: Value2
+          LaunchSpecificationOverrides:
+            LaunchTemplateId: lt-01234567890abcdef
+            Version: 1
         - Name: compute_resource2
           InstanceType: c4.xlarge
       CustomActions:
@@ -148,6 +151,9 @@ Scheduling:
           Efa:
             Enabled: true
             GdrSupport: false
+          LaunchSpecificationOverrides:
+            LaunchTemplateId: lt-1234567890abcdef0
+            Version: 1
 SharedStorage:
   - MountDir: /my/mount/point1
     Name: name1

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -70,7 +70,7 @@ Scheduling:
           CustomSlurmSettings:
             Param1: Value1
             Param2: Value2
-          LaunchSpecificationOverrides:
+          LaunchTemplateOverrides:
             LaunchTemplateId: lt-01234567890abcdef
             Version: 1
         - Name: compute_resource2
@@ -151,7 +151,7 @@ Scheduling:
           Efa:
             Enabled: true
             GdrSupport: false
-          LaunchSpecificationOverrides:
+          LaunchTemplateOverrides:
             LaunchTemplateId: lt-1234567890abcdef0
             Version: 1
 SharedStorage:

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -871,7 +871,7 @@ def test_instances_memory_scheduling_validator(
 
 
 @pytest.mark.parametrize(
-    "compute_resource_name, launch_template_id, launch_template_version, instance_types, "
+    "compute_resource_name, launch_template_id, launch_template_version, "
     "mock_lt_data, mock_exception, expected_message",
     [
         # Launch template not found
@@ -879,7 +879,6 @@ def test_instances_memory_scheduling_validator(
             "TestComputeResource",
             "lt-12345678901234567",
             1,
-            ["c5.xlarge"],
             None,
             Exception("Launch template not found"),
             "Launch template 'lt-12345678901234567' version '1' specified in Compute Resource "
@@ -891,44 +890,20 @@ def test_instances_memory_scheduling_validator(
             "TestComputeResource",
             "lt-12345678901234567",
             1,
-            ["c5.xlarge"],
             {"NetworkInterfaces": [{"DeviceIndex": 0, "SubnetId": "subnet-123"}]},
             None,
             "",
             id="Only NetworkInterfaces - allowed",
-        ),
-        # Launch template with only allowed properties (InstanceType matching)
-        pytest.param(
-            "TestComputeResource",
-            "lt-12345678901234567",
-            1,
-            ["c5.xlarge"],
-            {"InstanceType": "c5.xlarge"},
-            None,
-            "",
-            id="InstanceType matching compute resource - allowed",
-        ),
-        # Launch template with both allowed properties
-        pytest.param(
-            "TestComputeResource",
-            "lt-12345678901234567",
-            1,
-            ["c5.xlarge", "c5.2xlarge"],
-            {"NetworkInterfaces": [{"DeviceIndex": 0}], "InstanceType": "c5.xlarge"},
-            None,
-            "",
-            id="Both NetworkInterfaces and InstanceType - allowed",
         ),
         # Launch template with disallowed property
         pytest.param(
             "TestComputeResource",
             "lt-12345678901234567",
             1,
-            ["c5.xlarge"],
             {"NetworkInterfaces": [{"DeviceIndex": 0}], "MetadataOptions": {"HttpTokens": "required"}},
             None,
             "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' contains "
-            "properties that are not allowed: MetadataOptions. Only NetworkInterfaces and InstanceType are allowed.",
+            "properties that are not allowed: MetadataOptions. Only NetworkInterfaces is allowed.",
             id="MetadataOptions not allowed",
         ),
         # Launch template with multiple disallowed properties
@@ -936,31 +911,17 @@ def test_instances_memory_scheduling_validator(
             "TestComputeResource",
             "lt-12345678901234567",
             1,
-            ["c5.xlarge"],
             {"UserData": "base64data", "ImageId": "ami-12345"},
             None,
             "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' contains "
-            "properties that are not allowed: ImageId, UserData. Only NetworkInterfaces and InstanceType are allowed.",
+            "properties that are not allowed: ImageId, UserData. Only NetworkInterfaces is allowed.",
             id="Multiple disallowed properties",
-        ),
-        # Launch template with InstanceType not matching compute resource
-        pytest.param(
-            "TestComputeResource",
-            "lt-12345678901234567",
-            1,
-            ["c5.xlarge", "c5.2xlarge"],
-            {"InstanceType": "m5.xlarge"},
-            None,
-            "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' specifies "
-            "InstanceType 'm5.xlarge' which does not match the compute resource instance type(s): c5.xlarge, c5.2xlarge.",
-            id="InstanceType not matching",
         ),
         # No launch template specified (should pass without validation)
         pytest.param(
             "TestComputeResource",
             None,
             None,
-            ["c5.xlarge"],
             None,
             None,
             "",
@@ -973,7 +934,6 @@ def test_launch_template_validator(
     compute_resource_name,
     launch_template_id,
     launch_template_version,
-    instance_types,
     mock_lt_data,
     mock_exception,
     expected_message,
@@ -991,6 +951,5 @@ def test_launch_template_validator(
         compute_resource_name=compute_resource_name,
         launch_template_id=launch_template_id,
         launch_template_version=launch_template_version,
-        instance_types=instance_types,
     )
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -868,3 +868,129 @@ def test_instances_memory_scheduling_validator(
         compute_resource_name, instance_types_info, memory_scheduling_enabled
     )
     assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "compute_resource_name, launch_template_id, launch_template_version, instance_types, "
+    "mock_lt_data, mock_exception, expected_message",
+    [
+        # Launch template not found
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge"],
+            None,
+            Exception("Launch template not found"),
+            "Launch template 'lt-12345678901234567' version '1' specified in Compute Resource "
+            "'TestComputeResource' could not be found or accessed",
+            id="Launch template not found",
+        ),
+        # Launch template with only allowed properties (NetworkInterfaces)
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge"],
+            {"NetworkInterfaces": [{"DeviceIndex": 0, "SubnetId": "subnet-123"}]},
+            None,
+            "",
+            id="Only NetworkInterfaces - allowed",
+        ),
+        # Launch template with only allowed properties (InstanceType matching)
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge"],
+            {"InstanceType": "c5.xlarge"},
+            None,
+            "",
+            id="InstanceType matching compute resource - allowed",
+        ),
+        # Launch template with both allowed properties
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge", "c5.2xlarge"],
+            {"NetworkInterfaces": [{"DeviceIndex": 0}], "InstanceType": "c5.xlarge"},
+            None,
+            "",
+            id="Both NetworkInterfaces and InstanceType - allowed",
+        ),
+        # Launch template with disallowed property
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge"],
+            {"NetworkInterfaces": [{"DeviceIndex": 0}], "MetadataOptions": {"HttpTokens": "required"}},
+            None,
+            "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' contains "
+            "properties that are not allowed: MetadataOptions. Only NetworkInterfaces and InstanceType are allowed.",
+            id="MetadataOptions not allowed",
+        ),
+        # Launch template with multiple disallowed properties
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge"],
+            {"UserData": "base64data", "ImageId": "ami-12345"},
+            None,
+            "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' contains "
+            "properties that are not allowed: ImageId, UserData. Only NetworkInterfaces and InstanceType are allowed.",
+            id="Multiple disallowed properties",
+        ),
+        # Launch template with InstanceType not matching compute resource
+        pytest.param(
+            "TestComputeResource",
+            "lt-12345678901234567",
+            1,
+            ["c5.xlarge", "c5.2xlarge"],
+            {"InstanceType": "m5.xlarge"},
+            None,
+            "Launch template 'lt-12345678901234567' in Compute Resource 'TestComputeResource' specifies "
+            "InstanceType 'm5.xlarge' which does not match the compute resource instance type(s): c5.xlarge, c5.2xlarge.",
+            id="InstanceType not matching",
+        ),
+        # No launch template specified (should pass without validation)
+        pytest.param(
+            "TestComputeResource",
+            None,
+            None,
+            ["c5.xlarge"],
+            None,
+            None,
+            "",
+            id="No launch template specified",
+        ),
+    ],
+)
+def test_launch_template_validator(
+    mocker,
+    compute_resource_name,
+    launch_template_id,
+    launch_template_version,
+    instance_types,
+    mock_lt_data,
+    mock_exception,
+    expected_message,
+):
+    from pcluster.validators.instances_validators import LaunchTemplateValidator
+
+    if launch_template_id:
+        mock_ec2 = mocker.patch("pcluster.validators.instances_validators.AWSApi")
+        if mock_exception:
+            mock_ec2.instance().ec2.describe_launch_template_version.side_effect = mock_exception
+        else:
+            mock_ec2.instance().ec2.describe_launch_template_version.return_value = mock_lt_data
+
+    actual_failures = LaunchTemplateValidator().execute(
+        compute_resource_name=compute_resource_name,
+        launch_template_id=launch_template_id,
+        launch_template_version=launch_template_version,
+        instance_types=instance_types,
+    )
+    assert_failure_messages(actual_failures, expected_message)

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -291,6 +291,13 @@ test-suites:
           instances: [ "p6e-gb200.36xlarge" ]
           oss: [ "ubuntu2204", "ubuntu2404", "rocky9", "alinux2023", "rhel9" ]
           schedulers: [ "slurm" ]
+  launch_template_overrides:
+    test_launch_template_overrides.py::test_launch_template_overrides:
+      dimensions:
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_OS_X86_0 }}]
+          instances: ["c5n.18xlarge"]
+          oss: [{{ OS_X86_0 }}]
+          schedulers: ["slurm"]
   health_checks:
     test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -294,7 +294,7 @@ test-suites:
   launch_template_overrides:
     test_launch_template_overrides.py::test_launch_template_overrides:
       dimensions:
-        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_OS_X86_0 }}]
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_NOPG_OS_X86_0 }}]
           instances: ["c5n.18xlarge"]
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -1,0 +1,232 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from utils import generate_stack_name, get_compute_nodes_instance_ids
+
+from tests.common.assertions import assert_head_node_is_running, assert_no_errors_in_logs
+
+def _create_override_launch_template(ec2_client, subnet_id, security_group_id, stack_name):
+    """
+    Create a launch template with 18 EFA network interfaces for testing LaunchSpecificationOverrides.
+
+    Args:
+        ec2_client: boto3 EC2 client
+        subnet_id: Subnet ID to use for network interfaces
+        security_group_id: Security group ID to use for network interfaces
+        stack_name: Stack name to use for naming the launch template
+
+    Returns:
+        Tuple of (launch_template_id, version)
+    """
+    # Create network interfaces configuration with 16 EFA interfaces
+    network_interfaces = [
+        {
+            "DeviceIndex": i,
+            "InterfaceType": "efa",
+            "SubnetId": subnet_id,
+            "Groups": [security_group_id],
+        }
+        for i in range(16)
+    ]
+
+    response = ec2_client.create_launch_template(
+        LaunchTemplateName=f"{stack_name}-override-lt",
+        LaunchTemplateData={
+            "NetworkInterfaces": network_interfaces,
+        },
+        TagSpecifications=[
+            {
+                "ResourceType": "launch-template",
+                "Tags": [
+                    {"Key": "Name", "Value": f"{stack_name}-override-lt"},
+                    {"Key": "parallelcluster:test", "Value": "launch-template-overrides"},
+                ],
+            }
+        ],
+    )
+
+    launch_template_id = response["LaunchTemplate"]["LaunchTemplateId"]
+    version = response["LaunchTemplate"]["LatestVersionNumber"]
+
+    logging.info(f"Created override launch template {launch_template_id} version {version}")
+    return launch_template_id, version
+
+
+def _delete_launch_template(ec2_client, launch_template_id):
+    """Delete the launch template created for testing."""
+    try:
+        ec2_client.delete_launch_template(LaunchTemplateId=launch_template_id)
+        logging.info(f"Deleted launch template {launch_template_id}")
+    except Exception as e:
+        logging.warning(f"Failed to delete launch template {launch_template_id}: {e}")
+
+
+@pytest.fixture()
+def override_launch_template(request, region, vpc_stack):
+    """Fixture to create and cleanup the override launch template."""
+    ec2_client = boto3.client("ec2", region_name=region)
+    stack_name = generate_stack_name("integ-tests-lt-override", request.config.getoption("stackname_suffix"))
+
+    # Get subnet and create a security group for the launch template
+    subnet_id = vpc_stack.get_private_subnet()
+
+    # Create a simple security group that allows all traffic (simplest config that works)
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
+    sg_response = ec2_client.create_security_group(
+        GroupName=f"{stack_name}-override-sg",
+        Description="Security group for launch template override test",
+        VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "security-group",
+                "Tags": [
+                    {"Key": "Name", "Value": f"{stack_name}-override-sg"},
+                    {"Key": "parallelcluster:test", "Value": "launch-template-overrides"},
+                ],
+            }
+        ],
+    )
+    security_group_id = sg_response["GroupId"]
+
+    # Allow all inbound traffic
+    ec2_client.authorize_security_group_ingress(
+        GroupId=security_group_id,
+        IpPermissions=[
+            {
+                "IpProtocol": "-1",
+                "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+            }
+        ],
+    )
+
+    launch_template_id, version = _create_override_launch_template(
+        ec2_client, subnet_id, security_group_id, stack_name
+    )
+
+    yield {
+        "launch_template_id": launch_template_id,
+        "version": version,
+        "security_group_id": security_group_id,
+        "subnet_id": subnet_id,
+    }
+
+    # Cleanup
+    _delete_launch_template(ec2_client, launch_template_id)
+    try:
+        ec2_client.delete_security_group(GroupId=security_group_id)
+        logging.info(f"Deleted security group {security_group_id}")
+    except Exception as e:
+        logging.warning(f"Failed to delete security group {security_group_id}: {e}")
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_launch_template_overrides(
+    region,
+    os,
+    pcluster_config_reader,
+    clusters_factory,
+    scheduler_commands_factory,
+    override_launch_template,
+    vpc_stack,
+):
+    """
+    Test that LaunchSpecificationOverrides properly applies a custom launch template to compute nodes.
+
+    This test:
+    1. Creates a launch template with 16 EFA network interfaces configured with a specific subnet and security group
+    2. Creates a cluster with c5n.18xlarge instances that references this launch template via LaunchSpecificationOverrides
+    3. Runs a job on the compute nodes
+    4. Verifies that the compute nodes have the expected network interface configuration from the override
+    """
+
+    # Create cluster config with the override launch template
+    cluster_config = pcluster_config_reader(
+        override_launch_template_id=override_launch_template["launch_template_id"],
+        override_launch_template_version=override_launch_template["version"],
+    )
+    cluster = clusters_factory(cluster_config)
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    # Submit a job to run on compute nodes
+    result = scheduler_commands.submit_command("hostname", partition="queue1")
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+
+    # Verify network interface configuration on compute nodes (similar to _test_efa_eni_configuration)
+    _test_launch_template_override_eni_configuration(cluster, region, override_launch_template)
+
+
+def _test_launch_template_override_eni_configuration(cluster, region, override_launch_template):
+    """Verify compute nodes have the expected network interface configuration from the launch template override.
+
+    With the launch template override specifying 16 EFA interfaces:
+    - Each compute node should have exactly 16 ENIs
+    - All ENIs should have InterfaceType 'efa'
+    - All ENIs should use the security group from the override launch template
+    """
+    ec2_client = boto3.client("ec2", region_name=region)
+    compute_instance_ids = get_compute_nodes_instance_ids(cluster.cfn_name, region)
+
+    assert_that(compute_instance_ids).described_as("Should have at least one compute node").is_not_empty()
+
+    expected_security_group = override_launch_template["security_group_id"]
+
+    for instance_id in compute_instance_ids:
+        instance_info = ec2_client.describe_instances(InstanceIds=[instance_id])["Reservations"][0]["Instances"][0]
+        enis = instance_info["NetworkInterfaces"]
+        logging.info(f"Instance {instance_id} has {len(enis)} ENIs")
+
+        efa_enis = []
+        for eni in enis:
+            interface_type = eni.get("InterfaceType", "interface")
+            private_ips = eni.get("PrivateIpAddresses", [])
+            attachment = eni.get("Attachment", {})
+            network_card_index = attachment.get("NetworkCardIndex", 0)
+            device_index = attachment.get("DeviceIndex", 0)
+            security_groups = [sg["GroupId"] for sg in eni.get("Groups", [])]
+
+            logging.info(
+                f"  ENI {eni['NetworkInterfaceId']}: InterfaceType={interface_type}, "
+                f"PrivateIPs={len(private_ips)}, NetworkCardIndex={network_card_index}, "
+                f"DeviceIndex={device_index}, SecurityGroups={security_groups}"
+            )
+
+            if interface_type == "efa":
+                efa_enis.append(eni)
+
+            # Verify security group from override is applied
+            assert_that(security_groups).described_as(
+                f"ENI {eni['NetworkInterfaceId']} should have the override security group"
+            ).contains(expected_security_group)
+
+        # Verify we have 16 ENIs as specified in the override launch template
+        assert_that(len(enis)).described_as(
+            f"Instance {instance_id} should have 16 ENIs from the launch template override"
+        ).is_equal_to(16)
+
+        # Verify all ENIs are EFA type
+        assert_that(len(efa_enis)).described_as(
+            f"Instance {instance_id} should have all 16 ENIs with InterfaceType 'efa'"
+        ).is_equal_to(16)
+
+        logging.info(
+            f"Instance {instance_id}: {len(efa_enis)} EFA ENI(s) with override security group {expected_security_group}"
+        )

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -33,15 +33,21 @@ def _create_override_launch_template(ec2_client, subnet_id, security_group_id, s
     Returns:
         Tuple of (launch_template_id, version)
     """
-    # Create network interfaces configuration with 16 EFA interfaces
+    # Create network interfaces configuration with 2 interfaces:
+    # - First interface (DeviceIndex 0): regular ENI (no InterfaceType specified)
+    # - Second interface (DeviceIndex 1): efa-only
     network_interfaces = [
         {
-            "DeviceIndex": i,
-            "InterfaceType": "efa",
+            "DeviceIndex": 0,
             "SubnetId": subnet_id,
             "Groups": [security_group_id],
-        }
-        for i in range(16)
+        },
+        {
+            "DeviceIndex": 1,
+            "InterfaceType": "efa-only",
+            "SubnetId": subnet_id,
+            "Groups": [security_group_id],
+        },
     ]
 
     response = ec2_client.create_launch_template(
@@ -177,9 +183,10 @@ def test_launch_template_overrides(
 def _test_launch_template_override_eni_configuration(cluster, region, override_launch_template):
     """Verify compute nodes have the expected network interface configuration from the launch template override.
 
-    With the launch template override specifying 16 EFA interfaces:
-    - Each compute node should have exactly 16 ENIs
-    - All ENIs should have InterfaceType 'efa'
+    Efa enabled is set to false, but with the launch template override, an efa-only interface will be configured.
+    With the launch template override specifying 2 interfaces:
+    - First interface (DeviceIndex 0): regular ENI
+    - Second interface (DeviceIndex 1): efa-only
     - All ENIs should use the security group from the override launch template
     """
     ec2_client = boto3.client("ec2", region_name=region)
@@ -194,7 +201,8 @@ def _test_launch_template_override_eni_configuration(cluster, region, override_l
         enis = instance_info["NetworkInterfaces"]
         logging.info(f"Instance {instance_id} has {len(enis)} ENIs")
 
-        efa_enis = []
+        efa_only_enis = []
+        regular_enis = []
         for eni in enis:
             interface_type = eni.get("InterfaceType", "interface")
             private_ips = eni.get("PrivateIpAddresses", [])
@@ -209,24 +217,26 @@ def _test_launch_template_override_eni_configuration(cluster, region, override_l
                 f"DeviceIndex={device_index}, SecurityGroups={security_groups}"
             )
 
-            if interface_type == "efa":
-                efa_enis.append(eni)
+            if interface_type == "efa-only":
+                efa_only_enis.append(eni)
+            else:
+                regular_enis.append(eni)
 
             # Verify security group from override is applied
             assert_that(security_groups).described_as(
                 f"ENI {eni['NetworkInterfaceId']} should have the override security group"
             ).contains(expected_security_group)
 
-        # Verify we have 16 ENIs as specified in the override launch template
+        # Verify we have 2 ENIs as specified in the override launch template
         assert_that(len(enis)).described_as(
-            f"Instance {instance_id} should have 16 ENIs from the launch template override"
-        ).is_equal_to(16)
+            f"Instance {instance_id} should have 2 ENIs from the launch template override"
+        ).is_equal_to(2)
 
-        # Verify all ENIs are EFA type
-        assert_that(len(efa_enis)).described_as(
-            f"Instance {instance_id} should have all 16 ENIs with InterfaceType 'efa'"
-        ).is_equal_to(16)
+        # Verify we have 1 regular ENI and 1 efa-only ENI
+        assert_that(len(regular_enis)).described_as(
+            f"Instance {instance_id} should have 1 regular ENI"
+        ).is_equal_to(1)
 
-        logging.info(
-            f"Instance {instance_id}: {len(efa_enis)} EFA ENI(s) with override security group {expected_security_group}"
-        )
+        assert_that(len(efa_only_enis)).described_as(
+            f"Instance {instance_id} should have 1 efa-only ENI"
+        ).is_equal_to(1)

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -20,7 +20,7 @@ from utils import generate_stack_name, get_compute_nodes_instance_ids
 
 def _create_override_launch_template(ec2_client, subnet_id, security_group_id, stack_name):
     """
-    Create a launch template with 18 EFA network interfaces for testing LaunchSpecificationOverrides.
+    Create a launch template with 2 network interfaces for testing LaunchSpecificationOverrides.
 
     Args:
         ec2_client: boto3 EC2 client
@@ -150,8 +150,8 @@ def test_launch_template_overrides(
     Test that LaunchSpecificationOverrides properly applies a custom launch template to compute nodes.
 
     This test:
-    1. Creates a launch template with 16 EFA network interfaces configured with a specific subnet and security group
-    2. Creates a cluster with c5n.18xlarge instances that references this launch template via LaunchSpecificationOverrides
+    1. Creates a launch template with 2 network interfaces configured with a specific subnet and security group
+    2. Creates a cluster with c5n.18xlarge instances that references this launch template
     3. Runs a job on the compute nodes
     4. Verifies that the compute nodes have the expected network interface configuration from the override
     """

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -10,7 +10,6 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
-from datetime import datetime, timedelta, timezone
 
 import boto3
 import pytest
@@ -18,7 +17,6 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 from utils import generate_stack_name, get_compute_nodes_instance_ids
 
-from tests.common.assertions import assert_head_node_is_running, assert_no_errors_in_logs
 
 def _create_override_launch_template(ec2_client, subnet_id, security_group_id, stack_name):
     """
@@ -120,9 +118,7 @@ def override_launch_template(request, region, vpc_stack):
         ],
     )
 
-    launch_template_id, version = _create_override_launch_template(
-        ec2_client, subnet_id, security_group_id, stack_name
-    )
+    launch_template_id, version = _create_override_launch_template(ec2_client, subnet_id, security_group_id, stack_name)
 
     yield {
         "launch_template_id": launch_template_id,
@@ -161,9 +157,11 @@ def test_launch_template_overrides(
     """
 
     # Create cluster config with the override launch template
+    # Also add the security group to the head node so it can accept traffic from compute nodes
     cluster_config = pcluster_config_reader(
         override_launch_template_id=override_launch_template["launch_template_id"],
         override_launch_template_version=override_launch_template["version"],
+        override_security_group_id=override_launch_template["security_group_id"],
     )
     cluster = clusters_factory(cluster_config)
 
@@ -233,10 +231,8 @@ def _test_launch_template_override_eni_configuration(cluster, region, override_l
         ).is_equal_to(2)
 
         # Verify we have 1 regular ENI and 1 efa-only ENI
-        assert_that(len(regular_enis)).described_as(
-            f"Instance {instance_id} should have 1 regular ENI"
-        ).is_equal_to(1)
+        assert_that(len(regular_enis)).described_as(f"Instance {instance_id} should have 1 regular ENI").is_equal_to(1)
 
-        assert_that(len(efa_only_enis)).described_as(
-            f"Instance {instance_id} should have 1 efa-only ENI"
-        ).is_equal_to(1)
+        assert_that(len(efa_only_enis)).described_as(f"Instance {instance_id} should have 1 efa-only ENI").is_equal_to(
+            1
+        )

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -20,7 +20,7 @@ from utils import generate_stack_name, get_compute_nodes_instance_ids
 
 def _create_override_launch_template(ec2_client, subnet_id, security_group_id, stack_name):
     """
-    Create a launch template with 2 network interfaces for testing LaunchSpecificationOverrides.
+    Create a launch template with 2 network interfaces for testing LaunchTemplateOverrides.
 
     Args:
         ec2_client: boto3 EC2 client
@@ -147,7 +147,7 @@ def test_launch_template_overrides(
     vpc_stack,
 ):
     """
-    Test that LaunchSpecificationOverrides properly applies a custom launch template to compute nodes.
+    Test that LaunchTemplateOverrides properly applies a custom launch template to compute nodes.
 
     This test:
     1. Creates a launch template with 2 network interfaces configured with a specific subnet and security group

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
@@ -26,6 +26,6 @@ Scheduling:
           MaxCount: 2
           Efa:
             Enabled: false
-          LaunchSpecificationOverrides:
+          LaunchTemplateOverrides:
             LaunchTemplateId: {{ override_launch_template_id }}
             Version: {{ override_launch_template_version }}

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
@@ -1,0 +1,29 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+        PlacementGroup:
+          Enabled: true
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: c5n.18xlarge
+          MinCount: 1
+          MaxCount: 2
+          Efa:
+            Enabled: false
+          LaunchSpecificationOverrides:
+            LaunchTemplateId: {{ override_launch_template_id }}
+            Version: {{ override_launch_template_version }}

--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides/test_launch_template_overrides/pcluster.config.yaml
@@ -4,6 +4,8 @@ HeadNode:
   InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
+    AdditionalSecurityGroups:
+      - {{ override_security_group_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:


### PR DESCRIPTION
### Description of changes
* Add LaunchSpecificationOverrides to cluster config
* Merge process: For each top-level property in the user's launch template, it calls `add_property_override` with the entire value. This means:
  * Lists (like NetworkInterfaces) - Replaced entirely
  * Dicts (like MetadataOptions) - Also replaced entirely at the top level
 * Add validator to only allow launch templates that only specify network interfaces
 * Added unit test to test merge logic and validators
 * Added integration test to validate merging logic 

### Tests
* Ran unit tests and `test_launch_template_overrides` integration test created in this pr

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
