### PR TITLE
[Docs] Add changelog entry related to removal of deprecated Slurm parameter AccountingStorageUser 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Fix sporadic S3 bucket (with name parallelcluster-*-v1-do-not-delete) creation failure when multiple create-cluster commands are running simultaneously in the same region.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden
   via custom Slurm settings or the cluster name contains upper-case letters.
+- Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 
 3.15.0
 ------


### PR DESCRIPTION
### Description of changes
Add changelog entry related to removal of deprecated Slurm parameter AccountingStorageUser 

See https://github.com/aws/aws-parallelcluster-cookbook

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
