### PR TITLE
[integ-tests][OSU] Use rolling window for benchmark failure detection

### DIFF
--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -160,8 +160,6 @@ def _test_osu_benchmarks_pt2pt(
     # OSU pt2pt benchmarks cannot be executed with more than 2 MPI ranks.
     # Run them in 2 instances with 1 proc per instance, defined by map-by parameter.
     num_instances = 2
-    # Accept a max number of 4 failures on a total of 23-24 packet size tests.
-    accepted_number_of_failures = 4
 
     failed_benchmarks = []
     benchmark_group = "pt2pt"
@@ -178,10 +176,10 @@ def _test_osu_benchmarks_pt2pt(
             network_interfaces_count,
             test_datadir,
         )
-        failures = _check_osu_benchmarks_results(
+        failure_mask = _check_osu_benchmarks_results(
             test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output
         )
-        if failures > accepted_number_of_failures:
+        if _has_failure_cluster(failure_mask):
             failed_benchmarks.append(f"{mpi_version}-{benchmark_name}")
 
     return failed_benchmarks
@@ -200,9 +198,6 @@ def _test_osu_benchmarks_collective(
     slots_per_instance,
     partition=None,
 ):
-    # Accept a max number of 3 failures on a total of 19-21 packet size tests.
-    accepted_number_of_failures = 3
-
     failed_benchmarks = []
     benchmark_group = "collective"
     benchmark_names = ["osu_allgather", "osu_bcast", "osu_allreduce", "osu_barrier"]
@@ -224,10 +219,10 @@ def _test_osu_benchmarks_collective(
             test_datadir,
             timeout=24 + num_instances * 0.1,
         )
-        failures = _check_osu_benchmarks_results(
+        failure_mask = _check_osu_benchmarks_results(
             test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output
         )
-        if failures > accepted_number_of_failures:
+        if _has_failure_cluster(failure_mask):
             failed_benchmarks.append(f"{mpi_version}-{benchmark_name}")
 
     return failed_benchmarks
@@ -314,7 +309,7 @@ def _check_osu_benchmarks_results(
         content=output,
     )
     # Check avg latency for all packet sizes
-    failures = 0
+    failure_mask = []
     evaluation_output = ""
     if benchmark_name == "osu_barrier":
         # osu_barrier outputs only a single latency value without packet size
@@ -355,8 +350,9 @@ def _check_osu_benchmarks_results(
 
                 evaluation_output += f"\n{message}"
 
+                failure_mask.append(is_failure)
+
                 if is_failure:
-                    failures = failures + 1
                     logging.error(message)
                 else:
                     logging.info(message)
@@ -366,4 +362,25 @@ def _check_osu_benchmarks_results(
             content=evaluation_output,
         )
 
-    return failures
+    return failure_mask
+
+
+def _has_failure_cluster(failure_mask, window_size=4, min_failures=3):
+    """
+    Detect clustered failures using a rolling window.
+
+    Instead of counting total failures across all packet sizes, look for clusters
+    of failures in consecutive packet sizes. This catches real regressions in a
+    specific packet-size range while ignoring scattered noise.
+
+    A benchmark is considered failed if any window of `window_size` consecutive
+    packet sizes contains at least `min_failures` failures.
+    """
+    if not failure_mask:
+        return False
+    if len(failure_mask) < window_size:
+        return sum(failure_mask) >= min(min_failures, len(failure_mask))
+    for i in range(len(failure_mask) - window_size + 1):
+        if sum(failure_mask[i : i + window_size]) >= min_failures:  # noqa: E203
+            return True
+    return False


### PR DESCRIPTION
### Description of changes
Replace the fixed threshold count (3 for collective, 4 for pt2pt) with a rolling window approach: a benchmark is flagged as failed only if 3 out of any 4 consecutive packet sizes exceed the tolerance.

The old method counted total failures across all packet sizes, treating scattered failures the same as clustered ones. Since benchmark characteristics vary by packet-size range, scattered failures are more likely noise while clustered failures indicate a real regression in a specific range.

Simulated against the 5 most recent DynamoDB runs with the new p75 thresholds:

Old detection: 10/30 test failures (33.3%)
Rolling window 4/3: 8/30 test failures (26.7%)
The 2 eliminated false positives had scattered failures across unrelated packet sizes. The 8 remaining failures all have dense clusters (e.g. 3+ consecutive sizes at ps 4-32 in osu_allreduce), which are stronger signals of actual issues.

### Tests
tests on develop.yaml have passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
