### PR TITLE
[E2E Test Visibility] Fix TestMetadata UUID reuse causing DynamoDB records to be overwritten

### DIFF
--- a/tests/integration-tests/framework/metadata_table_manager.py
+++ b/tests/integration-tests/framework/metadata_table_manager.py
@@ -30,7 +30,7 @@ class TestMetadata:
     """Metadata for a test"""
 
     name: str
-    id: str = uuid.uuid4().hex  # TODO: The value is initialized once. It is a problem only if tests run sequentially.
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
     region: str = ""
     os: str = ""
     feature: str = ""


### PR DESCRIPTION
### Description of changes
Previously the UUID is computed once at module load time. When a worker runs test A then test B, both get the same DynamoDB key, and B's `put_item` overwrites A's record.

Now it generates a new UUID per instance.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
