### PR TITLE
[Test] Import matplotlib with lazy loading to prevent burst of harmless warnings

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -18,7 +18,6 @@ from collections import defaultdict
 from typing import List
 
 import boto3
-import matplotlib.pyplot as plt
 import pandas as pd
 import untangle
 from framework.metrics_publisher import Metric, MetricsPublisher
@@ -606,6 +605,8 @@ def _get_statistics_by_category(  # noqa C901
 
 
 def plot_statistics(result, name_prefix):
+    import matplotlib.pyplot as plt
+
     plt.figure(figsize=(40, 12))
 
     # Collect and sort all unique time points


### PR DESCRIPTION
### Description of changes
Import matplotlib with lazy loading to prevent burst of warning messages about `classic.mplstyle`.
Matplotlib is imported by a test we do not even execute in our daily run.
This is to prevent burst of harmless warnings like:

```
WARNING - 49104 - core - In /usr/local/bin/.pyenv/versions/integration-tests-44056/lib/python3.9/site-packages/matplotlib/mpl-data/stylelib/classic.mplstyle: 'resetCache' deprecated - use 'reset_cache'
```



### Tests
Verified that with this change the burst of warning is not there anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
