### PR TITLE
[Integ] Modify the selection of AMI type and OS for testing

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -50,6 +50,8 @@ Metadata:
 Conditions:
   IsBuildImageProxy: !Equals [!Ref EnableBuildImageProxy, "true"]
   IsClusterProxy: !Not [!Condition IsBuildImageProxy]
+  # China regions (aws-cn partition) use cn.com.amazonaws prefix for VPC Interface endpoint service names
+  IsChinaRegion: !Equals [!Ref "AWS::Partition", "aws-cn"]
 
 Resources:
 
@@ -140,6 +142,7 @@ Resources:
       RouteTableId: !Ref PrivateSubnetRT
 
   # VPC ENDPOINTS (build-image mode only)
+  # S3 Gateway endpoint uses standard com.amazonaws naming in all partitions
   S3Endpoint:
     Type: AWS::EC2::VPCEndpoint
     Condition: IsBuildImageProxy
@@ -150,6 +153,7 @@ Resources:
       RouteTableIds:
         - !Ref PrivateSubnetRT
 
+  # Interface endpoints use com.amazonaws in all partitions, except for some services in China regions
   LogsEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Condition: IsBuildImageProxy
@@ -161,11 +165,14 @@ Resources:
       SubnetIds:
         - !Ref PrivateSubnet
 
+  # EC2 VPC endpoint uses cn.com.amazonaws prefix in China regions
   EC2Endpoint:
     Type: AWS::EC2::VPCEndpoint
     Condition: IsBuildImageProxy
     Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2
+      ServiceName: !Sub
+        - "${Prefix}.${AWS::Region}.ec2"
+        - Prefix: !If [IsChinaRegion, "cn.com.amazonaws", "com.amazonaws"]
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
       VpcId: !Ref Vpc
@@ -205,11 +212,14 @@ Resources:
       SubnetIds:
         - !Ref PrivateSubnet
 
+  # ImageBuilder VPC endpoint uses cn.com.amazonaws prefix in China regions
   ImageBuilderEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Condition: IsBuildImageProxy
     Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.imagebuilder
+      ServiceName: !Sub
+        - "${Prefix}.${AWS::Region}.imagebuilder"
+        - Prefix: !If [IsChinaRegion, "cn.com.amazonaws", "com.amazonaws"]
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
       VpcId: !Ref Vpc

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -53,6 +53,49 @@ class ImageNotFound(Exception):
     pass
 
 
+def _get_base_ami(region, os, architecture):
+    """Select the appropriate base AMI and feature flags based on OS.
+
+    Uses first-stage AMIs for RHEL/Rocky/Ubuntu (kernel version requirements),
+    remarkable (Deep Learning) AMIs for ubuntu2204, and official AMIs for everything else.
+    Returns (base_ami, feature_flags) where feature_flags is a dict with keys:
+      enable_nvidia, update_os_packages, enable_lustre_client, enable_dcv.
+    """
+    enable_nvidia = os not in ["ubuntu2404"]
+    update_os_packages = os in ["alinux2", "alinux2023", "rocky9"]
+    enable_lustre_client = True
+    enable_dcv = True
+
+    if os in ["ubuntu2204"]:
+        # Test Deep Learning AMIs
+        base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
+        enable_nvidia = False  # Deep learning AMIs have Nvidia pre-installed
+    elif "rhel" in os or "ubuntu" in os or os == "rocky8":
+        # Test AMIs from first stage build. Because RHEL/Rocky and Ubuntu have specific requirement of kernel versions.
+        try:
+            base_ami = retrieve_latest_ami(region, os, ami_type="first_stage", architecture=architecture)
+        except IndexError:  # If first stage AMI is not available, use official AMI.
+            # Therefore, the test tries to succeed at best effort.
+            logging.info("First stage AMI not available, using official AMI instead.")
+            base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
+            update_os_packages = True
+            if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
+                enable_lustre_client = False
+    else:
+        # Test vanilla AMIs.
+        base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
+        if os in ["rocky9"]:
+            enable_lustre_client = False
+
+    feature_flags = {
+        "enable_nvidia": enable_nvidia,
+        "update_os_packages": update_os_packages,
+        "enable_lustre_client": enable_lustre_client,
+        "enable_dcv": enable_dcv,
+    }
+    return base_ami, feature_flags
+
+
 @pytest.mark.usefixtures("instance")
 def test_build_image_no_internet(
     region,
@@ -65,7 +108,7 @@ def test_build_image_no_internet(
     request,
 ):
     """Test build image in a private subnet with no internet access, only VPC endpoints and a proxy for OS repos."""
-    base_ami = retrieve_latest_ami(region, os, architecture=architecture)
+    base_ami, _ = _get_base_ami(region, os, architecture)
 
     # Create proxy stack with build-image mode enabled
     no_internet_proxy_stack = proxy_stack_factory(enable_build_image_proxy=True)
@@ -175,49 +218,18 @@ def test_build_image(
     bucket_name = s3_bucket_factory()
     _set_s3_bucket_policy(bucket_name, get_arn_partition(region), region)
 
-    enable_nvidia = True
-    update_os_packages = False
-    enable_lustre_client = True
-
-    # Disable nvidia installation for ubuntu2404 because nvidia drivers are failing with newest kernel
-    if os in ["ubuntu2404"]:
-        enable_nvidia = False
-
-    # Get base AMI
-    if os in ["ubuntu2204"]:
-        # Test Deep Learning AMIs
-        base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
-        enable_nvidia = False  # Deep learning AMIs have Nvidia pre-installed
-    elif "rhel" in os or "ubuntu" in os or os == "rocky8":
-        # Test AMIs from first stage build. Because RHEL/Rocky and Ubuntu have specific requirement of kernel versions.
-        try:
-            base_ami = retrieve_latest_ami(region, os, ami_type="first_stage", architecture=architecture)
-        except IndexError:  # If first stage AMI is not available, use official AMI.
-            # Therefore, the test tries to succeed at best effort.
-            logging.info("First stage AMI not available, using official AMI instead.")
-            base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
-            update_os_packages = True
-            if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
-                enable_lustre_client = False
-    else:
-        # Test vanilla AMIs.
-        base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
-        if os in ["rocky9"]:
-            enable_lustre_client = False
-    if os in ["alinux2", "alinux2023", "rocky9"]:
-        update_os_packages = True
-
-    enable_dcv = True
+    # Get base AMI and feature flags
+    base_ami, flags = _get_base_ami(region, os, architecture)
 
     image_config = pcluster_config_reader(
         config_file="image.config.yaml",
         parent_image=base_ami,
         instance_role=instance_role,
         bucket_name=bucket_name,
-        enable_nvidia=str(enable_nvidia and get_gpu_count(instance) > 0).lower(),
-        update_os_packages=str(update_os_packages).lower(),
-        enable_lustre_client=str(enable_lustre_client).lower(),
-        enable_dcv=str(enable_dcv).lower(),
+        enable_nvidia=str(flags["enable_nvidia"] and get_gpu_count(instance) > 0).lower(),
+        update_os_packages=str(flags["update_os_packages"]).lower(),
+        enable_lustre_client=str(flags["enable_lustre_client"]).lower(),
+        enable_dcv=str(flags["enable_dcv"]).lower(),
     )
 
     image = images_factory(image_id, image_config, region)


### PR DESCRIPTION
### Description of changes
* Modify the selection of AMI type and OS for testing
* USe China specific service for VPC endpoints (Only Ec2 and Imagebuilder has different domains)

cookbook https://github.com/aws/aws-parallelcluster-cookbook/pull/3158
### Tests
* test_build_image_no_internet in China + govcloud partition

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
