### PR TITLE
Handle BucketAlreadyOwnedByYou race condition in S3 bucket initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.16.0
+------
+
+**BUG FIXES**
+- Fix sporadic S3 bucket (with name parallelcluster-*-v1-do-not-delete) creation failure when multiple create-cluster commands are running simultaneously in the same region.
+
 3.15.0
 ------
 

--- a/cli/src/pcluster/models/s3_bucket.py
+++ b/cli/src/pcluster/models/s3_bucket.py
@@ -478,8 +478,11 @@ class S3BucketFactory:
             try:
                 bucket.create_bucket()
             except AWSClientError as error:
-                LOGGER.error("Unable to create S3 bucket %s.", bucket.name)
-                raise error
+                if error.error_code == "BucketAlreadyOwnedByYou":
+                    LOGGER.info("S3 bucket %s was created shortly before by another process. Proceeding.", bucket.name)
+                else:
+                    LOGGER.error("Unable to create S3 bucket %s.", bucket.name)
+                    raise error
         else:
             LOGGER.error("Unable to check S3 bucket %s existence.", bucket.name)
             raise e


### PR DESCRIPTION
### Description of changes

The default S3 bucket name is deterministic per account+region, so concurrent cluster creation calls (e.g. parallel integration tests) can race: multiple callers get a 404 from head_bucket, then all attempt create_bucket. The first succeeds; the rest fail with BucketAlreadyOwnedByYou, which was previously unhandled and surfaced as "Unable to initialize s3 bucket."

Treat BucketAlreadyOwnedByYou as a success condition since it confirms the bucket exists and is owned by the caller, which is the desired end state. Log at info level and proceed normally.

### Tests
* Tests will run after PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
