### PR TITLE
[Validators] The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 3.16.0
 ------
 
+**CHANGES**
+- The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`, 
+  consistent with the existing limit for `Database`. This prevents runtime failures caused by MySQL's table name length limit.
+
 **BUG FIXES**
 - Fix sporadic S3 bucket (with name parallelcluster-*-v1-do-not-delete) creation failure when multiple create-cluster commands are running simultaneously in the same region.
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -89,7 +89,9 @@ class ClusterNameValidator(Validator):
     """Cluster name validator."""
 
     def _validate(self, name, scheduling):
-        if scheduling.scheduler == "slurm" and scheduling.settings.database is not None:
+        if scheduling.scheduler == "slurm" and (
+            scheduling.settings.database is not None or scheduling.settings.external_slurmdbd is not None
+        ):
             if not re.match(PCLUSTER_NAME_REGEX % (PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING - 1), name):
                 self._add_failure(
                     (

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -192,6 +192,26 @@ def test_cluster_name_validator(cluster_name, scheduling, should_trigger_error):
             ),
             False,
         ),
+        (
+            "ClusterNameWith40------------------Chars",
+            SlurmScheduling(
+                queues=None,
+                settings=SlurmSettings(
+                    external_slurmdbd=ExternalSlurmdbd(host="test.slurmdbd.host", port=6819),
+                ),
+            ),
+            False,
+        ),
+        (
+            "ClusterNameWith41-------------------Chars",
+            SlurmScheduling(
+                queues=None,
+                settings=SlurmSettings(
+                    external_slurmdbd=ExternalSlurmdbd(host="test.slurmdbd.host", port=6819),
+                ),
+            ),
+            True,
+        ),
     ],
 )
 def test_cluster_name_validator_slurm_accounting(cluster_name, scheduling, should_trigger_error):


### PR DESCRIPTION
### Description of changes
The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`. This is consistent with the existing limit for `Database`.
This limitation prevents runtime failures caused by MySQL's table name length limit.

#### what if we do not enforce this limit?
Without enforcing this limit the user may have hard time understanding the root cause of the failure.
The cluster creation would succeed but acccunting data would not be pushed.
The user must check slurmdbd logs to spot the issue, signaled by this error line:

```
[2026-04-01T22:03:34.775] error: mysql_query failed: 1059 Identifier name 'integ-tests-b1scxqkp3595s8c5-integ-mgiacomo0401_assoc_usage_day_table' is too long
```

We did not change the error message because it was already comprehensive:

```
    {
      "level": "ERROR",
      "type": "ClusterNameValidator",
      "message": "Error: The cluster name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and when using Slurm accounting it can't be longer than 40 characters."
    },
```

### Tests
* Unit tests included in PR, which has been updated to capture the changes.
* Verified that the validator fails as expected when external slurmdbd is used and cluster name exceeds 40 chars: succeeds otherwise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
