### PR TITLE
[Integ] Add `long` option to check the status of cloud-init failures

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1729,7 +1729,7 @@ def _wait_compute_cloudinit_done(remote_command_executor, compute_node):
     """Wait till cloud-init complete on a given compute node"""
     compute_node_private_ip = compute_node.get("privateIpAddress")
     compute_cloudinit_status_output = remote_command_executor.run_remote_command(
-        f"ssh -q {compute_node_private_ip} sudo cloud-init status"
+        f"ssh -q {compute_node_private_ip} sudo cloud-init status --long"
     ).stdout
     assert_that(compute_cloudinit_status_output).contains("status: done")
 


### PR DESCRIPTION
### Description of changes
* Add `long` option to check the status of cloud-init failures
Test failed with below output but no details on what the failure was

```
with status 2.
=== stdout ===
status: done
```
Refrence https://docs.cloud-init.io/en/latest/explanation/failure_states.html#recoverable-failure

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
