### PR TITLE
[Dependencies] Upgrade Python runtime to Python 3.12 in all Lambda functions.

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -1088,7 +1088,7 @@ class PclusterLambdaConstruct(Construct):
             handler=f"{handler_func}.handler",
             memory_size=128,
             role=execution_role,
-            runtime="python3.9",
+            runtime="python3.12",
             timeout=timeout,
             vpc_config=(
                 awslambda.CfnFunction.VpcConfigProperty(

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -815,7 +815,7 @@ class ImageBuilderCdkStack(Stack):
             handler="delete_image_stack.handler",
             memory_size=128,
             role=execution_role,
-            runtime="python3.9",
+            runtime="python3.12",
             timeout=900,
             environment=lambda_env,
             tags=build_tags,

--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -241,7 +241,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt PrepRole.Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Timeout: 300
       TracingConfig:
         Mode: Active
@@ -560,7 +560,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt PostRole.Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Timeout: 300
       TracingConfig:
         Mode: Active
@@ -767,7 +767,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt DomainCertificateSetupLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Timeout: 300
       TracingConfig:
         Mode: Active
@@ -879,7 +879,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CleanupLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Timeout: 900
       TracingConfig:
         Mode: Active

--- a/tests/integration-tests/resources/file-cache-storage-cfn.yaml
+++ b/tests/integration-tests/resources/file-cache-storage-cfn.yaml
@@ -44,7 +44,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt FileCacheLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Timeout: 300
       TracingConfig:
         Mode: Active


### PR DESCRIPTION
### Description of changes
* Upgrade Python runtime to Python 3.12 in all Lambda functions.
* This is a patch to address the Lambda 3.9 EOL

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
