### PR TITLE
[Test] In test_dcv_configuration, tolerate intermittent crashes on GNOME Tracker Suite (tracker-store)

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -48,8 +48,8 @@ UNTOLERATED_CRASH_PATTERNS = [
 TOLERATED_CRASH_PATTERNS = [
     # gnome-software segfaults in libadwaita related to animated scrolling of UI widget, observed on RHEL9/Rocky9
     re.compile(r"gnome-software.*scroll_to \(libadwaita", re.DOTALL),
-    # tracker-miner-fs-3 and tracker-extract crash on Ubuntu/RHEL — GNOME file indexer, unrelated to DCV
-    re.compile(r"tracker-(miner|extract)", re.DOTALL),
+    # tracker-miner-fs-3, tracker-extract, and tracker-store crash on Ubuntu/RHEL — GNOME file indexer, unrelated to DCV
+    re.compile(r"tracker-(miner|extract|store)", re.DOTALL),
 ]
 
 DIAGNOSIS_SCRIPT_DIR = Path(__file__).resolve().parent.parent / "common" / "diagnosis"


### PR DESCRIPTION
### Description of changes
In test_dcv_configuration, tolerate intermittent crashes on GNOME Tracker Suite (tracker-store), as they are harmless crashes not related to either ParallelCluster or DCV.

### Tests
This is an intermittent failure, not deterministically reproducible. 
The change is only additive to a regex so no need to run another round of test for this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
