### PR TITLE
[Test] Check for active export tasks only

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -393,7 +393,9 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, use_pcluster_
 
     # test without a prefix or output file
     wait_for_no_active_export_tasks(cluster.region)
-    ret = cluster.export_logs(bucket=bucket_name if not use_pcluster_bucket else None)
+    ret = retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(cluster.export_logs)(
+        bucket=bucket_name if not use_pcluster_bucket else None
+    )
     assert_that(ret).contains_key("url")
     filename = ret["url"].split(".tar.gz")[0].split("/")[-1] + ".tar.gz"
     archive_found = True

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -704,24 +704,23 @@ def upload_github_artifacts_to_s3(bucket_name, region, request):
 def wait_for_no_active_export_tasks(region):
     """Wait until there are no active CloudWatch Logs export tasks in the region.
 
-    CloudWatch Logs allows only one export task per region at a time. This function
-    polls until any running or pending export task completes, preventing conflicts with
-    subsequent export calls.
-    See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
+    Each account can only have one active (RUNNING or PENDING) export task per region at a time.
+    This function uses the statusCode filter to query only active tasks server-side,
+    preventing conflicts with subsequent export calls and avoiding pagination through
+    years of completed historical tasks.
+    See: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateExportTask.html
     """
-    active_statuses = {"RUNNING", "PENDING", "PENDING_CANCEL"}
+    logging.info("Starting the check for active export tasks in region %s", region)
+    active_statuses = ("RUNNING", "PENDING")
     logs_client = boto3.client("logs", region_name=region)
-    paginator = logs_client.get_paginator("describe_export_tasks")
     max_wait = 300  # 5 minutes
     poll_interval = 10
     elapsed = 0
     while elapsed < max_wait:
-        active_tasks = [
-            task
-            for page in paginator.paginate()
-            for task in page.get("exportTasks", [])
-            if task.get("status", {}).get("code") in active_statuses
-        ]
+        active_tasks = []
+        for status_code in active_statuses:
+            response = logs_client.describe_export_tasks(statusCode=status_code)
+            active_tasks.extend(response.get("exportTasks", []))
         if not active_tasks:
             logging.info("No active export tasks in region %s", region)
             return


### PR DESCRIPTION

### Description of changes

Check for active export tasks only
* We look for RUNNING and PENDING tasks only as there are ~19K historical export tasks with varying statuses which we loop through.
* Add a retry mechanism for exporting logs


### Tests
* test_slurm_cli_commands

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
