### PR TITLE
[Test] Add EFS and FSxLustre managed storage to cluster created for M…

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -36,7 +36,16 @@ Scheduling:
         {% endif %}
 SharedStorage:
   - MountDir: /shared
-    Name: name1
+    Name: shared-ebs
     StorageType: Ebs
+  - MountDir: /shared-efs
+    Name: shared-efs
+    StorageType: Efs
+  - MountDir: /shared-fsx-lustre
+    Name: shared-fsx-lustre
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 1200
+      DeletionPolicy: Delete
 DevSettings:
   EfaInterfaceType: efa


### PR DESCRIPTION
### Description of changes
Add EFS and FSxLustre managed storage to cluster created for Multi NICS test.

 This is a minor extension of the scope of the test to verify that the multi NICs setup does not introduce issues in mounting storage.

Here we are just interested in validating the mounting of storage; we do not need to make any further check on it (Eg r/w operations).

### Tests
* SUCCEEDED `test_multi_nics`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
