### PR TITLE
[Integ] Rocky specific Repo mirrors used in China

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -378,6 +378,7 @@ Resources:
               # RHEL repos: Red Hat Update Infrastructure (RHUI)
               # EPEL GPG key: CloudFront distribution
               # DCV GPG key: CloudFront distribution (NICE DCV)
+              # Rocky mirrors: domains from China mirrorlist resolution
               cat << FILTER > /etc/tinyproxy/filter
             \.ubuntu\.com$
             \.launchpadcontent\.net$
@@ -385,6 +386,21 @@ Resources:
             ^dl\.rockylinux\.org$
             ^mirrors\.rockylinux\.org$
             ^download\.rockylinux\.org$
+            ^mirror\.ps\.kz$
+            \.production\.gcp\.mirrors\.ctrliq\.cloud$
+            ^mirror\.hashy0917\.net$
+            ^rocky\.mirror\.co\.ge$
+            ^in\.mirrors\.cicku\.me$
+            ^mirrors\.ipserverone\.com$
+            ^mirror\.bharatdatacenter\.com$
+            ^mirrors\.esto\.network$
+            ^ftp\.iij\.ad\.jp$
+            ^mirror\.dc\.uz$
+            ^mirror\.ourhost\.az$
+            ^mirror\.maeen\.sa$
+            ^mirror\.nevacloud\.com$
+            ^ftp\.yz\.yamagata-u\.ac\.jp$
+            ^mirror\.twds\.com\.tw$
             ^cdn\.amazonlinux\.com$
             ^awscli\.amazonaws\.com
             \.s3\.amazonaws\.com


### PR DESCRIPTION
### Description of changes
*  Rocky specific Repo mirrors used in China

### Tests
* Successful Build image test in china for Rocky8, Ubuntu 22/24, Rhel 8/9 and Al2023.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
