### PR TITLE
[Test] Import matplotlib with lazy loading in test `performance_tests_plots.py` to prevent burst of harmless warning messages about `classic.mplstyle`.

### DIFF
--- a/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
+++ b/tests/integration-tests/tests/performance_tests/plotting/performance_tests_plots.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 
 import click
-import matplotlib.pyplot as plt
 
 from ..common import METRICS
 
@@ -17,6 +16,8 @@ def generate(datadir, outdir, configurations, nodes):
 
 
 def generate_plots(datadir, outdir, configurations, nodes):
+    import matplotlib.pyplot as plt
+
     # Load samples
     samples = {}
     for configuration in configurations:


### PR DESCRIPTION
### Description of changes
Import matplotlib with lazy loading in test `performance_tests_plots.py` to prevent burst of harmless warning messages about `classic.mplstyle`.

In https://github.com/aws/aws-parallelcluster/pull/7280 we removed some of those warnings, but we should do lazy loading also in performance_tests_plots to remove them completely.

Before this fix:

```
2026-03-13 18:37:08,867 - INFO - 45895 - conftest - Skipping DDB metadata due to --skip-ddb-metadata flag
2026-03-13 18:37:08,969 - WARNING - 46042 - core - In /usr/local/bin/.pyenv/versions/integration-tests-35824/lib/python3.9/site-packages/matplotlib/mpl-data/stylelib/classic.mplstyle: 'parseString' deprecated - use 'parse_string'
2026-03-13 18:37:08,969 - WARNING - 46042 - core - In /usr/local/bin/.pyenv/versions/integration-tests-35824/lib/python3.9/site-packages/matplotlib/mpl-data/stylelib/classic.mplstyle: 'resetCache' deprecated - use 'reset_cache'
```

after this fix:

```
2026-03-13 18:44:59,466 - INFO - 36632 - conftest - Skipping DDB metadata due to --skip-ddb-metadata flag
2026-03-13 18:45:01,340 - INFO - 36949 - conftest - Skipping DDB metadata due to --skip-ddb-metadata flag
2026-03-13 18:45:03,351 - INFO - 36718 - conftest - Skipping DDB metadata due to --skip-ddb-metadata flag
```

### Tests
* Launched tests with and w/o the fix and verified fix works (see above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
