### PR TITLE
[3.14.2] Use p4d capacity reservation dynamically

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -260,9 +260,9 @@ test-suites:
           instances: ["c5n.18xlarge"]
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
-        - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
+        - regions: [{{ p4d_24xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_OS_X86_2 }}]   # do not move, unless capacity reservation is moved as well
           instances: ["p4d.24xlarge"]
-          oss: [{{ NO_RHEL_OS_X86_1 }}]  # The capacity reservation cannot use RHEL operating system
+          oss: [{{ OS_X86_2 }}]  # The capacity reservation cannot use RHEL operating system
           schedulers: ["slurm"]
         - regions: [ "use2-az2" ]  # do not move, unless capacity reservation is moved as well
           instances: [ "p6-b200.48xlarge" ]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -128,7 +128,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
+        - regions: [{{ p4d_24xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_alinux2 }}]
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -634,7 +634,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, instance, a
         output_file_path = test_datadir / output_file if output_file else config_file_path
         default_values = _get_default_template_values(vpc_stack, request)
         inject_internal_storage_settings(kwargs)
-        inject_placement_group_settings(vpc_stack, instance, kwargs)
+        inject_placement_group_settings(vpc_stack, instance, region, kwargs)
         inject_flexible_instance_types_settings(instance, region, kwargs)
         file_loader = FileSystemLoader(str(test_datadir))
         env = SandboxedEnvironment(loader=file_loader)
@@ -654,9 +654,18 @@ def inject_internal_storage_settings(kwargs):
         kwargs["shared_headnode_storage_type"] = "Efs"
 
 
-def inject_placement_group_settings(vpc_stack, instance, kwargs):
+def inject_placement_group_settings(vpc_stack, instance, region, kwargs):
     if vpc_stack.az_override:
-        kwargs["capacity_reservation_framework_placement_group"] = f"{instance}_placement_group_{vpc_stack.az_override}"
+        placement_group_name = f"{instance}_placement_group_{vpc_stack.az_override}"
+        try:
+            ec2_client = boto3.client("ec2", region_name=region)
+            ec2_client.describe_placement_groups(GroupNames=[placement_group_name])
+            kwargs["capacity_reservation_framework_placement_group"] = placement_group_name
+        except Exception:
+            logging.info("Placement group %s not found, skipping placement group setting", placement_group_name)
+            kwargs["capacity_reservation_framework_placement_group"] = ""
+    else:
+        kwargs["capacity_reservation_framework_placement_group"] = ""
 
 
 def inject_flexible_instance_types_settings(instance, region, kwargs):

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -296,7 +296,17 @@ def _check_or_create_capacity_reservations(config_file, os_parameters, instance_
                 instance_type, instance_type_parameters, os, os_parameters
             )
             end_date = datetime.now(timezone.utc) + timedelta(hours=hours)
-            candidate_regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1"]
+            candidate_regions = [
+                "us-east-1",
+                "us-east-2",
+                "us-west-2",
+                "eu-west-1",
+                "ap-northeast-2",
+                "ap-southeast-2",
+                "ap-northeast-1",
+                "eu-west-2",
+                "eu-north-1",
+            ]
             if _find_and_modify_existing_capacity_reservation(
                 az_for_capacity_reservation, candidate_regions, count, end_date, instance_type, var, os_platform
             ):

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -112,11 +112,13 @@ def test_efa(
         az_id = vpc_stack.az_override or vpc_stack.default_az_id
         head_node_instance = _try_reserve_head_node_instance(region, az_id, architecture, os)
     max_queue_size = 2
-    p6_b200_capacity_reservation_id = None
-    if instance == "p6-b200.48xlarge":
+    capacity_reservation_id = None
+    # p family instances need capacity blocks and so placement group is set to false
+    placement_group_enabled = not instance.startswith("p")
+    if instance in ("p6-b200.48xlarge", "p6-b300.48xlarge"):
         capacity_reservations_ids = get_capacity_reservation_id(request, instance, region, max_queue_size, os)
         if capacity_reservations_ids:
-            p6_b200_capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")
+            capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")
         else:
             message = f"Skipping the test as no Capacity Block for {instance} and os {os} was found in {region}"
             logging.warn(message)
@@ -126,7 +128,8 @@ def test_efa(
     cluster_config = pcluster_config_reader(
         head_node_instance=head_node_instance,
         max_queue_size=max_queue_size,
-        p6_b200_capacity_reservation_id=p6_b200_capacity_reservation_id,
+        capacity_reservation_id=capacity_reservation_id,
+        placement_group_enabled=placement_group_enabled,
     )
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -10,7 +10,9 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+from datetime import datetime, timedelta, timezone
 
+import boto3
 import pytest
 import xmltodict
 from assertpy import assert_that, soft_assertions
@@ -28,9 +30,62 @@ from tests.common.utils import (
     wait_process_completion,
 )
 
+# Candidate head node instance types for when compute is p* or hpc* (one per family).
+HEAD_NODE_CANDIDATES_X86 = [
+    "c5.18xlarge",
+    "c6i.16xlarge",
+    "c7i.16xlarge",
+    "m5.16xlarge",
+    "m6i.16xlarge",
+    "m7i.16xlarge",
+    "r5.16xlarge",
+]
+HEAD_NODE_CANDIDATES_ARM = [
+    "c6g.16xlarge",
+    "c7g.16xlarge",
+    "m6g.16xlarge",
+    "m7g.16xlarge",
+    "r6g.16xlarge",
+]
+
 FABTESTS_BASIC_TESTS = ["rdm_tagged_bw", "rdm_tagged_pingpong"]
 
 FABTESTS_GDRCOPY_TESTS = ["runt"]
+
+
+def _try_reserve_head_node_instance(region, az_id, architecture, os):
+    """Try to create a 1-hour capacity reservation for a head node instance in the given AZ.
+
+    Iterates through candidate instance types (one per family) and returns the first one that succeeds.
+    Returns the selected instance type. Falls back to the first candidate if all reservations fail.
+    """
+    ec2_client = boto3.client("ec2", region_name=region)
+    candidates = HEAD_NODE_CANDIDATES_X86 if architecture == "x86_64" else HEAD_NODE_CANDIDATES_ARM
+    instance_platform = "Red Hat Enterprise Linux" if "rhel" in os else "Linux/UNIX"
+    end_date = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    for candidate in candidates:
+        try:
+            response = ec2_client.create_capacity_reservation(
+                InstanceType=candidate,
+                InstancePlatform=instance_platform,
+                AvailabilityZoneId=az_id,
+                InstanceCount=1,
+                EndDateType="limited",
+                EndDate=end_date,
+                Tenancy="default",
+            )
+            cr_id = response["CapacityReservation"]["CapacityReservationId"]
+            logging.info("Created head node capacity reservation %s for %s in %s", cr_id, candidate, az_id)
+            return candidate
+        except Exception as e:
+            logging.info("Capacity reservation for head node %s failed in %s: %s", candidate, az_id, e)
+
+    # All candidates failed
+    pytest.fail(
+        "Could not reserve capacity for any head node instance type candidate",
+    )
+    return None
 
 
 @pytest.mark.usefixtures("serial_execution_by_instance")
@@ -45,21 +100,17 @@ def test_efa(
     architecture,
     scheduler_commands_factory,
     request,
+    vpc_stack,
 ):
     """
     Test all EFA Features.
 
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
+    head_node_instance = instance
     if instance.startswith("p") or instance.startswith("hpc"):
-        if architecture == "x86_64":
-            head_node_instance = "c5.18xlarge"
-        else:
-            head_node_instance = "c6g.16xlarge"
-    else:
-        # Use the same instance type for both compute node and head node
-        # when the instance type is available in open capacity pool
-        head_node_instance = instance
+        az_id = vpc_stack.az_override or vpc_stack.default_az_id
+        head_node_instance = _try_reserve_head_node_instance(region, az_id, architecture, os)
     max_queue_size = 2
     p6_b200_capacity_reservation_id = None
     if instance == "p6-b200.48xlarge":

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -113,9 +113,10 @@ def test_efa(
         head_node_instance = _try_reserve_head_node_instance(region, az_id, architecture, os)
     max_queue_size = 2
     capacity_reservation_id = None
-    # p family instances need capacity blocks and so placement group is set to false
-    placement_group_enabled = not instance.startswith("p")
-    if instance in ("p6-b200.48xlarge", "p6-b300.48xlarge"):
+    # p6 family instances need capacity blocks and so placement group is set to false
+    capacity_block_instance_type = instance.startswith("p6")
+    placement_group_enabled = not capacity_block_instance_type
+    if capacity_block_instance_type:
         capacity_reservations_ids = get_capacity_reservation_id(request, instance, region, max_queue_size, os)
         if capacity_reservations_ids:
             capacity_reservation_id = capacity_reservations_ids[0].get("CapacityReservationId")

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
       Networking:
         PlacementGroup:
           Enabled: {{ placement_group_enabled }}
-          {% if placement_group_enabled %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
+          {% if placement_group_enabled and capacity_reservation_framework_placement_group %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -4,7 +4,7 @@ HeadNode:
   InstanceType: {{ head_node_instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
-    {% if instance == "p4d.24xlarge" %}ElasticIp: true{% endif %}
+    ElasticIp: true
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -21,7 +21,7 @@ Scheduling:
       Networking:
         PlacementGroup:
           Enabled: {{ placement_group_enabled }}
-          {% if instance in ["c5n.18xlarge", "c6gn.16xlarge"] %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
+          {% if placement_group_enabled %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:
@@ -32,11 +32,6 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
-            {% if instance == "p4d.24xlarge" %}GdrSupport: true{% endif %}
-{% if instance == "p4d.24xlarge" %}
-          CapacityReservationTarget:
-            CapacityReservationResourceGroupArn: arn:aws:resource-groups:us-east-1:447714826191:group/EC2CRGroup
-{% endif %}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -13,14 +13,14 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmQueues:
     - Name: efa-enabled
-      {% if p6_b200_capacity_reservation_id %}
+      {% if capacity_reservation_id %}
       CapacityType: CAPACITY_BLOCK
       CapacityReservationTarget:
-        CapacityReservationId: {{ p6_b200_capacity_reservation_id }}
+        CapacityReservationId: {{ capacity_reservation_id }}
       {% endif %}
       Networking:
         PlacementGroup:
-          Enabled: {% if instance not in ["p4d.24xlarge", "p6-b200.48xlarge"] %}true{% else %}false{% endif %}
+          Enabled: {{ placement_group_enabled }}
           {% if instance in ["c5n.18xlarge", "c6gn.16xlarge"] %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam/test_openfoam/pcluster.config.yaml
@@ -34,7 +34,9 @@ Scheduling:
           - {{ private_subnet_id }}
         PlacementGroup:
           Enabled: true
+          {% if capacity_reservation_framework_placement_group %}
           Name: {{ capacity_reservation_framework_placement_group }}
+          {% endif %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore # Required to report patching status

--- a/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_osu/test_osu/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
       Networking:
         PlacementGroup:
           Enabled: {{ placement_group_enabled }}
-          {% if placement_group_enabled %}
+          {% if placement_group_enabled and capacity_reservation_framework_placement_group %}
           Name: {{ capacity_reservation_framework_placement_group }}
           {% endif %}
         SubnetIds:

--- a/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_starccm/test_starccm/pcluster.config.yaml
@@ -40,7 +40,9 @@ Scheduling:
           - {{ private_subnet_id }}
         PlacementGroup:
           Enabled: true
+          {% if capacity_reservation_framework_placement_group %}
           Name: {{ capacity_reservation_framework_placement_group }}
+          {% endif %}
       Iam:
         AdditionalIamPolicies:
           - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
@@ -28,8 +28,10 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+        {% if capacity_reservation_framework_placement_group %}
         PlacementGroup:
           Name: {{ capacity_reservation_framework_placement_group }}
+        {% endif %}
       CustomActions:
         OnNodeConfigured:
           Script: s3://{{ bucket_name }}/neuron-installation.sh


### PR DESCRIPTION
### Description of changes
* This is a cherry pick from develop branch

### Tests
The following test has passed
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: [{{ p4d_24xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_alinux2 }}]
          instances: ["p4d.24xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
