### PR TITLE
[AD] Fix race condition in AD 1-click template that caused stack creation failure

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -622,6 +622,8 @@ Resources:
 
   Post:
     Type: Custom::PostLambda
+    DependsOn:
+      - AdDomainAdminNodeWaitCondition
     Properties:
       ServiceToken: !GetAtt PostLambda.Arn
       AdminNodeInstanceId: !Ref AdDomainAdminNode


### PR DESCRIPTION
### Description of changes
Fix race condition in AD 1-click template that caused stack creation failure by making the Post custom resource wait for the AdAdminNode to complete the registration of users.

The Post custom resource executes operations on AD users, which are created by the AdAdminNode. So it requires the AdAdminNode to complete its user data. So far the custom resource depends on AdAdminNode, but this is not enough because CloudFormation considered the EC2 instance created as soon as it launched, which unblocks the custom resource too early. To make the custom resource wait for the node3 to complete its user data, the custom resource must waith for the wait condition signaled by the end of the user data.

### Tests
SUCCESS `test_ad_integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
