### PR TITLE
[Integ] Create folder path to avoid noise in logs

### DIFF
--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
@@ -50,7 +50,10 @@ TOTAL_RANK=$(($SLURM_NNODES*32))
 # Download file for simulation (64 in the file name corresponds to the number of ranks hardcoded into the file).
 # To use a different number of ranks you need to generate another one:
 # python3 inst-sweep/genneffs_nccl.py -n <total-number-of-ranks> --all --output <output-dir>
-NEFF_FILE=test_nccl_64r_50allg_int8_393216/0/file.neff
+
+NEFF_FILE_PATH=test_nccl_64r_50allg_int8_393216/0/
+mkdir -p $NEFF_FILE_PATH
+NEFF_FILE=$NEFF_FILE_PATH/file.neff
 if [[ ! -f $NEFF_FILE ]]; then
   aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH}test_nccl_64r_50allg_int8_393216_0_file.neff $NEFF_FILE --region us-east-1
 fi


### PR DESCRIPTION
### Description of changes
* Create folder path to avoid noise in logs
```
ownload failed: s3://....../test_nccl_64r_50allg_int8_393216_0_file.neff to test_nccl_64r_50allg_int8_393216/0/file.neff Could not create directory /home/ubuntu/test_nccl_64r_50allg_int8_393216/0: [Errno 2] No such file or directory: '/home/ubuntu/test_nccl_64r_50allg_int8_393216/0'

```

### Tests
* test_tranium

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
