### PR TITLE
[Test] Move test_efa with hpc5a.48xlarge from us-east-2 to eu-west-1

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -285,7 +285,7 @@ test-suites:
           instances: ["hpc6id.32xlarge"]
           oss: [{{ OS_X86_4 }}]
           schedulers: [ "slurm" ]
-        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
+        - regions: ["euw1-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
           oss: [{{ OS_X86_6 }}]
           schedulers: [ "slurm" ]


### PR DESCRIPTION
### Description of changes
Move test_efa with hpc5a.48xlarge from us-east-2 to eu-west-1 to decrease the risk of insufficient capacity exceptions.

### Tests
ONGOING `test_efa`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
