### PR TITLE
[Test] Add option `--skip-ddb-metadata` to skip DDB metadata and save time on personal tests

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -241,6 +241,12 @@ def pytest_addoption(parser):
         "--capacity-reservation-id",
         help="Use an existing capacity reservation.",
     )
+    parser.addoption(
+        "--skip-ddb-metadata",
+        action="store_true",
+        default=False,
+        help="Skip the setup and push of DDB metadata.",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -330,6 +336,9 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
 
 
 def pytest_collection_finish(session):
+    if session.config.getoption("skip_ddb_metadata", default=False):
+        logging.info("Skipping DDB metadata due to --skip-ddb-metadata flag")
+        return
     _log_collected_tests(session)
     # Create the metadata table after the regions are collected
     try:

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -112,6 +112,7 @@ TEST_DEFAULTS = {
     "proxy_stack": None,
     "build_image_roles_stack": None,
     "capacity_reservation_id": None,
+    "skip_ddb_metadata": False,
 }
 
 
@@ -514,6 +515,12 @@ def _init_argparser():
         help="Use an existing capacity reservation.",
         default=TEST_DEFAULTS.get("capacity_reservation_id"),
     )
+    debug_group.add_argument(
+        "--skip-ddb-metadata",
+        action="store_true",
+        help="Skip the setup and push of DDB metadata.",
+        default=TEST_DEFAULTS.get("skip_ddb_metadata"),
+    )
 
     return parser
 
@@ -757,6 +764,9 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.capacity_reservation_id:
         pytest_args.extend(["--capacity-reservation-id", args.capacity_reservation_id])
+
+    if args.skip_ddb_metadata:
+        pytest_args.append("--skip-ddb-metadata")
 
 
 def _set_validate_instance_type_args(args, pytest_args):


### PR DESCRIPTION
### Description of changes
Add option `--skip-ddb-metadata` ion test runner to skip DDB metadata. 
By default DDB metadata will never be skipped.

DDB metadata is useful for the official development pipelines to keep track of test success/failures, but it may not for personal executions, and it slows the test execution down by minutes.

By default metadata processing is enabled and you will see lines like:

```
2026-03-13 17:19:06,032 - INFO - 10275 - conftest - Metadata reporting region us-east-1
```

When disabled, you will se a line like:

````
2026-03-13 17:21:19,062 - INFO - 26654 - conftest - Skipping DDB metadata due to --skip-ddb-metadata flag
```

### Tests
* ONGOING `test_essential_features`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
