### PR TITLE
Scope down security group for test_launch_template_override

### DIFF
--- a/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
+++ b/tests/integration-tests/tests/launch_template_overrides/test_launch_template_overrides.py
@@ -107,13 +107,13 @@ def override_launch_template(request, region, vpc_stack):
     )
     security_group_id = sg_response["GroupId"]
 
-    # Allow all inbound traffic
+    # Allow all inbound traffic from within the security group (self-referencing)
     ec2_client.authorize_security_group_ingress(
         GroupId=security_group_id,
         IpPermissions=[
             {
                 "IpProtocol": "-1",
-                "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                "UserIdGroupPairs": [{"GroupId": security_group_id}],
             }
         ],
     )


### PR DESCRIPTION
### Description of changes
* Scope down security group for test_launch_template_override
* Addresses a ticket about Publicly Accessible Rpcbind

### Tests
* Ran test_launch_template_overrides

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
