### PR TITLE
Add tag and untag permissions

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -440,6 +440,8 @@ Resources:
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
               - cloudwatch:PutCompositeAlarm
+              - cloudwatch:TagResource
+              - cloudwatch:UntagResource
             Resource: '*'
             Effect: Allow
             Condition: !If

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -374,6 +374,8 @@ Resources:
               - cloudwatch:PutCompositeAlarm
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
+              - cloudwatch:TagResource
+              - cloudwatch:UntagResource
             Resource: '*'
             Effect: Allow
             Condition: !If
@@ -992,6 +994,8 @@ Resources:
               - cloudwatch:PutCompositeAlarm
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
+              - cloudwatch:TagResource
+              - cloudwatch:UntagResource
             Resource: "*"
 #          - Effect: Allow # TODO: Refactor it, comment it out now to workaround exceeds quota for PolicySize: 6144
 #            Action:

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -584,6 +584,8 @@ def _create_permission_boundary(permission_boundary_name):
                         "cloudwatch:PutCompositeAlarm",
                         "cloudwatch:DeleteAlarms",
                         "cloudwatch:DescribeAlarms",
+                        "cloudwatch:TagResource",
+                        "cloudwatch:UntagResource",
                     ],
                     "Condition": {
                         "Fn::If": [


### PR DESCRIPTION
### Description of changes
* Add tag and untag permissions to prevent the following error message:
```
HeadNodeAlarm
CREATE_IN_PROGRESS
-
Encountered a permissions error performing a tagging operation, please add required tag permissions. Retrying request without including tags. See https://repost.aws/knowledge-center/cloudformation-tagging-permission-error for how to resolve. Resource handler returned message: "Unauthorized tagging operation"
```
* PR #7209 added a new ClustermgtdHeartbeat alarm. When CFN creates these new alarm resources, CDK propagates stack tags to them, and CFN calls cloudwatch:TagResource. This is why these additional permissions are needed.

### Tests
* Ran integ test and check there was no error

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
