### PR TITLE
[Image] Add more verbosity when downloading Cookbook

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -221,8 +221,14 @@ phases:
               mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
               delays=(1 2 4 8 16 32 64 128 256)
               for i in {0..8}; do
-                curl -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL" && break
-                echo "Curl attempt $((i+1)) failed, retrying in ${!delays[$i]}s..."
+                HTTP_CODE=$(curl -sS -L -w '%{http_code}' -o /etc/chef/aws-parallelcluster-cookbook.tgz "$COOKBOOK_URL")
+                if [[ "$HTTP_CODE" -eq 200 ]]; then
+                  echo "Cookbook download succeeded (HTTP $HTTP_CODE)"
+                  break
+                fi
+                echo "Cookbook download attempt $((i+1)) failed with HTTP $HTTP_CODE. Response body:"
+                cat /etc/chef/aws-parallelcluster-cookbook.tgz
+                echo ""
                 sleep ${!delays[$i]}
               done
               


### PR DESCRIPTION
### Description of changes
* Use the write-out flag to capture just the HTTP status code. On non-200, print the response body (which will be the S3 XML error like AccessDenied or ExpiredToken)
* Use `-sS` option to silence (no progress bar) but still prints curl errors like curl: `(6) Could not resolve host or curl: (28) Connection timed out.` Covers both transport failures and HTTP failure.
```
Cookbook download attempt 1 failed with HTTP 403. Response body:
2026-03-20 17:17:06.371000	Stdout: <?xml version="1.0" encoding="UTF-8"?>
2026-03-20 17:17:06.372000	Stdout: <Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>N9ANSFDAXHB1Z4NN</RequestId><HostId>6+XkwyfEcE8tbfrtF5HsHlw3YNVvAFBTpVwH6yhgnnSu5Zi0rxrBiiRUIna6FIpfKR4/g0+9Hgo=</HostId></Error>
2026-03-20 17:17:07.424000	Stdout: Cookbook download attempt 2 failed with HTTP 403. Response body:
2026-03-20 17:17:07.425000	Stdout: <?xml version="1.0" encoding="UTF-8"?>
2026-03-20 17:17:07.425000	Stdout: <Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>6KHWXEPXMTHKPZRM</RequestId><HostId>Q1dOT6L/MzAU44FaWHAS1GNovHW+7rZtpgqfRvyDNcucrUfN++L0ZF1BygmzPFn/KXZyQmEdgd394mWMHVlF5vfzzmQMukzK</HostId></Error>
2026-03-20 17:17:09.471000	Stdout: Cookbook download attempt 3 failed with HTTP 403. Response body:
2026-03-20 17:17:09.471000	Stdout: <?xml version="1.0" encoding="UTF-8"?>
```

### Tests
* Build image with above failure

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
