### PR TITLE
[Test] Add a check before we do updates

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -192,7 +192,7 @@ class Cluster:
             logging.error("Failed starting cluster with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
             raise
 
-    def stop(self):
+    def stop(self, wait_stopped=False):
         """Run pcluster stop and return the result."""
         cmd_args = ["pcluster", "update-compute-fleet", "--cluster-name", self.name, "--status"]
         scheduler = self.config["Scheduling"]["Scheduler"]
@@ -203,7 +203,12 @@ class Cluster:
         try:
             result = run_pcluster_command(cmd_args, log_error=False, custom_cli_credentials=self.custom_cli_credentials)
             logging.info("Cluster {0} stopped successfully".format(self.name))
-
+            if wait_stopped:
+                retry(
+                    wait_fixed=seconds(10),
+                    stop_max_delay=minutes(2),
+                    retry_on_result=lambda describe_result: "STOPPED" != describe_result["status"],
+                )(self.describe_compute_fleet)()
             return result.stdout
         except subprocess.CalledProcessError as e:
             logging.error("Failed stopping cluster with error:\n%s\nand output:\n%s", e.stderr, e.stdout)

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -16,7 +16,6 @@ import os as os_lib
 import re
 import tarfile
 import tempfile
-import time
 
 import boto3
 import botocore
@@ -298,14 +297,13 @@ def _test_pcluster_compute_fleet(cluster, expected_num_nodes):
     last_stop_time = compute_fleet["lastStatusUpdatedTime"]
 
     logging.info("Testing pcluster start functionalities")
-    # Do a complicated sequence of start and stop and see if commands will still work
-    cluster.start()
-    time.sleep(15)
-    cluster.stop()
-    time.sleep(15)
-    cluster.stop()
-    time.sleep(30)
-    cluster.start()
+    # Do a complicated sequence of start and stop and see if commands will still work.
+    # We must wait for terminal states between commands to avoid racing with clusterstatusmgtd's
+    # ~60s poll loop, which transitions *_REQUESTED -> *ING and would cause conditional DDB write failures.
+    cluster.start(wait_running=True)
+    cluster.stop(wait_stopped=True)
+    cluster.stop(wait_stopped=True)  # idempotent on already-stopped fleet
+    cluster.start(wait_running=True)
     compute_fleet = cluster.describe_compute_fleet()
     last_start_time = compute_fleet["lastStatusUpdatedTime"]
     logging.info("Checking last status update time is updated")


### PR DESCRIPTION
### Description of changes
* [Test] Add a check on compute fleet status before we do another update.
Without this check we can see below failures
```

and output:
{
  "message": "Bad Request: Failed when starting compute fleet due to a concurrent update of the status. Please retry the operation."
}
```

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
