### PR TITLE
[Test] Fix issues causing intermittent test failures: test_efa, test_ad_integration, test_queue_parameters_update, test_slurm, test_multiple_efs

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -285,8 +285,8 @@ test-suites:
           instances: ["hpc6id.32xlarge"]
           oss: [{{ OS_X86_4 }}]
           schedulers: [ "slurm" ]
-        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
-          instances: [{{ common.instance("instance_type_1") }}]
+        - regions: ["eun1-az2"]  # do not move, unless instance type support is moved as well
+          instances: ["hpc6a.48xlarge"]
           oss: [{{ OS_X86_6 }}]
           schedulers: [ "slurm" ]
   ultraserver:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -409,7 +409,6 @@ def _setup_custom_logger(log_file):
 
 
 @pytest.fixture(scope="class")
-@pytest.mark.usefixtures("setup_credentials")
 def clusters_factory(request, region):
     """
     Define a fixture to manage the creation and destruction of clusters.
@@ -522,7 +521,6 @@ def api_client(region, api_server_factory, api_uri):
 
 
 @pytest.fixture(scope="class")
-@pytest.mark.usefixtures("setup_credentials")
 def images_factory(request):
     """
     Define a fixture to manage the creation and destruction of images.
@@ -949,7 +947,6 @@ def cfn_stacks_factory(request):
 
 
 @pytest.fixture()
-@pytest.mark.usefixtures("setup_credentials")
 def parameterized_cfn_stacks_factory(request):
     """Define a fixture that returns a parameterized stack factory and manages the stack creation and deletion."""
     factory = CfnStacksFactory(request.config.getoption("credential"))
@@ -1045,7 +1042,6 @@ def register_cli_credentials(initialize_cli_creds):
 
 
 @pytest.fixture(scope="class")
-@pytest.mark.usefixtures("clusters_factory", "images_factory")
 def create_roles_stack(request, region):
     """Define a fixture that returns a stack factory for IAM roles."""
     logging.info("Creating IAM roles stack")

--- a/tests/integration-tests/diagnosis_utils.py
+++ b/tests/integration-tests/diagnosis_utils.py
@@ -38,6 +38,11 @@ CMD_RETRIEVE_RECIPE_EXECUTION = (
 )
 PATTERN_IMDS_UNREACHABLE = r"cloud-init.*Timed out, no response from urls:.*169\.254\.169\.254"
 PATTERN_NETWORK_FAILURE = r"cloud-init.*Failed to establish a new connection"
+# Matches the chef-client.log block in the EC2 console output
+PATTERN_CHEF_CLIENT_LOG_BLOCK = re.compile(
+    r"[^\n]*BEGIN CHEF-CLIENT\.LOG[^\n]*.*?[^\n]*END CHEF-CLIENT\.LOG[^\n]*",
+    re.DOTALL,
+)
 
 
 def retrieve_console_errors(region, instance_id):
@@ -45,6 +50,8 @@ def retrieve_console_errors(region, instance_id):
     Retrieve error lines from the head node EC2 console output.
 
     Uses boto3 to fetch the latest console output and filters for error lines.
+    Also appends the full chef-client.log block when present, so RCA has the full chef run
+    context instead of just lines matching the generic failure pattern.
 
     :param region: AWS region of the cluster.
     :param instance_id: EC2 instance ID of the head node.
@@ -60,7 +67,14 @@ def retrieve_console_errors(region, instance_id):
         error_lines = [
             line for line in console_output.splitlines() if re.search(PATTERN_GENERIC_FAILURE, line, re.IGNORECASE)
         ]
-        return "\n".join(error_lines) if error_lines else "No error found"
+        sections = []
+        sections.append("\n".join(error_lines) if error_lines else "No error found")
+
+        chef_match = PATTERN_CHEF_CLIENT_LOG_BLOCK.search(console_output)
+        if chef_match:
+            sections.append(chef_match.group(0))
+
+        return "\n==========\n".join(sections)
     except Exception as e:
         logging.warning("Exception retrieving console output: %s", e)
         return f"Failed to retrieve console output: {e}"

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -426,8 +426,8 @@ def _check_ssh_key_generation(user, remote_command_executor, scheduler_commands,
 
     # Switch User - Interactive
     switch_user_commands = [
-        f"sudo su {user.alias} --command='ls {ssh_key_path}'",
-        f"sudo su - {user.alias} --command='ls {ssh_key_path}'",
+        f"sudo su {user.alias} --command='sleep 3 && ls {ssh_key_path}'",
+        f"sudo su - {user.alias} --command='sleep 3 && ls {ssh_key_path}'",
         # TODO: Checks for below commands are failing, even if a manual check on the same cluster succeeds.
         # We need to double check these failures, but we can consider them as not blocking.
         # f"sudo -u {user.alias} ls {ssh_key_path}",

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -17,6 +17,8 @@ from assertpy import assert_that
 from retrying import retry
 from time_utils import minutes, seconds
 
+from tests.common.utils import is_blank
+
 
 class SchedulerCommands(metaclass=ABCMeta):
     """Define common scheduler commands."""
@@ -398,17 +400,24 @@ class SlurmCommands(SchedulerCommands):
             if match_stdout:
                 stdout = match_stdout.group(1)
                 logging.info("stdout:" + stdout)
-        if stderr is not None or stdout is not None:
-            if stderr == stdout:
-                result = self._remote_command_executor.run_remote_command(f'echo "stderr/stdout:" && cat {stderr}')
+        dump_timeout = 60
+        if not is_blank(stderr) or not is_blank(stdout):
+            if not is_blank(stderr) and stderr == stdout:
+                result = self._remote_command_executor.run_remote_command(
+                    f'echo "stderr/stdout:" && cat {stderr}', timeout=dump_timeout
+                )
                 logging.error(result.stdout)
             else:
-                if stderr is not None:
-                    stderr_result = self._remote_command_executor.run_remote_command(f'echo "stderr" && cat {stderr}')
+                if not is_blank(stderr):
+                    stderr_result = self._remote_command_executor.run_remote_command(
+                        f'echo "stderr" && cat {stderr}', timeout=dump_timeout
+                    )
                     logging.error(stderr_result.stdout)
 
-                if stdout is not None:
-                    stdout_result = self._remote_command_executor.run_remote_command(f'echo "stdout" && cat {stdout}')
+                if not is_blank(stdout):
+                    stdout_result = self._remote_command_executor.run_remote_command(
+                        f'echo "stdout" && cat {stdout}', timeout=dump_timeout
+                    )
                     logging.error(stdout_result.stdout)
         else:
             logging.error("Unable to retrieve job output.")

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -304,6 +304,11 @@ def get_sts_endpoint(region):
     return "https://sts.{0}.{1}".format(region, get_aws_domain(region))
 
 
+def is_blank(value):
+    """Return True if the value is None or an empty/whitespace-only string."""
+    return value is None or value.strip() == ""
+
+
 def generate_random_string():
     """
     Generate a random prefix that is 16 characters long.

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1734,15 +1734,17 @@ def _wait_compute_cloudinit_done(remote_command_executor, compute_node):
     assert_that(compute_cloudinit_status_output).contains("status: done")
 
 
-def _assert_mpi_process_completion(
-    remote_command_executor, slurm_commands, num_nodes, after_completion, check_proc_file
-):
-    result = slurm_commands.submit_command(
-        f'ps aux | grep "mpiexec.hydra.*sleep" | grep -v "grep" >> {check_proc_file}', nodes=num_nodes
+def _assert_mpi_process_completion(remote_command_executor, num_nodes, after_completion):
+    proc_track_result = remote_command_executor.run_remote_command(
+        f'srun -N {num_nodes} bash -c \'ps aux | grep "mpiexec.hydra.*sleep" | grep -v "grep" || true\''
     )
-    job_id = slurm_commands.assert_job_submitted(result.stdout)
-    slurm_commands.wait_job_completed(job_id)
-    proc_track_result = remote_command_executor.run_remote_command(f"cat {check_proc_file}")
+    logging.info(
+        "MPI process check (after_completion=%s) on %d nodes:\nstdout:\n%s\nstderr:\n%s",
+        after_completion,
+        num_nodes,
+        proc_track_result.stdout,
+        proc_track_result.stderr,
+    )
     if after_completion:
         assert_that(proc_track_result.stdout).does_not_match(".*mpiexec.hydra.*sleep")
     else:
@@ -1751,13 +1753,8 @@ def _assert_mpi_process_completion(
 
 def _check_mpi_process(remote_command_executor, slurm_commands, num_nodes, after_completion):
     """Submit script and check for MPI processes."""
-    # Clean up old datafiles
-    check_proc_file = "/shared/check_proc.out"
-
-    # Check completion status of MPI process using the shared datafile
-    remote_command_executor.run_remote_command(f"rm -f {check_proc_file}")
     retry(wait_fixed=seconds(10), stop_max_attempt_number=4)(_assert_mpi_process_completion)(
-        remote_command_executor, slurm_commands, num_nodes, after_completion, check_proc_file
+        remote_command_executor, num_nodes, after_completion
     )
 
 

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -250,8 +250,8 @@ def write_file_into_efs(
         package_update: true
         package_upgrade: true
         runcmd:
-        - yum install -y nfs-utils
-        - yum install -y amazon-efs-utils
+        - dnf install -y nfs-utils
+        - dnf install -y amazon-efs-utils
         {write_file_user_data}
         - opt/aws/bin/cfn-signal -e $? --stack ${{AWS::StackName}} --resource InstanceToWriteEFS --region ${{AWS::Region}}
         """  # noqa: E501
@@ -296,7 +296,7 @@ def write_file_into_efs(
         Instance(
             "InstanceToWriteEFS",
             CreationPolicy={"ResourceSignal": {"Timeout": "PT10M"}},
-            ImageId=retrieve_latest_ami(region, "alinux2"),
+            ImageId=retrieve_latest_ami(region, "alinux2023"),
             InstanceType="c5.xlarge",
             LaunchTemplate=LaunchTemplateSpecification(
                 LaunchTemplateId=Ref(launch_template), Version=GetAtt(launch_template, "LatestVersionNumber")


### PR DESCRIPTION
### Description of changes
Fixed issues causing intermittent failures on the following tests:
* `test_efa`: Replaced hpc5a.48xlarge on us-east-2 with hpc6a.48xlarge on eu-north-1 to reduce the risk of insufficient capacity exceptions.
* `test_ad_integration`: Fixed a race condition in the SSH key generation check by adding a sleep before the ls command inside the switch-user session, giving the PAM hook time to finish generating the user's SSH key and avoiding sporadic "Permission denied" failures.
* `test_queue_parameters_update`: Prevented the test from hanging indefinitely when dumping job output, caused by a weak condition and the lack of an SSH timeout. Hangs in this test could also trigger the watchdog to kill unrelated tests sharing the same VPC.
* `test_multiple_efs`: Switched the auxiliary instance that writes EFS data from AL2 to AL2023. AL2 reaches end of life in June 2026, and AL2023 should provide a more robust networking driver bootstrap, preventing the sporadic networking failures observed in this test.
* `test_slurm`: Removed an unnecessary dependency on NFS shared storage by replacing the shared-file round-trip with an srun that streams output back directly. NFS cross-client visibility is already covered by storage-specific tests and was just noise here.

Also, included the following improvements:
1. the RCA retrieval by including the chef client log captured in the head node console logs.
2. removed redundant use of fixture marks to make our tests able to run with pytest 8+ which is the version pulled in when we run the test with python 3.10+

### Tests
* SUCCESS `test_efa`
* SUCCESS `test_ad_integration`
* SUCCESS `test_queue_parameters_update`
* SUCCESS `test_slurm`
* SUCCESS `test_multiple_efs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
