### PR TITLE
[Integ] Check export task is happening before every pcluster export-log

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -93,9 +93,7 @@ def test_slurm_cli_commands(
     filters = [{}, {"node_type": "HeadNode"}, {"node_type": "Compute"}, {"queue_name": "ondemand1"}]
     for filter_ in filters:
         _test_describe_instances(cluster, **filter_)
-    wait_for_no_active_export_tasks(cluster.region)
     _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster)
-    wait_for_no_active_export_tasks(cluster.region)
     _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, True)
     check_pcluster_list_cluster_log_streams(cluster, os)
     _test_pcluster_get_cluster_log_events(cluster)
@@ -371,11 +369,13 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, use_pcluster_
 
     # test with a prefix and an output file
     bucket_prefix = "test_prefix"
+    wait_for_no_active_export_tasks(cluster.region)
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
         cluster, bucket_name if not use_pcluster_bucket else None, instance_ids, bucket_prefix
     )
 
     # test export-cluster-logs with filter option
+    wait_for_no_active_export_tasks(cluster.region)
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
         cluster,
         bucket_name if not use_pcluster_bucket else None,
@@ -394,6 +394,7 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, use_pcluster_
     assert_that(bucket_cleaned_up).is_true()
 
     # test without a prefix or output file
+    wait_for_no_active_export_tasks(cluster.region)
     ret = cluster.export_logs(bucket=bucket_name if not use_pcluster_bucket else None)
     assert_that(ret).contains_key("url")
     filename = ret["url"].split(".tar.gz")[0].split("/")[-1] + ".tar.gz"


### PR DESCRIPTION

### Description of changes
* Check export task is happening before every pcluster export-log command


Below Test is ongoing

```
test-suites:
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023", "ubuntu2404"]
          schedulers: ["slurm"]
```
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
