### PR TITLE
[Test] In test_build_image, use flexible instance types to reduce the risk of ICEs.

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
@@ -19,4 +19,6 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource1
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}


### PR DESCRIPTION
### Description of changes
In test_build_image, use flexible instance types to reduce the risk of ICEs.

### Tests
SUCCESS `test_build_image`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
