### PR TITLE
[integ-tests-framework] Move push_result_to_dynamodb to tests/common/utils

### DIFF
--- a/tests/integration-tests/tests/common/nccl_common.py
+++ b/tests/integration-tests/tests/common/nccl_common.py
@@ -17,7 +17,7 @@ import pytest
 from assertpy import assert_that
 from utils import get_instance_info
 
-from tests.performance_tests.common import push_result_to_dynamodb
+from tests.common.utils import push_result_to_dynamodb
 
 NCCL_COMMON_DATADIR = pathlib.Path(__file__).parent / "data/nccl/"
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -15,11 +15,14 @@ import pathlib
 import random
 import string
 import time
+import uuid
 from importlib.metadata import version as get_package_version
 
 import boto3
 from assertpy import assert_that
 from botocore.exceptions import ClientError
+from framework.framework_constants import METADATA_DEFAULT_REGION, PERFORMANCE_METADATA_TABLE
+from framework.metadata_table_manager import MetadataTableManager
 from packaging import version as packaging_version
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from retrying import retry
@@ -652,3 +655,35 @@ def get_capacity_reservation_id(request, instance_type, region, count, os):
                         }
                     )
     return reservations_ids
+
+
+def push_result_to_dynamodb(name, result, instance, os, mpi_variation=None, num_instances=None):
+    reporting_region = METADATA_DEFAULT_REGION
+    logging.info(f"Metadata reporting region {reporting_region}")
+    # Create the metadata table in case it doesn't exist
+    MetadataTableManager(reporting_region, PERFORMANCE_METADATA_TABLE).create_metadata_table()
+    try:
+        # Create DynamoDB resource
+        dynamodb = boto3.resource("dynamodb", region_name=reporting_region)
+        table = dynamodb.Table(PERFORMANCE_METADATA_TABLE)
+
+        # Prepare item to be inserted
+        item = {
+            "id": str(uuid.uuid4().hex),
+            "name": name,
+            "instance": instance,
+            "os": os,
+            "timestamp": int(time.time()),
+            "result": str(result),
+            "pcluster_version": f"v{get_installed_parallelcluster_version()}",
+            "mpi_variation": str(mpi_variation),
+            "num_instances": num_instances,
+        }
+
+        # Put item in the table
+        table.put_item(Item=item)
+        logging.info(f"Successfully pushed result to DynamoDB with id: {item['id']}")
+
+    except Exception as e:
+        logging.error(f"Failed to push result to DynamoDB: {str(e)}")
+        raise

--- a/tests/integration-tests/tests/performance_tests/common.py
+++ b/tests/integration-tests/tests/performance_tests/common.py
@@ -3,20 +3,16 @@ import logging
 import os as os_lib
 import pathlib
 import shutil
-import time
-import uuid
 from math import ceil
 from os import makedirs
 
 import boto3
 from assertpy import assert_that
-from framework.framework_constants import METADATA_DEFAULT_REGION, PERFORMANCE_METADATA_TABLE
-from framework.metadata_table_manager import MetadataTableManager
 from retrying import retry
 from time_utils import seconds
 from utils import get_username_for_os
 
-from tests.common.utils import fetch_instance_slots, get_installed_parallelcluster_version
+from tests.common.utils import fetch_instance_slots
 
 # Common settings used by all test scenarios
 # You can change these variables to adapt the performance test to your needs.
@@ -253,35 +249,3 @@ def _log_output_performance_difference(node, performance_degradation, observed_v
         f"Nodes: {node}, Baseline: {baseline_value} seconds, Observed: {observed_value} seconds, "
         f"Percentage difference: {percentage_difference}%, Outcome: {outcome}"
     )
-
-
-def push_result_to_dynamodb(name, result, instance, os, mpi_variation=None, num_instances=None):
-    reporting_region = METADATA_DEFAULT_REGION
-    logging.info(f"Metadata reporting region {reporting_region}")
-    # Create the metadata table in case it doesn't exist
-    MetadataTableManager(reporting_region, PERFORMANCE_METADATA_TABLE).create_metadata_table()
-    try:
-        # Create DynamoDB resource
-        dynamodb = boto3.resource("dynamodb", region_name=reporting_region)
-        table = dynamodb.Table(PERFORMANCE_METADATA_TABLE)
-
-        # Prepare item to be inserted
-        item = {
-            "id": str(uuid.uuid4().hex),
-            "name": name,
-            "instance": instance,
-            "os": os,
-            "timestamp": int(time.time()),
-            "result": str(result),
-            "pcluster_version": f"v{get_installed_parallelcluster_version()}",
-            "mpi_variation": str(mpi_variation),
-            "num_instances": num_instances,
-        }
-
-        # Put item in the table
-        table.put_item(Item=item)
-        logging.info(f"Successfully pushed result to DynamoDB with id: {item['id']}")
-
-    except Exception as e:
-        logging.error(f"Failed to push result to DynamoDB: {str(e)}")
-        raise

--- a/tests/integration-tests/tests/performance_tests/test_openfoam.py
+++ b/tests/integration-tests/tests/performance_tests/test_openfoam.py
@@ -4,7 +4,8 @@ from concurrent.futures.thread import ThreadPoolExecutor
 import pytest
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 
-from tests.performance_tests.common import _log_output_performance_difference, push_result_to_dynamodb
+from tests.common.utils import push_result_to_dynamodb
+from tests.performance_tests.common import _log_output_performance_difference
 
 # timeout in seconds
 OPENFOAM_INSTALLATION_TIMEOUT = 300

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -22,10 +22,10 @@ from tests.common.osu_common import run_individual_osu_benchmark
 from tests.common.utils import (
     fetch_instance_slots,
     get_capacity_reservation_id,
+    push_result_to_dynamodb,
     run_system_analyzer,
     write_file,
 )
-from tests.performance_tests.common import push_result_to_dynamodb
 
 # We collected OSU benchmarks results for these instance types
 OSU_BENCHMARKS_INSTANCES = ["c5n.18xlarge", "p5en.48xlarge", "p6-b200.48xlarge"]

--- a/tests/integration-tests/tests/performance_tests/test_starccm.py
+++ b/tests/integration-tests/tests/performance_tests/test_starccm.py
@@ -5,8 +5,13 @@ import boto3
 import pytest
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 
-from tests.common.utils import assert_no_file_handler_leak, fetch_instance_slots, get_compute_ip_to_num_files
-from tests.performance_tests.common import _log_output_performance_difference, push_result_to_dynamodb
+from tests.common.utils import (
+    assert_no_file_handler_leak,
+    fetch_instance_slots,
+    get_compute_ip_to_num_files,
+    push_result_to_dynamodb,
+)
+from tests.performance_tests.common import _log_output_performance_difference
 
 # timeout in seconds
 STARCCM_INSTALLATION_TIMEOUT = 1800


### PR DESCRIPTION
### Description of changes
The SSM automation test pipeline deletes tests/performance_tests before running tests, breaking nccl_common.py's top-level import from that package.

Moreover, The function is a generic DynamoDB reporting utility with no performance-test-specific logic, so tests/common/utils is a more appropriate home regardless.

### Tests
* Tests will run after this PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
