### PR TITLE
[Test] Add integ test to capture fragilities in cluster update workflow

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -229,6 +229,15 @@ class Cluster:
             retry_on_result=lambda result: result["clusterStatus"] != expected_status,
         )(self.describe_cluster)()
 
+    def wait_cluster_stack_status(self, expected_statuses: list, stop_max_delay_minute: int = 15):
+        """Wait for the cluster stack to reach the desired status."""
+        retry(
+            wait_fixed=seconds(10),
+            stop_max_delay=minutes(stop_max_delay_minute),
+            retry_on_result=lambda result: result["cloudFormationStackStatus"] not in expected_statuses,
+        )(self.describe_cluster)()
+        return self.describe_cluster()["cloudFormationStackStatus"]
+
     def describe_compute_fleet(self):
         """Run pcluster describe-compute-fleet and return the result."""
         cmd_args = ["pcluster", "describe-compute-fleet", "--cluster-name", self.name]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -846,6 +846,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
+    test_update_race_conditions.py::test_update_race_conditions:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [{{ OS_X86_2 }}]
+          schedulers: ["slurm"]
   users:
     test_default_user_home.py::test_default_user_local_home:
       dimensions:

--- a/tests/integration-tests/diagnosis_utils.py
+++ b/tests/integration-tests/diagnosis_utils.py
@@ -15,7 +15,9 @@ import re
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
-from utils import find_all_matches_in_log
+from utils import find_all_matches_in_log, get_username_for_os
+
+from tests.common.utils import get_config_version_from_ddb, get_deployed_config_version
 
 RCA_LOG_FILES = [
     "/var/log/chef-client.log",
@@ -27,6 +29,11 @@ RCA_LOG_FILES = [
 PATTERN_GENERIC_FAILURE = r"error|fail|fatal|exception|critical"
 PATTERN_CHEF_ERROR = r"ERROR:"
 PATTERN_ICE_ERROR = r"InsufficientInstanceCapacity.*?sufficient\s+(\S+)\s+capacity"
+CMD_RETRIEVE_RECIPE_EXECUTION = (
+    "cat /var/log/chef-client.log"
+    " | grep 'INFO: Run List is'"
+    " | sed -E 's/^\\[([^]]+)\\].*recipe\\[([^]]+)\\].*/\\1 \\2/'"
+)
 
 
 def extract_ice_from_rca_details(rca_details):
@@ -71,3 +78,72 @@ def retrieve_rca_details(cluster, num_errors=10):
     ]
 
     return rca_details
+
+
+def get_cluster_nodes_snapshot(cluster):  # noqa: C901
+    """
+    Return an enriched snapshot of all cluster instances (head node, compute, login nodes).
+
+    Calls describe-cluster-instances for each node type and augments each instance dict with:
+    - deployed_config_version: cluster config version from dna.json on the node (via SSH).
+    - ddb_config_version: cluster config version stored in DynamoDB (compute and login nodes only).
+    - recipes: list of {"timestamp", "recipe"} dicts extracted from chef-client.log.
+    - errors: list of error messages for any of the above that failed to retrieve.
+
+    Compute nodes are reached via SSH through the head node (bastion).
+    Login nodes are reached via SSH through the head node (bastion).
+    The head node is reached directly.
+
+    :param cluster: Cluster object (from clusters_factory) with SSH access and API methods.
+    :return: dict with key "instances" containing a list of enriched instance dicts.
+    """
+    instances = []
+    for node_type in ["HeadNode", "Compute", "LoginNode"]:
+        for node in cluster.describe_cluster_instances(node_type=node_type):
+            node["deployed_config_version"] = None
+            node["ddb_config_version"] = None
+            node["recipes"] = None
+            node["errors"] = []
+
+            n_id = node["instanceId"]
+            n_ip = node["privateIpAddress"]
+
+            # Build RemoteCommandExecutor args based on node type
+            if node_type == "HeadNode":
+                rce_args = {}
+            elif node_type == "Compute":
+                rce_args = dict(compute_node_ip=n_ip)
+            else:
+                username = get_username_for_os(cluster.os)
+                rce_args = dict(login_node_ip=n_ip, bastion=f"{username}@{cluster.head_node_ip}")
+
+            # Config version from dna.json on the node
+            try:
+                node["deployed_config_version"] = get_deployed_config_version(cluster, **rce_args)
+            except Exception as e:
+                node["errors"].append(f"Failed to get deployed config version: {e}")
+
+            # Config version from DynamoDB (not applicable for head node)
+            if node_type != "HeadNode":
+                try:
+                    node["ddb_config_version"] = get_config_version_from_ddb(cluster.region, cluster.name, n_id)
+                except Exception as e:
+                    node["errors"].append(f"Failed to get DynamoDB config version: {e}")
+
+            # Executed recipes
+            try:
+                rce = RemoteCommandExecutor(cluster, **rce_args)
+                result = rce.run_remote_command(CMD_RETRIEVE_RECIPE_EXECUTION)
+                node["recipes"] = []
+                for line in result.stdout.strip().splitlines():
+                    parts = line.split(" ", 1)
+                    if len(parts) == 2:
+                        node["recipes"].append({"timestamp": parts[0], "recipe": parts[1]})
+                    else:
+                        node["recipes"].append({"timestamp": None, "recipe": line})
+            except Exception as e:
+                node["errors"].append(f"Failed to get recipes: {e}")
+
+            instances.append(node)
+
+    return {"instances": instances}

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -479,27 +479,33 @@ def wait_process_completion(remote_command_executor, pid):
         return result.stdout.strip()
 
 
-def get_deployed_config_version(cluster, compute_node_ip: str = None):
-    """Retrieves the cluster config version deployed on the cluster node from its dna.json
-    If 'compute_node_ip' is specified, the config version will be retrieved from the compute node;
-    otherwise, it will be retrieved from the head node.
+def get_deployed_config_version(cluster, compute_node_ip: str = None, login_node_ip: str = None, bastion: str = None):
+    """Retrieves the cluster config version deployed on a cluster node from its dna.json.
+
+    If 'compute_node_ip' is specified, the config version is retrieved from that compute node.
+    If 'login_node_ip' and 'bastion' are specified, it is retrieved from that login node via the bastion.
+    Otherwise, it is retrieved from the head node.
     """
-    dna_json = get_deployed_dna_json(cluster, compute_node_ip)
+    dna_json = get_deployed_dna_json(cluster, compute_node_ip, login_node_ip, bastion)
 
     return dna_json["cluster"]["cluster_config_version"]
 
 
-def get_deployed_dna_json(cluster, compute_node_ip: str = None):
-    """Retrieves the dna.json from the cluster node
-    If 'compute_node_ip' is specified, it will be retrieved from the compute node;
-    otherwise, it will be retrieved from the head node.
+def get_deployed_dna_json(cluster, compute_node_ip: str = None, login_node_ip: str = None, bastion: str = None):
+    """Retrieve the dna.json deployed on a cluster node via SSH.
+
+    By default the dna.json is retrieved from the head node.
+    If 'compute_node_ip' is specified, it will be retrieved from that compute node.
+    If 'login_node_ip' is specified, it will be retrieved from that login node.
+
+    Returns the parsed dna.json as a dict.
+
+    Raises:
+        RuntimeError: if the remote command fails (e.g. node is unreachable).
+        ValueError: if the response is not valid JSON or does not contain the expected 'cluster' key.
     """
     command = "sudo cat /etc/chef/dna.json"
-    rce = (
-        RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip)
-        if compute_node_ip
-        else RemoteCommandExecutor(cluster)
-    )
+    rce = RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip, login_node_ip=login_node_ip, bastion=bastion)
 
     try:
         result = rce.run_remote_command(command).stdout
@@ -522,6 +528,21 @@ def get_ddb_item(region_name: str, table_name: str, item_key: dict):
     """
     table = boto3.resource("dynamodb", region_name=region_name).Table(table_name)
     return table.get_item(Key=item_key).get("Item")
+
+
+def get_config_version_from_ddb(region, cluster_name, instance_id):
+    """Get the current cluster config version from DynamoDB."""
+    dynamodb = boto3.client("dynamodb", region_name=region)
+    table_name = f"parallelcluster-{cluster_name}"
+    ddb_key = f"CLUSTER_CONFIG.{instance_id}"
+
+    response = dynamodb.get_item(TableName=table_name, Key={"Id": {"S": ddb_key}})
+
+    if "Item" in response:
+        data = response["Item"].get("Data", {}).get("M", {})
+        return data.get("cluster_config_version", {}).get("S", "")
+
+    raise ValueError(f"No DynamoDB record found for instance {instance_id}")
 
 
 def get_compute_ip_to_num_files(remote_command_executor, slurm_commands):

--- a/tests/integration-tests/tests/update/test_update_race_conditions.py
+++ b/tests/integration-tests/tests/update/test_update_race_conditions.py
@@ -1,0 +1,549 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import boto3
+import pytest
+from assertpy import assert_that, soft_assertions
+from diagnosis_utils import get_cluster_nodes_snapshot
+from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+from time_utils import minutes, seconds
+from utils import match_regex_in_log
+
+from tests.common.schedulers_common import SlurmCommands
+from tests.common.utils import get_deployed_config_version
+
+logger = logging.getLogger(__name__)
+
+UPDATE_DETECTION_SERVICE = "pcluster-check-update.timer"
+UPDATE_ACTION_SCRIPT_CN = "/opt/parallelcluster/scripts/cfn-hup-update-action.sh"
+UPDATE_ACTION_SCRIPT_LN = "/opt/parallelcluster/pyenv/versions/3.14.2/envs/cfn_bootstrap_virtualenv/bin/cfn-init"
+BLOCKING_S3_KEY_PREFIX = "block_bootstrap"
+NODE_TYPE_COMPUTE = "ComputeNode"
+NODE_TYPE_LOGIN = "LoginNode"
+PHASE_ON_NODE_START = "OnNodeStart"
+PHASE_ON_NODE_CONFIGURED = "OnNodeConfigured"
+
+
+def get_node_ip(rce, node_name):
+    result = rce.run_remote_command(
+        f"scontrol show node {node_name} | grep NodeAddr | awk -F= '{{print $2}}' | awk '{{print $1}}'"
+    )
+    ip = result.stdout.strip()
+    logger.info(f"Resolved node {node_name} to IP {ip}")
+    return ip
+
+
+def get_blocking_s3_key(node_type: str, phase: str):
+    return f"{BLOCKING_S3_KEY_PREFIX}_{node_type}_{phase}"
+
+
+def get_blocking_s3_uri(bucket_name: str, node_type: str, phase: str):
+    return f"s3://{bucket_name}/{get_blocking_s3_key(node_type, phase)}"
+
+
+def block_node_boostrap(region, bucket_name, node_type: str, phase: str):
+    s3_key = get_blocking_s3_key(node_type, phase)
+    boto3.client("s3", region_name=region).put_object(Bucket=bucket_name, Key=s3_key, Body=b"")
+    logger.info(f"Created bootstrap blocking marker s3://{bucket_name}/{s3_key} for {node_type} in phase {phase}")
+
+
+def unblock_node_bootstrap(region, bucket_name, node_type: str, phase: str):
+    s3_key = get_blocking_s3_key(node_type, phase)
+    boto3.client("s3", region_name=region).delete_object(Bucket=bucket_name, Key=s3_key)
+    logger.info(f"Removed bootstrap blocking marker s3://{bucket_name}/{s3_key} for {node_type} in phase {phase}")
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(20))
+def wait_for_readiness_check_last_retry(rce, after_utc=None):
+    match, lines = match_regex_in_log(
+        rce,
+        "/var/log/chef-client.log",
+        r"Retrying execution of execute\[Check cluster readiness\], 1 attempt left",
+        after_utc=after_utc,
+    )
+    if not match:
+        raise Exception(f"Readiness check has not reached the second-last retry yet. Last lines: {lines}")
+    logger.info(f"Readiness check reached second-last iteration (1 attempt left): {lines}")
+
+
+@retry(wait_fixed=seconds(5), stop_max_delay=minutes(1))
+def get_login_nodes_nested_stack_name(cluster, region):
+    """Retrieve the physical resource ID (stack name) of the LoginNodesNestedStack from the parent stack."""
+    client = boto3.client("cloudformation", region_name=region)
+    paginator = client.get_paginator("list_stack_resources")
+    for page in paginator.paginate(StackName=cluster.name):
+        for resource in page["StackResourceSummaries"]:
+            if resource["LogicalResourceId"].startswith("LoginNodesNestedStack"):
+                return resource["PhysicalResourceId"]
+    raise Exception("LoginNodesNestedStack resource not found in parent stack")
+
+
+@retry(wait_fixed=seconds(5), stop_max_delay=minutes(10))
+def wait_for_login_nodes_lt_update_complete(cluster, region, after_utc=None):
+    expected_status = "UPDATE_COMPLETE"
+    after_dt = datetime.fromisoformat(after_utc.replace("Z", "+00:00")) if after_utc else None
+    nested_stack_name = get_login_nodes_nested_stack_name(cluster, region)
+    client = boto3.client("cloudformation", region_name=region)
+    paginator = client.get_paginator("describe_stack_events")
+    for page in paginator.paginate(StackName=nested_stack_name):
+        for event in page["StackEvents"]:
+            if (
+                event.get("LogicalResourceId", "").startswith("LoginNodeLaunchTemplate")
+                and event["ResourceType"] == "AWS::EC2::LaunchTemplate"
+                and event["ResourceStatus"] == "UPDATE_COMPLETE"
+                and (not after_dt or event["Timestamp"] >= after_dt)
+            ):
+                logger.info(f"LoginNodeLaunchTemplate reached expected status {expected_status}: {event['EventId']}")
+                return
+    raise Exception(
+        f"LoginNodeLaunchTemplate has not reached the expected status {expected_status} (after_utc={after_utc})"
+    )
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
+def wait_for_update_failure_on_node(rce, cluster, node_name: str, after_utc=None):
+    cn_ip = get_node_ip(rce, node_name)
+    cn_rce = RemoteCommandExecutor(cluster, compute_node_ip=cn_ip)
+    update_action_script_path = "/opt/parallelcluster/scripts/cfn-hup-update-action.sh"
+    match, lines = match_regex_in_log(
+        cn_rce,
+        "/var/log/parallelcluster/pcluster-check-update.log",
+        rf"Permission denied.*{update_action_script_path}|{update_action_script_path}.*Permission denied",
+        after_utc=after_utc,
+    )
+    if not match:
+        raise Exception(f"No evidence of update script failure in pcluster-check-update.log yet. Last lines: {lines}")
+    logger.info(f"Found evidence of update failure in node {node_name} due to missing execute permissions: {lines}")
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(30))
+def wait_for_stack_rollback_complete(cluster):
+    client = boto3.client("cloudformation", region_name=cluster.region)
+    stack_status = client.describe_stacks(StackName=cluster.name)["Stacks"][0]["StackStatus"]
+    logger.info(f"Current stack status: {stack_status}")
+    if stack_status != "UPDATE_ROLLBACK_COMPLETE":
+        raise Exception(f"Stack not in UPDATE_ROLLBACK_COMPLETE state: {stack_status}")
+    return stack_status
+
+
+def check_deployed_config_version(rce, cluster, node_name: str):
+    updated_config_version = get_deployed_config_version(cluster)
+    cn_ip = get_node_ip(rce, node_name)
+    cn_config_version = get_deployed_config_version(cluster, compute_node_ip=cn_ip)
+    return cn_config_version == updated_config_version
+
+
+def start_slow_dynamic_node(region, bucket_name, rce, node_name: str, phase: str):
+    block_node_boostrap(region, bucket_name, NODE_TYPE_COMPUTE, phase)
+    SlurmCommands(rce).submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "sleep 300",
+            "host": node_name,
+        }
+    )
+
+
+def launch_slow_login_node(region, bucket_name, cluster, phase):
+    block_node_boostrap(region, bucket_name, NODE_TYPE_LOGIN, phase)
+    original_login_node_ids = {n["instanceId"] for n in cluster.describe_login_nodes()}
+    login_node_to_terminate = next(iter(original_login_node_ids))
+    boto3.client("ec2", region_name=cluster.region).terminate_instances(InstanceIds=[login_node_to_terminate])
+    logger.info(
+        f"Terminated login node {login_node_to_terminate}. "
+        f"Waiting for a replacement login node that will be slowed down in {phase}"
+    )
+    new_login_node_id = wait_for_new_login_node(cluster, original_login_node_ids)
+    logger.info(f"New login node {new_login_node_id} has joined the cluster")
+    return new_login_node_id
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(10))
+def wait_for_new_login_node(cluster, original_instance_ids):
+    current_instance_ids = {n["instanceId"] for n in cluster.describe_login_nodes()}
+    new_ids = current_instance_ids - original_instance_ids
+    if not new_ids:
+        raise Exception(
+            f"No new login node found yet. " f"Original: {original_instance_ids}, current: {current_instance_ids}"
+        )
+    return next(iter(new_ids))
+
+
+def block_update_detection_on_compute_node(rce, cluster, node_name: str):
+    cn_ip = get_node_ip(rce, node_name)
+    cn_rce = RemoteCommandExecutor(cluster, compute_node_ip=cn_ip)
+    cn_rce.run_remote_command(f"sudo systemctl stop {UPDATE_DETECTION_SERVICE}")
+    logger.info(f"Stopped service {UPDATE_DETECTION_SERVICE} on node {node_name}")
+
+
+def unblock_update_detection_on_compute_node(rce, cluster, node_name: str):
+    cn_ip = get_node_ip(rce, node_name)
+    cn_rce = RemoteCommandExecutor(cluster, compute_node_ip=cn_ip)
+    cn_rce.run_remote_command(f"sudo systemctl start {UPDATE_DETECTION_SERVICE}")
+    logger.info(f"Started service {UPDATE_DETECTION_SERVICE} on node {node_name}")
+
+
+def inject_transient_update_failure_on_compute_node(rce, cluster, node_name: str):
+    cn_ip = get_node_ip(rce, node_name)
+    cn_rce = RemoteCommandExecutor(cluster, compute_node_ip=cn_ip)
+    cn_rce.run_remote_command(f"sudo chmod -x {UPDATE_ACTION_SCRIPT_CN}")
+    logger.info(
+        f"Removed execute permissions from {UPDATE_ACTION_SCRIPT_CN} on {node_name} to inject transient update failure"
+    )
+
+
+def remove_transient_update_failure_on_compute_node(rce, cluster, node_name: str):
+    cn_ip = get_node_ip(rce, node_name)
+    cn_rce = RemoteCommandExecutor(cluster, compute_node_ip=cn_ip)
+    cn_rce.run_remote_command(f"sudo chmod +x {UPDATE_ACTION_SCRIPT_CN}")
+    logger.info(f"Restored execute permissions on {UPDATE_ACTION_SCRIPT_CN} on {node_name}")
+
+
+def _node_label(node):
+    return f"Node {node['nodeType']} {node['instanceId']} ({node['privateIpAddress']})"
+
+
+def assert_config_version_dna_matches_ddb(cluster_nodes_snapshot):
+    for node in cluster_nodes_snapshot["instances"]:
+        # We do not need to check HeadNode because that is the source of truth
+        if node["nodeType"] == "HeadNode":
+            continue
+        node_label = _node_label(node)
+        if node["deployed_config_version"] is None:
+            assert_that(node["errors"]).described_as(
+                f"{node_label} deployed config version could not be retrieved"
+            ).is_empty()
+        if node["ddb_config_version"] is None:
+            assert_that(node["errors"]).described_as(
+                f"{node_label} DynamoDB config version could not be retrieved"
+            ).is_empty()
+        assert_that(node["ddb_config_version"]).described_as(
+            f"{node_label} DynamoDB config version ({node['ddb_config_version']}) "
+            f"does not match deployed config version ({node['deployed_config_version']})"
+        ).is_equal_to(node["deployed_config_version"])
+
+
+def assert_config_version_matches_head_node(snapshot, expected_failure_instance_ids=None):
+    expected_failure_instance_ids = expected_failure_instance_ids or set()
+    head_nodes = [n for n in snapshot["instances"] if n["nodeType"] == "HeadNode"]
+    assert_that(head_nodes).described_as("Head node not found in snapshot").is_not_empty()
+    head_config_version = head_nodes[0]["deployed_config_version"]
+    assert_that(head_config_version).described_as("Head node config version could not be retrieved").is_not_none()
+    for node in snapshot["instances"]:
+        # We do not need to check HeadNode because that is the source of truth
+        if node["nodeType"] == "HeadNode":
+            continue
+        prefix = _node_label(node)
+        if node["deployed_config_version"] is None:
+            assert_that(node["errors"]).described_as(
+                f"{prefix} deployed config version could not be retrieved"
+            ).is_empty()
+            continue
+        if node["instanceId"] in expected_failure_instance_ids:
+            if node["deployed_config_version"] != head_config_version:
+                logger.warning(
+                    f"{prefix} deployed config version ({node['deployed_config_version']}) "
+                    f"does not match head node ({head_config_version}) "
+                    "(expected failure due to [RaceCondition 5], not blocking the test)"
+                )
+            continue
+        assert_that(node["deployed_config_version"]).described_as(
+            f"{prefix} deployed config version ({node['deployed_config_version']}) "
+            f"does not match head node ({head_config_version})"
+        ).is_equal_to(head_config_version)
+
+
+def assert_correct_recipe_order(snapshot):
+    finalize_recipe = "aws-parallelcluster-entrypoints::finalize"
+    update_recipe = "aws-parallelcluster-entrypoints::update"
+    for node in snapshot["instances"]:
+        if node["nodeType"] == "HeadNode":
+            continue
+        prefix = _node_label(node)
+        recipes_data = node["recipes"]
+        if recipes_data is None:
+            assert_that(node["errors"]).described_as(f"{prefix} recipes could not be retrieved").is_empty()
+            continue
+        recipes = [r["recipe"] for r in recipes_data]
+        assert_that(recipes).described_as(f"{prefix} is missing the finalize recipe").contains(finalize_recipe)
+        if update_recipe in recipes:
+            last_finalize_idx = len(recipes) - 1 - recipes[::-1].index(finalize_recipe)
+            first_update_idx = recipes.index(update_recipe)
+            assert_that(first_update_idx).described_as(
+                f"{prefix} executed the update recipe (position {first_update_idx}) "
+                f"before the last finalize recipe (position {last_finalize_idx}). Recipes: {recipes_data}"
+            ).is_greater_than(last_finalize_idx)
+
+
+def assert_update_recipe_executed_on_old_nodes(snapshot, update_submitted_at, expected_failure_instance_ids=None):
+    """Assert that all nodes launched before update_submitted_at have executed the update recipe after that time.
+
+    :param snapshot: cluster nodes snapshot from get_cluster_nodes_snapshot.
+    :param update_submitted_at: UTC timestamp string in ISO format (e.g. "2026-03-16T12:34:56.000Z").
+    :param expected_failure_instance_ids: optional set of instance IDs where assertion failures are logged as
+        warnings instead of causing the test to fail.
+    """
+    expected_failure_instance_ids = expected_failure_instance_ids or set()
+    update_recipe = "aws-parallelcluster-entrypoints::update"
+    cutoff = datetime.fromisoformat(update_submitted_at.replace("Z", "+00:00"))
+    for node in snapshot["instances"]:
+        if node["nodeType"] == "HeadNode":
+            continue
+        prefix = _node_label(node)
+        launch_time_str = node.get("launchTime")
+        if launch_time_str is None:
+            continue
+        launch_time = datetime.fromisoformat(launch_time_str.replace("Z", "+00:00"))
+        if launch_time >= cutoff:
+            continue
+        recipes_data = node["recipes"]
+        if recipes_data is None:
+            assert_that(node["errors"]).described_as(f"{prefix} recipes could not be retrieved").is_empty()
+            continue
+        update_entries = [r for r in recipes_data if r["recipe"] == update_recipe and r["timestamp"] is not None]
+        update_after_cutoff = [
+            r for r in update_entries if datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00")) >= cutoff
+        ]
+        if node["instanceId"] in expected_failure_instance_ids:
+            if not update_after_cutoff:
+                logger.warning(
+                    f"{prefix} was launched at {launch_time_str} (before update at {update_submitted_at}) "
+                    f"but did not execute the update recipe after the update was submitted "
+                    f"(expected failure due to [RaceCondition 5], not blocking the test). Recipes: {recipes_data}"
+                )
+            continue
+        assert_that(update_after_cutoff).described_as(
+            f"{prefix} was launched at {launch_time_str} (before update at {update_submitted_at}) "
+            f"but did not execute the update recipe after the update was submitted. Recipes: {recipes_data}"
+        ).is_not_empty()
+
+
+# CN_1: a dynamic compute node that completes the bootstrap after the readiness check
+# CN_2: a dynamic compute node that completes the bootstrap at the second-last iteration of the readiness check
+# CN_3: a static node that fails the update due to a transient failure
+# CN_4: a static compute node that is unable to detect the update till the second-last iteration of the readiness check
+# LN_1: a login node forcefully terminated to trigger replacement
+CN_1 = "q1-dy-cr1-1"
+CN_2 = "q1-dy-cr1-2"
+CN_3 = "q1-st-cr1-1"
+CN_4 = "q1-st-cr1-2"
+
+
+@pytest.mark.usefixtures("os", "instance", "scheduler")
+def test_update_race_conditions(
+    region,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+    s3_bucket_factory,
+):
+    """
+    Test that a cluster update succeeds despite concurrent race conditions on compute and login nodes.
+
+    Race conditions under test:
+        * [RaceCondition 1] A node that completes the bootstrap after the update is not able to execute the update.
+           We know this could happen when DNA files are removed at the end of a successful update.
+        * [RaceCondition 2] A node that completes the bootstrap close to the end of the readiness check can cause
+           the readiness check to fail because it does not have enough time to complete the update.
+        * [RaceCondition 3] A node that faces a transient failure in the execution of the update does not retry
+           the update.
+        * [RaceCondition 4] A node that faces a transient failure in the detection of the update does not retry
+           the update.
+        * [RaceCondition 5] A login node that is started before the update but completes the config phase during
+           the update will skip the update. This happens because cfn-hup will see the updated
+           launch template and will think thereafter that it has deployed the updated config,
+           even if it did not.
+
+    The test creates a cluster with 2 static compute nodes, 1 login node, and capacity for dynamic
+    compute nodes. It then performs two successive updates, each designed to exercise different
+    race conditions that can occur during the update process.
+
+    Nodes under test:
+        CN_1 (q1-dy-cr1-1): dynamic node, bootstrap blocked in OnNodeConfigured before update 1.
+        CN_2 (q1-dy-cr1-2): dynamic node, bootstrap blocked in OnNodeConfigured before update 2.
+        CN_3 (q1-st-cr1-1): static node, transient failure injected in the execution of its update before update 2.
+        CN_4 (q1-st-cr1-2): static node, transient failure injected in the detection of its update before update 2.
+
+    Update 1: validates race condition #1
+        [RaceCondition 1]  CN_1 is launched with its bootstrap blocked before the update is submitted. The update
+        completes while CN_1 is still bootstrapping. CN_1 is then unblocked and given time to
+        attempt applying the update. The test verifies that CN_1 was able to pick up the new
+        config version despite having started its bootstrap before the update.
+
+    Update 2: validates race conditions #2, #3, #4 and #5
+        Before submitting the update, the following conditions are set up:
+        - [RaceCondition 2] CN_2 has its bootstrap blocked in OnNodeConfigured, so it will complete bootstrapping
+          during the readiness check window.
+        - [RaceCondition 3] CN_3 has execute permissions removed from the update action script, causing a transient
+          "Permission denied" failure. Permissions are restored after the failure is confirmed,
+          so the node can succeed on retry.
+        - [RaceCondition 4] CN_4 has its update detection service (pcluster-check-update) stopped, so it misses
+          the update notification until the service is restarted near the end of the readiness check.
+        - [RaceCondition 5] A login node is terminated and replaced by a slow-bootstrapping one (blocked in
+          OnNodeStart). After the login node Launch Template is updated in CloudFormation, the
+          slow login node is unblocked so it completes bootstrap with the already-updated LT.
+          This node is exposed to a race condition where it bootstraps with the old LT, but when cfn-hup starts
+          it detects the new LT and will think thereafter to have deplpoyed the updated LT.
+          As a result, when the login node ends the bootstrap, it will not detect the update
+          because cfn-hup thinks it already has deployed the updated config.
+
+    Verifications (soft assertions - all run even if some fail):
+        - The cluster stack reaches UPDATE_COMPLETE.
+        - Every compute and login node has the same config version as the head node.
+        - Every compute and login node executed the update recipe after the finalize recipe.
+        - The node that completed the bootstrap after the first successful update was able to deploy the update.
+    """
+    # Upload the blocking bootstrap script to S3
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    block_bootstrap_s3_key = "block_bootstrap.sh"
+    bucket.upload_file(str(test_datadir / "block_bootstrap.sh"), block_bootstrap_s3_key)
+    block_bootstrap_script_s3_uri = f"s3://{bucket_name}/{block_bootstrap_s3_key}"
+
+    # These args are equal for every cluster creation/update
+    common_cluster_config_args = dict(
+        resource_bucket=bucket_name,
+        block_bootstrap_script_s3_uri=block_bootstrap_script_s3_uri,
+        blocking_file_cn_on_node_start=get_blocking_s3_uri(bucket_name, NODE_TYPE_COMPUTE, PHASE_ON_NODE_START),
+        blocking_file_cn_on_node_configured=get_blocking_s3_uri(
+            bucket_name, NODE_TYPE_COMPUTE, PHASE_ON_NODE_CONFIGURED
+        ),
+        blocking_file_ln_on_node_start=get_blocking_s3_uri(bucket_name, NODE_TYPE_LOGIN, PHASE_ON_NODE_START),
+        blocking_file_ln_on_node_configured=get_blocking_s3_uri(bucket_name, NODE_TYPE_LOGIN, PHASE_ON_NODE_CONFIGURED),
+    )
+
+    # Create cluster
+    config_file_1 = pcluster_config_reader(
+        output_file="pcluster.config.1.yaml",
+        login_nodes_count=1,
+        **common_cluster_config_args,
+    )
+    cluster = clusters_factory(config_file_1)
+    rce = RemoteCommandExecutor(cluster)
+
+    logger.info(
+        f"Launching new dynamic compute node {CN_1}, which will terminate the bootstrap after the cluster update"
+    )
+    start_slow_dynamic_node(region, bucket_name, rce, CN_1, PHASE_ON_NODE_CONFIGURED)
+
+    logger.info("Submitting cluster update 1")
+    config_file_update_1 = pcluster_config_reader(
+        output_file="pcluster.config.update-1.yaml",
+        login_nodes_count=2,
+        **common_cluster_config_args,
+    )
+    cluster.update(config_file_update_1, wait=True, raise_on_error=True)
+
+    logger.info(f"Unblocking compute node {CN_1}, which will now complete its bootstrap")
+    unblock_node_bootstrap(region, bucket_name, NODE_TYPE_COMPUTE, PHASE_ON_NODE_CONFIGURED)
+
+    sleep_time = 300
+    logger.info(f"Sleeping {sleep_time}s to give the chance to compute node {CN_1} to apply the update")
+    time.sleep(sleep_time)
+
+    logger.info(f"Checking whether the compute node {CN_1} applied the update")
+    is_late_node_updated = check_deployed_config_version(rce, cluster, CN_1)
+    logger.info(f"The compute node {CN_1} did {'' if is_late_node_updated else 'not '}apply the update")
+
+    logger.info(
+        f"Launching new dynamic compute node {CN_2}, which will terminate the bootstrap at the end of readiness check"
+    )
+    start_slow_dynamic_node(region, bucket_name, rce, CN_2, PHASE_ON_NODE_CONFIGURED)
+
+    logger.info(f"Injecting transient failure into node {CN_3} that will cause update failure")
+    inject_transient_update_failure_on_compute_node(rce, cluster, CN_3)
+
+    logger.info(f"Injecting transient failure into node {CN_4} that will delay the detection of the update")
+    block_update_detection_on_compute_node(rce, cluster, CN_4)
+
+    logger.info("Launching a slow login node before cluster update 2")
+    login_node_id = launch_slow_login_node(region, bucket_name, cluster, PHASE_ON_NODE_START)
+    logger.info(
+        f"New slow login node launched: {login_node_id}. "
+        "This login node is exposed to race condition that we kept out of scope for PC 3.15.0."
+        "When such race condition occurs, the node is not able to detect the update, "
+        "so it ends up with the wrong cluster config version and misses the update recipe."
+    )
+
+    # TODO Add transient update failure on login node to verify the update is retried
+
+    logger.info("Submitting cluster update 2")
+    config_file_update_2 = pcluster_config_reader(
+        output_file="pcluster.config.update-2.yaml",
+        login_nodes_count=3,
+        **common_cluster_config_args,
+    )
+    update_2_submit_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    cluster.update(config_file_update_2, raise_on_error=False, wait=False)
+
+    logger.info("Waiting for login nodes launch template to be updated")
+    wait_for_login_nodes_lt_update_complete(cluster, region, after_utc=update_2_submit_time)
+    logger.info(f"Login nodes LT updated, now unblocking the slow login node {login_node_id}")
+    unblock_node_bootstrap(region, bucket_name, NODE_TYPE_LOGIN, PHASE_ON_NODE_START)
+    logger.info(f"Login node {login_node_id} unblocked")
+
+    logger.info(f"Waiting for compute node {CN_3} to fail the update due to transient failure")
+    wait_for_update_failure_on_node(rce, cluster, CN_3)
+    logger.info(f"Transient update failure detected on compute node {CN_3}")
+    remove_transient_update_failure_on_compute_node(rce, cluster, CN_3)
+    logger.info(f"Removed transient failure for compute node {CN_3}. If it retries, it will succeed the update.")
+
+    logger.info("Waiting for the readiness check to reach the second-last iteration")
+    wait_for_readiness_check_last_retry(rce, after_utc=update_2_submit_time)
+    logger.info("Second last iteration of readiness check detected")
+
+    logger.info(f"Unblocking bootstrap for compute node {CN_2}")
+    unblock_node_bootstrap(region, bucket_name, NODE_TYPE_COMPUTE, PHASE_ON_NODE_CONFIGURED)
+    logger.info(f"Bootstrap unblocked for compute node {CN_2}")
+
+    logger.info(f"Unblocking detection of update for compute node {CN_4}")
+    unblock_update_detection_on_compute_node(rce, cluster, CN_4)
+    logger.info(f"Unblocked detection of update for compute node {CN_4}")
+
+    # TODO Once we fix all the race condition, the only valid state will be UPDATE_COMPLETE
+    # We are leaving the other failed state for now so that we can use the verifications
+    # at the end of the test to facilitate troubleshooting
+    expected_stack_statuses = ["UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_ROLLBACK_FAILED"]
+    logger.info(f"Waiting for the cluster stack to reach a final state: {expected_stack_statuses}")
+    actual_cluster_stack_status = cluster.wait_cluster_stack_status(
+        expected_statuses=expected_stack_statuses,
+        stop_max_delay_minute=30,
+    )
+
+    logger.info("Verifications started")
+    logger.info(f"Cluster stack status is: {actual_cluster_stack_status}")
+    logger.info("Collecting cluster nodes snapshot")
+    cluster_snapshot = get_cluster_nodes_snapshot(cluster)
+    logger.info(f"Cluster snapshot:\n{json.dumps(cluster_snapshot, indent=2)}")
+
+    with soft_assertions():
+        expected_cluster_stack_status = "UPDATE_COMPLETE"
+        assert_that(actual_cluster_stack_status).described_as(
+            f"Cluster stack status should be {expected_cluster_stack_status}, but it is {actual_cluster_stack_status}"
+        ).is_equal_to(expected_cluster_stack_status)
+        assert_that(is_late_node_updated).described_as(
+            f"Compute node {CN_1} completed the bootstrap after update 1 and did not apply the expected update"
+        ).is_true()
+        assert_config_version_dna_matches_ddb(cluster_snapshot)
+        # IMPORTANT NOTE: In ParallelCluster 3.15.0 we are not fixing [RaceCondition 5],
+        # so the following two assertions are expected to fail for the slow login node started before update 2.
+        assert_config_version_matches_head_node(cluster_snapshot, expected_failure_instance_ids={login_node_id})
+        assert_update_recipe_executed_on_old_nodes(
+            cluster_snapshot, update_2_submit_time, expected_failure_instance_ids={login_node_id}
+        )
+        assert_correct_recipe_order(cluster_snapshot)
+    logger.info("Verifications completed")

--- a/tests/integration-tests/tests/update/test_update_race_conditions/test_update_race_conditions/block_bootstrap.sh
+++ b/tests/integration-tests/tests/update/test_update_race_conditions/test_update_race_conditions/block_bootstrap.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script blocks the bootstrap of the current node if a blocking marker object exists in S3.
+# Usage: block_bootstrap.sh s3://bucket-name/blocking-key
+
+S3_URI="${1}"
+
+echo "block_bootstrap.sh: Checking for blocking marker at ${S3_URI}"
+
+# Parse bucket and key from s3://bucket/key URI
+BUCKET=$(echo "${S3_URI}" | sed 's|s3://||' | cut -d'/' -f1)
+KEY=$(echo "${S3_URI}" | sed 's|s3://[^/]*/||')
+
+while aws s3api head-object --bucket "${BUCKET}" --key "${KEY}" > /dev/null 2>&1; do
+    echo "block_bootstrap.sh: Blocking marker exists at ${S3_URI}, waiting..."
+    sleep 5
+done
+
+echo "block_bootstrap.sh: Blocking marker removed from ${S3_URI}, proceeding with bootstrap"

--- a/tests/integration-tests/tests/update/test_update_race_conditions/test_update_race_conditions/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update_race_conditions/test_update_race_conditions/pcluster.config.yaml
@@ -1,0 +1,56 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: login1
+      InstanceType: {{ instance }}
+      Count: {{ login_nodes_count }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:{{ partition}}:iam::aws:policy/AmazonS3ReadOnlyAccess
+      CustomActions:
+        OnNodeStart:
+          Script: {{ block_bootstrap_script_s3_uri }}
+          Args:
+            - "{{ blocking_file_ln_on_node_start }}"
+        OnNodeConfigured:
+          Script: {{ block_bootstrap_script_s3_uri }}
+          Args:
+            - "{{ blocking_file_ln_on_node_configured }}"
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ resource_bucket }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: q1
+      ComputeResources:
+        - Name: cr1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 2
+          MaxCount: 5
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        S3Access:
+          - BucketName: {{ resource_bucket }}
+      CustomActions:
+        OnNodeStart:
+          Script: {{ block_bootstrap_script_s3_uri }}
+          Args:
+            - "{{ blocking_file_cn_on_node_start }}"
+        OnNodeConfigured:
+          Script: {{ block_bootstrap_script_s3_uri }}
+          Args:
+            - "{{ blocking_file_cn_on_node_configured }}"

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1130,22 +1130,34 @@ def get_file_mtime_age_seconds(remote_command_executor, file_path):
     return current_time - mtime
 
 
-def match_regex_in_log(rce, log_file: str, pattern: str, nlines: int = 50) -> tuple[bool, str]:
+def match_regex_in_log(
+    rce,
+    log_file: str,
+    pattern: str,
+    nlines: int = 50,
+    after_utc: str = None,
+) -> tuple[bool, str]:
     """
-    Search for a regex pattern in a remote log file.
+    Search for a regex pattern in a remote log file, optionally filtering to lines after a UTC timestamp.
 
     Args:
         rce: Remote command executor instance to run commands on the target host.
         log_file: Absolute path to the log file on the remote host.
         pattern: Regular expression pattern to search for in the log content.
         nlines: Number of lines from the end of the log to return if pattern is not found. Defaults to 50.
+        after_utc: Optional UTC timestamp string in ISO format (e.g. "2026-03-10T15:00:00.000Z"). Only lines at or after
+           this timestamp are considered. If None, searches the entire log.
 
     Returns:
         A tuple containing:
             - bool: True if the pattern was found, False otherwise.
             - str: The matched string if found, or the last `nlines` lines of the log if not found.
     """
-    result = rce.run_remote_command(f"cat {log_file}")
+    if after_utc:
+        cmd = f"awk '$0 >= \"{after_utc}\"' {log_file} 2>/dev/null || echo ''"
+        result = rce.run_remote_command(cmd, raise_on_error=False)
+    else:
+        result = rce.run_remote_command(f"cat {log_file}")
     log_content = result.stdout
 
     match = re.search(pattern, log_content)


### PR DESCRIPTION
### Description of changes
Cluster updates can encounter various race conditions, especially when compute and login nodes scale up and down during the update window. 

With this PR we add a new integ test to validate that the cluster is not exposed to the following race conditions:
1. **[Race Condition 1]** A node that completes the bootstrap after the update is not able to execute the update. We know this could happen when DNA files are removed at the end of a successful update.
2. **[Race Condition 2]** A node that completes the bootstrap close to the end of the readiness check can cause the readiness check to fail because it does not have enough time to complete the update.
3. **[Race Condition 3]** A node that faces a transient failure in the execution of the update does not retry the update.
4. **[Race Condition 4]** A node that faces a transient failure in the detection of the update does not retry the update.
5. **[Race Condition 5]** A login node that is started before the update but completes the config phase during the update will skip the update. This happens because cfn-hup will see the updated launch template and will think thereafter that it has deployed the updated config, even if it did not.

**Important Note**
Race conditions from 1 to 4 have been fixed in 3.15.0. Race condition 5 is not, so it would be a known issue causing the test failure. Instead of failing the test, we preferred to log the failure and let the test succeed. In this way we know that, if the test fails, it fails for unexpected reasons.

Additional improvements to common functionalities:
1. added the concept of cluster snapshot, which is a snapshot of `describe-cluster-instances` + some important diagnostic information for each cluster node, such as:
    * config version deployed on the node, according to its local dna
    * config version deployed on the node, according to DDB
    * timestamped order of execution of chef recipes
1. Add utility to wait for a set of acceptable stack statuses
3. Allow to search for patterns in logs with a timestamp constraint
4. Allow to retrieve dna.json from on login nodes
7. Allow to retrieve cluster config deployed on login nodes

### Tests
SUCCESS `test_update_race_conditions`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
