### PR TITLE
Test that dna.json is not deleted after rollback failure

### DIFF
--- a/tests/integration-tests/tests/update/test_update_rollback_failure.py
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure.py
@@ -156,8 +156,8 @@ def test_update_rollback_failure(
     # Verify clustermgtd is running
     _verify_clustermgtd_running(remote_command_executor)
 
-    # Verify dna.json files are deleted
-    _verify_dna_json_cleaned_up(remote_command_executor)
+    # Verify dna.json files are kept (rollback failure should preserve them for bootstrapping nodes)
+    _verify_dna_json_kept_after_rollback_failure(remote_command_executor)
 
     # Verify metadata_db.json is updated (cfn-hup processed the change)
     _verify_metadata_db_updated(remote_command_executor)
@@ -426,16 +426,16 @@ def _verify_clustermgtd_running(remote_command_executor):
     logger.info("clustermgtd is running ✓")
 
 
-def _verify_dna_json_cleaned_up(remote_command_executor):
-    """Verify that dna.json files are cleaned up after update failure."""
-    logger.info("Verifying dna.json files are cleaned up...")
+def _verify_dna_json_kept_after_rollback_failure(remote_command_executor):
+    """Verify that dna.json files are kept after rollback failure so bootstrapping nodes can use them."""
+    logger.info("Verifying dna.json files are kept after rollback failure...")
 
     result = remote_command_executor.run_remote_command(
         "find /opt/parallelcluster/shared/dna/ -name '*.json' 2>/dev/null | wc -l"
     )
     json_count = int(result.stdout.strip())
-    assert_that(json_count).is_equal_to(0)
-    logger.info("dna.json files are cleaned up ✓")
+    assert_that(json_count).is_greater_than(0)
+    logger.info("dna.json files are kept after rollback failure ✓")
 
 
 def _wait_for_node_config_version_change(region, cluster_name, instance_id, old_version, timeout_minutes=15):

--- a/tests/integration-tests/tests/update/test_update_rollback_failure.py
+++ b/tests/integration-tests/tests/update/test_update_rollback_failure.py
@@ -140,6 +140,9 @@ def test_update_rollback_failure(
     final_status = _wait_for_stack_rollback_complete(cluster, region)
     logger.info(f"Stack final status: {final_status}")
 
+    # Verify dna.json files were cleaned up after update failure (before rollback)
+    _verify_dna_cleaned_up_after_update_failure(remote_command_executor)
+
     # Wait for head node rollback to complete
     # Note: CFN stack reaches UPDATE_ROLLBACK_COMPLETE before head node finishes rollback recipe
     # Sleep briefly to ensure rollback recipe has started writing to chef-client.log
@@ -424,6 +427,18 @@ def _verify_clustermgtd_running(remote_command_executor):
     result = remote_command_executor.run_remote_command(f"sudo {supervisorctl_path} status clustermgtd")
     assert_that(result.stdout).contains("RUNNING")
     logger.info("clustermgtd is running ✓")
+
+
+def _verify_dna_cleaned_up_after_update_failure(remote_command_executor):
+    """Verify via logs that dna.json files were cleaned up after update failure."""
+    logger.info("Verifying dna.json files were cleaned up after update failure (via logs)...")
+    match, lines = match_regex_in_log(
+        remote_command_executor,
+        "/var/log/chef-client.log",
+        r"Update failure detected.*cleaning up DNA files",
+    )
+    assert_that(match).is_true()
+    logger.info("dna.json files were cleaned up after update failure")
 
 
 def _verify_dna_json_kept_after_rollback_failure(remote_command_executor):


### PR DESCRIPTION
### Description of changes
* Fix test_update_rollback_failure so that it passes when dna files are kept after rollback failure
* This is so bootstrapping nodes that finish bootstrapping after the rollback fails do not get stuck waiting for dna json

### Tests
* Ran test_update_rollback_failure

### References
* Related to: https://github.com/aws/aws-parallelcluster-cookbook/pull/3144

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
