### PR TITLE
[Test] Make RCA automation able to detect fatal errors from chef-client.log.

### DIFF
--- a/tests/integration-tests/diagnosis_utils.py
+++ b/tests/integration-tests/diagnosis_utils.py
@@ -27,7 +27,7 @@ RCA_LOG_FILES = [
     "/var/log/parallelcluster/slurmctld.log",
 ]
 PATTERN_GENERIC_FAILURE = r"error|fail|fatal|exception|critical"
-PATTERN_CHEF_ERROR = r"ERROR:"
+PATTERN_CHEF_ERROR = r"(ERROR|FATAL):"
 PATTERN_ICE_ERROR = r"InsufficientInstanceCapacity.*?sufficient\s+(\S+)\s+capacity"
 CMD_RETRIEVE_RECIPE_EXECUTION = (
     "cat /var/log/chef-client.log"


### PR DESCRIPTION
### Description of changes
Make RCA automation able to detect fatal errors from chef-client.log.
This is required to match error lines such as:

```
=== ROOT CAUSE ANALYSIS ===

--- SUMMARY ---
[]

--- /var/log/chef-client.log ---
[2026-03-25T18:22:17+00:00] ERROR: shard_seed: Failed to get dmi property serial_number: is dmidecode installed?
[2026-03-25T18:22:21+00:00] ERROR: Running exception handlers
[2026-03-25T18:22:21+00:00] ERROR: Exception handlers complete
[2026-03-25T18:22:21+00:00] FATAL: Stacktrace dumped to /etc/chef/local-mode-cache/cache/cinc-stacktrace.out
[2026-03-25T18:22:21+00:00] FATAL: ---------------------------------------------------------------------------------------
[2026-03-25T18:22:21+00:00] FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
[2026-03-25T18:22:21+00:00] FATAL: ---------------------------------------------------------------------------------------
[2026-03-25T18:22:21+00:00] FATAL: RuntimeError: This AMI was created with aws-parallelcluster-cookbook-3.16.0, but is trying to be used with aws-parallelcluster-cookbook-3.15.0. Please either use an AMI created with aws-parallelcluster-cookbook-3.15.0 or change your ParallelCluster to aws-parallelcluster-cookbook-3.16.0
```

### Tests
1. Injected failure with integ test and verified the RCA is able to report the fatal error  (see report above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
