### PR TITLE
Consolidate Image Managed Policies

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -83,10 +83,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref ParallelClusterClusterPolicy
         - !Ref ParallelClusterClusterPolicyBatch
-        - !Ref ParallelClusterBuildImageManagedPolicy
-        - !Ref ParallelClusterDeleteImageManagedPolicy
-        - !Ref ParallelClusterListImagesManagedPolicy
-        - !Ref ParallelClusterDescribeImageManagedPolicy
+        - !Ref ParallelClusterImagePolicy
         - !Ref ParallelClusterLogRetrievalPolicy
         - !Ref ParallelClusterLoginNodesStack
       MaxSessionDuration: 20000
@@ -520,13 +517,13 @@ Resources:
             Effect: Allow
             Sid: DirectoryServicePasswordReadFromSsm
 
-  ### IMAGE ACTIONS POLICIES
+  ### IMAGE ACTIONS POLICIES (merged build, delete, list, describe)
 
-  ParallelClusterBuildImageManagedPolicy:
+  ParallelClusterImagePolicy:
     Type: AWS::IAM::ManagedPolicy
     Condition: CreateIamResources
     Properties:
-      Description: Managed policy to execute pcluster build-image command without IAM permission
+      Description: Managed policy for pcluster image commands (build, delete, list, describe)
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -537,12 +534,15 @@ Resources:
               - ec2:DescribeInstanceTypeOfferings
               - ec2:DescribeInstanceTypes
               - ec2:DescribeSecurityGroups
+              - ec2:DeregisterImage
+              - ec2:DeleteSnapshot
             Resource: '*'
           - Sid: IAM
             Effect: Allow
             Action:
               - iam:CreateInstanceProfile
               - iam:AddRoleToInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
               - iam:GetRole
               - iam:GetRolePolicy
               - iam:GetInstanceProfile
@@ -563,19 +563,12 @@ Resources:
                   - lambda.amazonaws.com
                   - ec2.amazonaws.com
                   - ec2.amazonaws.com.cn
-          - Sid: CloudWatch
-            Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:TagResource
-              - logs:UntagResource
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
           - Sid: CloudFormation
             Effect: Allow
             Action:
               - cloudformation:DescribeStacks
               - cloudformation:CreateStack
+              - cloudformation:DeleteStack
             Resource:
               - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
           - Sid: Lambda
@@ -585,6 +578,8 @@ Resources:
               - lambda:TagResource
               - lambda:GetFunction
               - lambda:AddPermission
+              - lambda:RemovePermission
+              - lambda:DeleteFunction
             Resource:
               - !Sub 'arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
           - Sid: ImageBuilderGet
@@ -601,73 +596,7 @@ Resources:
               - imagebuilder:CreateComponent
               - imagebuilder:CreateDistributionConfiguration
               - imagebuilder:CreateInfrastructureConfiguration
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image/parallelclusterimage-*'
-              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
-              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:component/parallelclusterimage-*'
-              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
-              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
-          - Sid: S3Bucket
-            Effect: Allow
-            Action:
-              - s3:CreateBucket
-              - s3:ListBucket
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
-          - Sid: SNS
-            Effect: Allow
-            Action:
-              - sns:GetTopicAttributes
-              - sns:TagResource
-              - sns:CreateTopic
-              - sns:Subscribe
-              - sns:Publish
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:ParallelClusterImage-*'
-          - Sid: S3Objects
-            Effect: Allow
-            Action:
-              - s3:PutObject
-              - s3:GetObject
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
-          - Action:
-              - iam:CreateServiceLinkedRole
-            Resource:
-              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder
-            Effect: Allow
-            Condition:
-              StringLike:
-                iam:AWSServiceName:
-                  - imagebuilder.amazonaws.com
-
-  ParallelClusterDeleteImageManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Condition: CreateIamResources
-    Properties:
-      Description: Managed policy to execute pcluster delete-image command without IAM permission
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: EC2
-            Effect: Allow
-            Action:
-              - ec2:DeregisterImage
-              - ec2:DescribeImages
-              - ec2:DeleteSnapshot
-            Resource: '*'
-          - Sid: IAM
-            Effect: Allow
-            Action:
-              - iam:RemoveRoleFromInstanceProfile
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/${CustomIamPathPrefix}/*'
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CustomIamPathPrefix}/*'
-          - Sid: ImageBuilder
-            Effect: Allow
-            Action:
               - imagebuilder:DeleteImage
-              - imagebuilder:GetImage
               - imagebuilder:CancelImageCreation
               - imagebuilder:DeleteComponent
               - imagebuilder:DeleteImageRecipe
@@ -679,32 +608,22 @@ Resources:
               - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:component/parallelclusterimage-*'
               - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
               - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
-          - Sid: CloudFormation
-            Effect: Allow
-            Action:
-              - cloudformation:DescribeStacks
-              - cloudformation:DeleteStack
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
-          - Sid: Lambda
-            Effect: Allow
-            Action:
-              - lambda:RemovePermission
-              - lambda:DeleteFunction
-              - lambda:AddPermission
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
           - Sid: SNS
             Effect: Allow
             Action:
-              - SNS:DeleteTopic
-              - SNS:Unsubscribe
-              - SNS:GetTopicAttributes
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:Publish
+              - sns:DeleteTopic
+              - sns:Unsubscribe
             Resource:
               - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:ParallelClusterImage-*'
           - Sid: S3Bucket
             Effect: Allow
             Action:
+              - s3:CreateBucket
               - s3:ListBucket
               - s3:ListBucketVersions
             Resource:
@@ -722,50 +641,23 @@ Resources:
           - Sid: CloudWatch
             Effect: Allow
             Action:
+              - logs:CreateLogGroup
               - logs:DeleteLogGroup
+              - logs:TagResource
+              - logs:UntagResource
             Resource:
               - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/imagebuilder/ParallelClusterImage-*'
               - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
-
-  ParallelClusterListImagesManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Condition: CreateIamResources
-    Properties:
-      Description: Managed policy to execute pcluster list-images command
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: EC2
-            Effect: Allow
+          - Sid: ImageBuilderServiceLinkedRole
             Action:
-              - ec2:DescribeImages
-            Resource: '*'
-          - Sid: CloudFormation
-            Effect: Allow
-            Action:
-              - cloudformation:DescribeStacks
+              - iam:CreateServiceLinkedRole
             Resource:
-              - '*'
-
-  ParallelClusterDescribeImageManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Condition: CreateIamResources
-    Properties:
-      Description: Managed policy to execute pcluster describe-image command
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: EC2
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder
             Effect: Allow
-            Action:
-              - ec2:DescribeImages
-            Resource: '*'
-          - Sid: CloudFormation
-            Effect: Allow
-            Action:
-              - cloudformation:DescribeStacks
-            Resource:
-              - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - imagebuilder.amazonaws.com
 
   ### LOG COMMANDS
 


### PR DESCRIPTION
### Description of changes
* Consolidate Image Managed Policies
* Merged 4 separate IAM managed policies into a single ParallelClusterImagePolicy:
  - ParallelClusterBuildImageManagedPolicy
  - ParallelClusterDeleteImageManagedPolicy
  - ParallelClusterListImagesManagedPolicy
  - ParallelClusterDescribeImageManagedPolicy

Replaced with: ParallelClusterImagePolicy — one policy covering all image commands (build, delete, list, describe).

What was deduplicated in the merge:
- ec2:DescribeImages — appeared in all 4 policies
- cloudformation:DescribeStacks — appeared in all 4
- imagebuilder:Get* — was in both Build and Delete (as GetImage)
- sns:GetTopicAttributes — was in both Build and Delete
- s3:ListBucket — was in both Build and Delete
- ImageBuilder resource ARNs — identical between Build and Delete, now listed once
- SNS, Lambda, S3, CloudWatch resources — all consolidated

Actions combined from separate policies:
- EC2: build's describe actions + delete's DeregisterImage/DeleteSnapshot
- IAM: build's CreateInstanceProfile/AddRoleToInstanceProfile + delete's RemoveRoleFromInstanceProfile
- CloudFormation: CreateStack + DeleteStack + DescribeStacks
- Lambda: CreateFunction/TagResource/GetFunction/AddPermission + RemovePermission/DeleteFunction
- SNS: create/subscribe/publish + delete/unsubscribe
- S3: CreateBucket/PutObject/GetObject + versioning and delete actions
- CloudWatch: CreateLogGroup/TagResource/UntagResource + DeleteLogGroup (also added the imagebuilder log group ARN pattern)
- ImageBuilder: all create actions + all delete actions + CancelImageCreation

Role update: ParallelClusterUserRole.ManagedPolicyArns now references !Ref ParallelClusterImagePolicy instead of the 4 individual refs.


### Tests
* Ran the following integ tests:
  * `test_iam.py::test_iam_resource_prefix`
  * `test_iam.py::test_iam_policies`
  * `test_iam.py::test_iam_roles`
  * `test_iam_image.py::test_iam_roles`
  * `test_iam.py::test_s3_read_write_resource`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
