### PR TITLE
[Update] Fix race condition in login nodes load balancer lookup causing cluster update failure in clusters with login nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **CHANGES**
 - The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`, 
   consistent with the existing limit for `Database`. This prevents runtime failures caused by MySQL's table name length limit.
+- The CLI now requires the additional permission `tag:GetResources`.
 
 **BUG FIXES**
 - Fix sporadic S3 bucket (with name parallelcluster-*-v1-do-not-delete) creation failure when multiple create-cluster commands are running simultaneously in the same region.
@@ -14,6 +15,8 @@ CHANGELOG
   via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 - Fix clustermgtd failing to detect compute node bootstrap timeouts, which prevented the cluster from entering protected mode.
+- Fix race condition in load balancer lookup by using `tag:GetResources` to resolve load balancer ARNs by tags, 
+  which used to cause cluster update failure on clusters with login nodes.
 
 3.15.0
 ------

--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -22,6 +22,7 @@ from pcluster.aws.imagebuilder import ImageBuilderClient
 from pcluster.aws.kms import KmsClient
 from pcluster.aws.logs import LogsClient
 from pcluster.aws.resource_groups import ResourceGroupsClient
+from pcluster.aws.resource_groups_tagging_api import ResourceGroupsTaggingApiClient
 from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
@@ -63,6 +64,7 @@ class AWSApi:
         self._secretsmanager = None
         self._ssm = None
         self._resource_groups = None
+        self._resource_groups_tagging_api = None
 
     @property
     def cfn(self):
@@ -189,6 +191,13 @@ class AWSApi:
         if not self._resource_groups:
             self._resource_groups = ResourceGroupsClient()
         return self._resource_groups
+
+    @property
+    def resource_groups_tagging_api(self):
+        """Resource Groups Tagging API client."""
+        if not self._resource_groups_tagging_api:
+            self._resource_groups_tagging_api = ResourceGroupsTaggingApiClient()
+        return self._resource_groups_tagging_api
 
     @staticmethod
     def instance():

--- a/cli/src/pcluster/aws/elb.py
+++ b/cli/src/pcluster/aws/elb.py
@@ -41,6 +41,15 @@ class ElbClient(Boto3Client):
         return response["LoadBalancers"], response.get("NextMarker")
 
     @AWSExceptionHandler.handle_client_exception
+    def describe_load_balancer(self, load_balancer_arn: str) -> Any:
+        """Retrieve the load balancer matching the given ARN, or None if not found."""
+        if not load_balancer_arn:
+            return None
+        response = self._client.describe_load_balancers(LoadBalancerArns=[load_balancer_arn])
+        load_balancers = response.get("LoadBalancers", [])
+        return load_balancers[0] if load_balancers else None
+
+    @AWSExceptionHandler.handle_client_exception
     def describe_tags(self, load_balancer_arns: []):
         """Retrieve a list of tags associated to the load balancer arns provided as parameter."""
         """You can specify up to 20 load balancer arns in a single call."""

--- a/cli/src/pcluster/aws/resource_groups_tagging_api.py
+++ b/cli/src/pcluster/aws/resource_groups_tagging_api.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict, List
+
+from pcluster.aws.common import AWSExceptionHandler, Boto3Client
+
+
+class ResourceGroupsTaggingApiClient(Boto3Client):
+    """Implement Resource Groups Tagging API Boto3 client."""
+
+    def __init__(self):
+        super().__init__("resourcegroupstaggingapi")
+
+    @AWSExceptionHandler.handle_client_exception
+    def get_resources(self, tag_filters: Dict[str, str], resource_type_filters: List[str] = None) -> List[str]:
+        """
+        Return a list of resource ARNs matching the given tag filters and resource type filters.
+
+        :param tag_filters: dictionary of tag key/value pairs that resources must match (AND semantics).
+        :param resource_type_filters: list of resource type filters (e.g. ["elasticloadbalancing:loadbalancer"]).
+        :return: list of resource ARNs matching the filters.
+        """
+        arns = []
+        kwargs = {
+            "TagFilters": [{"Key": key, "Values": [value]} for key, value in tag_filters.items()],
+        }
+        if resource_type_filters:
+            kwargs["ResourceTypeFilters"] = resource_type_filters
+
+        pagination_tkn = ""
+        while True:
+            if pagination_tkn:
+                kwargs["PaginationToken"] = pagination_tkn
+            response = self._client.get_resources(**kwargs)
+            arns.extend(resource["ResourceARN"] for resource in response.get("ResourceTagMappingList", []))
+            pagination_tkn = response.get("PaginationToken", "")
+            if not pagination_tkn:
+                break
+        return arns

--- a/cli/src/pcluster/models/login_nodes_status.py
+++ b/cli/src/pcluster/models/login_nodes_status.py
@@ -12,7 +12,6 @@ import logging
 from enum import Enum
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.utils import get_chunks
 
 LOGGER = logging.getLogger(__name__)
 
@@ -83,37 +82,21 @@ class PoolStatus:
             self._populate_target_group_health()
 
     def _retrieve_assigned_load_balancer(self):
-        load_balancers = AWSApi.instance().elb.list_load_balancers()
-        tags_list = self._retrieve_all_tags([o.get("LoadBalancerArn") for o in load_balancers])
-        self._load_balancer_arn_from_tags(tags_list)
-        if self._load_balancer_arn:
-            for load_balancer in load_balancers:
-                if load_balancer.get("LoadBalancerArn") == self._load_balancer_arn:
-                    self._map_status(load_balancer.get("State").get("Code"))
-                    self._dns_name = load_balancer.get("DNSName")
-                    self._scheme = load_balancer.get("Scheme")
-                    break
-
-    def _load_balancer_arn_from_tags(self, tags_list):
-        for tags in tags_list:
-            if self._key_value_tag_found(
-                tags, "parallelcluster:cluster-name", self._stack_name
-            ) and self._key_value_tag_found(tags, "parallelcluster:login-nodes-pool", self._pool_name):
-                self._load_balancer_arn = tags.get("ResourceArn")
-                break
-
-    def _key_value_tag_found(self, tags, key, value):
-        if any(key == kv.get("Key") and kv.get("Value") == value for kv in tags.get("Tags")):
-            return True
-        return False
-
-    def _retrieve_all_tags(self, load_balancers):
-        tags = []
-        if len(load_balancers) > 0:
-            chunks = get_chunks(load_balancers)
-            for chunk in chunks:
-                tags.extend(AWSApi.instance().elb.describe_tags(chunk))
-        return tags
+        load_balancer_arns = AWSApi.instance().resource_groups_tagging_api.get_resources(
+            tag_filters={
+                "parallelcluster:cluster-name": self._stack_name,
+                "parallelcluster:login-nodes-pool": self._pool_name,
+            },
+            resource_type_filters=["elasticloadbalancing:loadbalancer"],
+        )
+        if not load_balancer_arns:
+            return
+        self._load_balancer_arn = load_balancer_arns[0]
+        load_balancer = AWSApi.instance().elb.describe_load_balancer(self._load_balancer_arn)
+        if load_balancer:
+            self._map_status(load_balancer.get("State").get("Code"))
+            self._dns_name = load_balancer.get("DNSName")
+            self._scheme = load_balancer.get("Scheme")
 
     def _map_status(self, load_balancer_state):
         if load_balancer_state == "provisioning":

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -24,6 +24,7 @@ from pcluster.aws.imagebuilder import ImageBuilderClient
 from pcluster.aws.kms import KmsClient
 from pcluster.aws.logs import LogsClient
 from pcluster.aws.resource_groups import ResourceGroupsClient
+from pcluster.aws.resource_groups_tagging_api import ResourceGroupsTaggingApiClient
 from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
@@ -112,6 +113,7 @@ class _DummyAWSApi(AWSApi):
         self._ddb_resource = _DummyDynamoResource()
         self._route53 = _DummyRoute53Client()
         self._resource_groups = _DummyResourceGroupsClient()
+        self._resource_groups_tagging_api = _DummyResourceGroupsTaggingApiClient()
         self._secretsmanager = _DummySecretsManagerClient()
         self._ssm = _DummySsmClient()
 
@@ -388,6 +390,16 @@ class _DummyResourceGroupsClient(ResourceGroupsClient):
             if group != "skip_dummy"
             else super().get_capacity_reservation_ids_from_group_resources(group)
         )
+
+
+class _DummyResourceGroupsTaggingApiClient(ResourceGroupsTaggingApiClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+        pass
+
+    def get_resources(self, tag_filters, resource_type_filters=None):
+        """Return an empty list of resource ARNs by default."""
+        return []
 
 
 class _DummySecretsManagerClient(SecretsManagerClient):

--- a/cli/tests/pcluster/aws/test_elb.py
+++ b/cli/tests/pcluster/aws/test_elb.py
@@ -192,3 +192,56 @@ def test_describe_target_health(boto3_stubber, generate_error):
     else:
         return_value = ElbClient().describe_target_health(dummy_target_arn)
         assert_that(return_value).is_equal_to(dummy_targets_health)
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_describe_load_balancer(boto3_stubber, generate_error):
+    """Verify that describe_load_balancer behaves as expected."""
+    dummy_load_balancer_arn = "dummy_load_balancer_arn"
+    dummy_message = "dummy error message"
+    dummy_load_balancer = {
+        "LoadBalancerArn": dummy_load_balancer_arn,
+        "DNSName": "dummy_dns_name",
+        "LoadBalancerName": "dummy-load-balancer",
+        "Scheme": "internet-facing",
+        "State": {"Code": "active"},
+    }
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_load_balancers",
+            expected_params={"LoadBalancerArns": [dummy_load_balancer_arn]},
+            response=(
+                dummy_message if generate_error else {"LoadBalancers": [dummy_load_balancer], "ResponseMetadata": {}}
+            ),
+            generate_error=generate_error,
+        )
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    if generate_error:
+        with pytest.raises(BaseException, match=dummy_message):
+            ElbClient().describe_load_balancer(dummy_load_balancer_arn)
+    else:
+        return_value = ElbClient().describe_load_balancer(dummy_load_balancer_arn)
+        assert_that(return_value).is_equal_to(dummy_load_balancer)
+
+
+def test_describe_load_balancer_not_found(boto3_stubber):
+    """Verify that describe_load_balancer returns None when the API returns no load balancers."""
+    dummy_load_balancer_arn = "dummy_load_balancer_arn"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_load_balancers",
+            expected_params={"LoadBalancerArns": [dummy_load_balancer_arn]},
+            response={"LoadBalancers": [], "ResponseMetadata": {}},
+            generate_error=False,
+        )
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    assert_that(ElbClient().describe_load_balancer(dummy_load_balancer_arn)).is_none()
+
+
+def test_describe_load_balancer_empty_arn(mocker):
+    """Verify that describe_load_balancer short-circuits to None when no ARN is provided, without calling the API."""
+    mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
+    assert_that(ElbClient().describe_load_balancer(None)).is_none()
+    assert_that(ElbClient().describe_load_balancer("")).is_none()

--- a/cli/tests/pcluster/aws/test_resource_groups_tagging_api.py
+++ b/cli/tests/pcluster/aws/test_resource_groups_tagging_api.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'LICENSE.txt' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.aws.resource_groups_tagging_api import ResourceGroupsTaggingApiClient
+from tests.utils import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.aws.common.boto3"
+
+
+def test_get_resources_returns_matching_arns(boto3_stubber):
+    """Verify get_resources builds the correct request and returns ARNs from the response."""
+    dummy_arn_1 = "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cluster-1/a"
+    dummy_arn_2 = "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cluster-1/b"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [
+                    {"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]},
+                    {"Key": "parallelcluster:login-nodes-pool", "Values": ["login"]},
+                ],
+                "ResourceTypeFilters": ["elasticloadbalancing:loadbalancer"],
+            },
+            response={
+                "ResourceTagMappingList": [
+                    {"ResourceARN": dummy_arn_1},
+                    {"ResourceARN": dummy_arn_2},
+                ],
+                "ResponseMetadata": {},
+            },
+            generate_error=False,
+        )
+    ]
+    boto3_stubber("resourcegroupstaggingapi", mocked_requests)
+
+    return_value = ResourceGroupsTaggingApiClient().get_resources(
+        tag_filters={
+            "parallelcluster:cluster-name": "cluster-1",
+            "parallelcluster:login-nodes-pool": "login",
+        },
+        resource_type_filters=["elasticloadbalancing:loadbalancer"],
+    )
+    assert_that(return_value).is_equal_to([dummy_arn_1, dummy_arn_2])
+
+
+def test_get_resources_without_resource_type_filter(boto3_stubber):
+    """Verify get_resources omits ResourceTypeFilters when not provided."""
+    dummy_arn = "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cluster-1/a"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [
+                    {"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]},
+                ],
+            },
+            response={
+                "ResourceTagMappingList": [{"ResourceARN": dummy_arn}],
+                "ResponseMetadata": {},
+            },
+            generate_error=False,
+        )
+    ]
+    boto3_stubber("resourcegroupstaggingapi", mocked_requests)
+
+    return_value = ResourceGroupsTaggingApiClient().get_resources(
+        tag_filters={"parallelcluster:cluster-name": "cluster-1"}
+    )
+    assert_that(return_value).is_equal_to([dummy_arn])
+
+
+def test_get_resources_follows_pagination(boto3_stubber):
+    """Verify get_resources follows pagination tokens and aggregates ARNs across pages."""
+    dummy_arn_1 = "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cluster-1/a"
+    dummy_arn_2 = "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cluster-1/b"
+    dummy_token = "next-page-token"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [{"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]}],
+                "ResourceTypeFilters": ["elasticloadbalancing:loadbalancer"],
+            },
+            response={
+                "ResourceTagMappingList": [{"ResourceARN": dummy_arn_1}],
+                "PaginationToken": dummy_token,
+                "ResponseMetadata": {},
+            },
+            generate_error=False,
+        ),
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [{"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]}],
+                "ResourceTypeFilters": ["elasticloadbalancing:loadbalancer"],
+                "PaginationToken": dummy_token,
+            },
+            response={
+                "ResourceTagMappingList": [{"ResourceARN": dummy_arn_2}],
+                "ResponseMetadata": {},
+            },
+            generate_error=False,
+        ),
+    ]
+    boto3_stubber("resourcegroupstaggingapi", mocked_requests)
+
+    return_value = ResourceGroupsTaggingApiClient().get_resources(
+        tag_filters={"parallelcluster:cluster-name": "cluster-1"},
+        resource_type_filters=["elasticloadbalancing:loadbalancer"],
+    )
+    assert_that(return_value).is_equal_to([dummy_arn_1, dummy_arn_2])
+
+
+def test_get_resources_empty_response(boto3_stubber):
+    """Verify get_resources returns an empty list when the API returns no matching resources."""
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [{"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]}],
+                "ResourceTypeFilters": ["elasticloadbalancing:loadbalancer"],
+            },
+            response={"ResourceTagMappingList": [], "ResponseMetadata": {}},
+            generate_error=False,
+        )
+    ]
+    boto3_stubber("resourcegroupstaggingapi", mocked_requests)
+
+    return_value = ResourceGroupsTaggingApiClient().get_resources(
+        tag_filters={"parallelcluster:cluster-name": "cluster-1"},
+        resource_type_filters=["elasticloadbalancing:loadbalancer"],
+    )
+    assert_that(return_value).is_equal_to([])
+
+
+def test_get_resources_error(boto3_stubber):
+    """Verify get_resources propagates a wrapped error when the API call fails."""
+    dummy_message = "dummy error message"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_resources",
+            expected_params={
+                "TagFilters": [{"Key": "parallelcluster:cluster-name", "Values": ["cluster-1"]}],
+                "ResourceTypeFilters": ["elasticloadbalancing:loadbalancer"],
+            },
+            response=dummy_message,
+            generate_error=True,
+        )
+    ]
+    boto3_stubber("resourcegroupstaggingapi", mocked_requests)
+
+    with pytest.raises(BaseException, match=dummy_message):
+        ResourceGroupsTaggingApiClient().get_resources(
+            tag_filters={"parallelcluster:cluster-name": "cluster-1"},
+            resource_type_filters=["elasticloadbalancing:loadbalancer"],
+        )

--- a/cli/tests/pcluster/models/test_login_nodes_status.py
+++ b/cli/tests/pcluster/models/test_login_nodes_status.py
@@ -32,55 +32,6 @@ class TestLoginNodesStatus:
         "Scheme": dummy_scheme_2,
         "State": {"Code": dummy_status},
     }
-    dummy_load_balancer_3 = {
-        "LoadBalancerArn": "dummy_load_balancer_arn_3",
-        "DNSName": "dummy_dns_name_3",
-        "LoadBalancerName": "dummy-load-balancer-3",
-        "Scheme": dummy_scheme_2,
-        "State": {"Code": "provisioning"},
-    }
-
-    dummy_tags_description = [
-        {
-            "ResourceArn": dummy_load_balancer_arn_1,
-            "Tags": [
-                {
-                    "Key": "parallelcluster:cluster-name",
-                    "Value": dummy_stack_name,
-                },
-                {
-                    "Key": "parallelcluster:login-nodes-pool",
-                    "Value": dummy_pool_name_1,
-                },
-            ],
-        },
-        {
-            "ResourceArn": dummy_load_balancer_arn_2,
-            "Tags": [
-                {
-                    "Key": "parallelcluster:cluster-name",
-                    "Value": dummy_stack_name,
-                },
-                {
-                    "Key": "parallelcluster:login-nodes-pool",
-                    "Value": dummy_pool_name_2,
-                },
-            ],
-        },
-        {
-            "ResourceArn": "another_dummy_load_balancer_arn",
-            "Tags": [
-                {
-                    "Key": "parallelcluster:cluster-name",
-                    "Value": "pcluster-name-2",
-                },
-                {
-                    "Key": "parallelcluster:login-nodes-pool",
-                    "Value": "dummy_pool_name_3",
-                },
-            ],
-        },
-    ]
 
     dummy_target_groups = [
         {
@@ -128,13 +79,50 @@ class TestLoginNodesStatus:
         },
     ]
 
-    def test_full_login_nodes_status(self, mocker):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
+    @staticmethod
+    def _mock_tagging_api(mocker, arn_by_pool):
+        """Mock the resource groups tagging api so it returns the NLB ARN for each pool."""
         mocker.patch(
-            "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2, self.dummy_load_balancer_3],
+            "pcluster.aws.resource_groups_tagging_api.ResourceGroupsTaggingApiClient.__init__", return_value=None
         )
-        mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
+
+        def get_resources(tag_filters, resource_type_filters=None):
+            pool_name = tag_filters.get("parallelcluster:login-nodes-pool")
+            arn = arn_by_pool.get(pool_name)
+            return [arn] if arn else []
+
+        mocker.patch(
+            "pcluster.aws.resource_groups_tagging_api.ResourceGroupsTaggingApiClient.get_resources",
+            side_effect=get_resources,
+        )
+
+    @staticmethod
+    def _mock_describe_load_balancer(mocker, load_balancers_by_arn):
+        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
+
+        def describe_load_balancer(arn):
+            return load_balancers_by_arn.get(arn)
+
+        mocker.patch(
+            "pcluster.aws.elb.ElbClient.describe_load_balancer",
+            side_effect=describe_load_balancer,
+        )
+
+    def test_full_login_nodes_status(self, mocker):
+        self._mock_tagging_api(
+            mocker,
+            {
+                self.dummy_pool_name_1: self.dummy_load_balancer_arn_1,
+                self.dummy_pool_name_2: self.dummy_load_balancer_arn_2,
+            },
+        )
+        self._mock_describe_load_balancer(
+            mocker,
+            {
+                self.dummy_load_balancer_arn_1: self.dummy_load_balancer_1,
+                self.dummy_load_balancer_arn_2: self.dummy_load_balancer_2,
+            },
+        )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
 
@@ -173,38 +161,28 @@ class TestLoginNodesStatus:
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_no_load_balancers_available(self, mocker):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        mocker.patch("pcluster.aws.elb.ElbClient.list_load_balancers", return_value=[])
-        login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
-        assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
-
-    def test_wrong_load_balancer_available(self, mocker):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        mocker.patch("pcluster.aws.elb.ElbClient.list_load_balancers", return_value=[self.dummy_load_balancer_2])
-        dummy_tags_description = [
-            {
-                "ResourceArn": "another_dummy_load_balancer_arn",
-                "Tags": [
-                    {
-                        "Key": self.dummy_load_balancer_arn_2,
-                        "Value": "pcluster-name-2",
-                    },
-                ],
-            },
-        ]
-        mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=dummy_tags_description)
+        # The tagging API returns no ARNs for any pool (e.g. cluster not yet created or already deleted).
+        self._mock_tagging_api(mocker, {})
+        self._mock_describe_load_balancer(mocker, {})
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
         login_nodes_status.retrieve_data([self.dummy_pool_name_1, self.dummy_pool_name_2])
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_target_group_arn_not_available(self, mocker):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        mocker.patch(
-            "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2, self.dummy_load_balancer_3],
+        self._mock_tagging_api(
+            mocker,
+            {
+                self.dummy_pool_name_1: self.dummy_load_balancer_arn_1,
+                self.dummy_pool_name_2: self.dummy_load_balancer_arn_2,
+            },
         )
-        mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
+        self._mock_describe_load_balancer(
+            mocker,
+            {
+                self.dummy_load_balancer_arn_1: self.dummy_load_balancer_1,
+                self.dummy_load_balancer_arn_2: self.dummy_load_balancer_2,
+            },
+        )
         mocker.patch(
             "pcluster.aws.elb.ElbClient.describe_target_groups", side_effect=Exception("Target Group Not Available")
         )
@@ -215,12 +193,20 @@ class TestLoginNodesStatus:
         assert_that(login_nodes_status.get_unhealthy_nodes()).is_equal_to(0)
 
     def test_target_group_health_not_available(self, mocker):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        mocker.patch(
-            "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=[self.dummy_load_balancer_1, self.dummy_load_balancer_2],
+        self._mock_tagging_api(
+            mocker,
+            {
+                self.dummy_pool_name_1: self.dummy_load_balancer_arn_1,
+                self.dummy_pool_name_2: self.dummy_load_balancer_arn_2,
+            },
         )
-        mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
+        self._mock_describe_load_balancer(
+            mocker,
+            {
+                self.dummy_load_balancer_arn_1: self.dummy_load_balancer_1,
+                self.dummy_load_balancer_arn_2: self.dummy_load_balancer_2,
+            },
+        )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch(
             "pcluster.aws.elb.ElbClient.describe_target_health", side_effect=Exception("Target Group Not Available")
@@ -241,28 +227,23 @@ class TestLoginNodesStatus:
         ],
     )
     def test_login_nodes_pool_state(self, mocker, load_balancer_status, expected_status):
-        mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
-        dummy_load_balancers = [
+        dummy_load_balancer_1 = {**self.dummy_load_balancer_1, "State": {"Code": load_balancer_status}}
+        dummy_load_balancer_2 = {**self.dummy_load_balancer_2, "State": {"Code": load_balancer_status}}
+
+        self._mock_tagging_api(
+            mocker,
             {
-                "LoadBalancerArn": self.dummy_load_balancer_arn_1,
-                "DNSName": self.dummy_dns_name_1,
-                "LoadBalancerName": "dummy-load-balancer-1",
-                "Scheme": self.dummy_scheme_1,
-                "State": {"Code": load_balancer_status},
+                self.dummy_pool_name_1: self.dummy_load_balancer_arn_1,
+                self.dummy_pool_name_2: self.dummy_load_balancer_arn_2,
             },
-            {
-                "LoadBalancerArn": self.dummy_load_balancer_arn_2,
-                "DNSName": self.dummy_dns_name_2,
-                "LoadBalancerName": "dummy-load-balancer-2",
-                "Scheme": self.dummy_scheme_2,
-                "State": {"Code": load_balancer_status},
-            },
-        ]
-        mocker.patch(
-            "pcluster.aws.elb.ElbClient.list_load_balancers",
-            return_value=dummy_load_balancers,
         )
-        mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=self.dummy_tags_description)
+        self._mock_describe_load_balancer(
+            mocker,
+            {
+                self.dummy_load_balancer_arn_1: dummy_load_balancer_1,
+                self.dummy_load_balancer_arn_2: dummy_load_balancer_2,
+            },
+        )
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
@@ -276,3 +257,48 @@ class TestLoginNodesStatus:
 
         assert_that(pool_1_status.get_status()).is_equal_to(expected_status)
         assert_that(pool_2_status.get_status()).is_equal_to(expected_status)
+
+    def test_tagging_api_called_with_expected_filters(self, mocker):
+        """Verify the tag filters and resource type filter passed to the Resource Groups Tagging API."""
+        mocker.patch(
+            "pcluster.aws.resource_groups_tagging_api.ResourceGroupsTaggingApiClient.__init__", return_value=None
+        )
+        get_resources_mock = mocker.patch(
+            "pcluster.aws.resource_groups_tagging_api.ResourceGroupsTaggingApiClient.get_resources",
+            return_value=[],
+        )
+        self._mock_describe_load_balancer(mocker, {})
+
+        LoginNodesStatus(self.dummy_stack_name).retrieve_data([self.dummy_pool_name_1])
+
+        get_resources_mock.assert_called_once_with(
+            tag_filters={
+                "parallelcluster:cluster-name": self.dummy_stack_name,
+                "parallelcluster:login-nodes-pool": self.dummy_pool_name_1,
+            },
+            resource_type_filters=["elasticloadbalancing:loadbalancer"],
+        )
+
+    def test_load_balancer_deleted_between_tag_lookup_and_describe(self, mocker):
+        """Race where the NLB is deleted between the tagging lookup and describe_load_balancer.
+
+        The tagging API returns an ARN, but the subsequent describe_load_balancer returns None because the NLB
+        no longer exists. The pool should still be considered available (ARN was found) but without status/DNS info.
+        """
+        self._mock_tagging_api(
+            mocker,
+            {self.dummy_pool_name_1: self.dummy_load_balancer_arn_1},
+        )
+        # describe_load_balancer returns None for this ARN, simulating a concurrent deletion.
+        self._mock_describe_load_balancer(mocker, {})
+        mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
+        mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
+
+        login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
+        login_nodes_status.retrieve_data([self.dummy_pool_name_1])
+
+        pool_status = login_nodes_status.get_pool_status_dict().get(self.dummy_pool_name_1)
+        assert_that(pool_status.get_pool_available()).is_true()
+        assert_that(pool_status.get_status()).is_none()
+        assert_that(pool_status.get_address()).is_none()
+        assert_that(pool_status.get_scheme()).is_none()

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -589,6 +589,11 @@ Resources:
             Effect: Allow
             Sid: ResourceGroupRead
           - Action:
+              - tag:GetResources
+            Resource: '*'
+            Effect: Allow
+            Sid: ResourceGroupsTaggingApiRead
+          - Action:
               - autoscaling:DeleteAutoScalingGroup
               - autoscaling:DeleteLifecycleHook
               - autoscaling:DescribeAutoScalingGroups

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -510,6 +510,11 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead
+          - Action:
+              - tag:GetResources
+            Resource: '*'
+            Effect: Allow
+            Sid: ResourceGroupsTaggingApiRead
           - Action: "secretsmanager:GetSecretValue"
             Resource: !Sub arn:${AWS::Partition}:secretsmanager:${Region}:${AWS::AccountId}:secret:*
             Effect: Allow


### PR DESCRIPTION
### Description of changes
Fix race condition in login nodes load balancer lookup causing cluster update failure in clusters with login nodes.

With this change we now retrieve the load balancer for a given login node pool with a single call tp the Resource Groups Tagging API, instead of listing all account NLBs and filtering by tags.

The previous approach could fail sporadically when a concurrent cluster operation deleted another NLB between list_load_balancers and describe_tags.

This change requires the CLI user to have the extra permission `tag:GetResources`.

### Tests
1. Manually verified that the describe-cluster works as usual, retrieving the login node details. This operation triggers the changed code.
1. SUCCESS `test_create_disable_sudo_access_for_default_user `. This test makes use of this change and it was the test that detected the race condition we are fixing in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
