### PR TITLE
[integ-tests-framework] Use Lazy import of dependencies in reports_generator

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
+import random
 import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
@@ -339,6 +340,7 @@ def _check_or_create_capacity_reservations(config_file, os_parameters, instance_
                 "us-west-2",
                 "us-east-1",
             ]
+            random.shuffle(candidate_regions)
             if not _create_capacity_reservations(az_for_capacity_reservation, candidate_regions, specs, var):
                 # If failed to create reservation, use use1-az6 to avoid making the test yaml syntactically wrong.
                 logging.info("Failed to create capacity reservation for %s. Using use1-az6", var)


### PR DESCRIPTION
### Description of changes
Sometimes, only a few functions in reports_generator.py are called by a environment, which doesn't have to have all Python dependencies installed

### Tests
* test will run after the PR is merge

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
