### PR TITLE
[Test] Add end2end test to validate SLURM Rest API.

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -561,6 +561,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
+    test_slurm_rest_api.py::test_slurm_rest_api:
+      dimensions:
+        - regions: [ "eu-north-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [{{ OS_X86_0 }}]
+          schedulers: [ "slurm" ]
   spot:
     test_spot.py::test_spot_default:
       dimensions:

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -477,3 +477,17 @@ def assert_regex_in_file(rce: RemoteCommandExecutor, file_name: str, pattern: st
     file_content = read_remote_file(rce, file_name)
     assertion = assert_that(bool(re.search(pattern, file_content, re.IGNORECASE)))
     assertion.is_false() if negate else assertion.is_true()
+
+
+def assert_systemd_service_running(remote_command_executor: RemoteCommandExecutor, service_name: str):
+    """Assert that a systemd service is in the 'running' sub-state."""
+    logging.info("Checking that %s systemd service is running", service_name)
+    result = remote_command_executor.run_remote_command(
+        f"sudo systemctl show {service_name} --property=SubState | cut -d= -f2",
+        raise_on_error=False,
+        pty=False,  # Disable PTY to avoid ANSI escape codes in the output
+    )
+    assert_that(result.return_code).is_equal_to(0)
+    assert_that(result.stdout.strip()).described_as(
+        f"Expected systemd service {service_name} to be running"
+    ).is_equal_to("running")

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import json
+import logging
+import re
+
+import boto3
+import pytest
+from assertpy import assert_that, soft_assertions
+from remote_command_executor import RemoteCommandExecutor
+from utils import to_snake_case
+
+from tests.common.assertions import assert_systemd_service_running
+
+# slurmrestd listens on this unix socket when configured via the upstream postinstall script
+# (aws-samples/aws-parallelcluster-post-install-scripts/rest-api).
+SLURMRESTD_SOCKET = "/var/spool/socket/slurmrestd.sock"
+
+REBUILD_SCRIPT_NAME = "rebuild_slurm.sh"
+CONFIGURE_SCRIPT_NAME = "configure_slurmrestd.sh"
+SLURM_REST_API_RB_NAME = "slurm_rest_api.rb"
+
+
+def _get_slurm_database_config_parameters(database_stack_outputs):
+    keys = ["DatabaseHost", "DatabaseAdminUser", "DatabaseSecretArn", "DatabaseClientSecurityGroup"]
+    return {to_snake_case(key): database_stack_outputs.get(key) for key in keys}
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_slurm_rest_api(
+    region,
+    pcluster_config_reader,
+    s3_bucket_factory,
+    vpc_stack_for_database,
+    database,
+    clusters_factory,
+    test_datadir,
+):
+    """Verify that the Slurm REST API (slurmrestd) is functional on a cluster where it is enabled."""
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / REBUILD_SCRIPT_NAME), f"scripts/{REBUILD_SCRIPT_NAME}")
+    bucket.upload_file(str(test_datadir / CONFIGURE_SCRIPT_NAME), f"scripts/{CONFIGURE_SCRIPT_NAME}")
+    bucket.upload_file(str(test_datadir / SLURM_REST_API_RB_NAME), f"scripts/{SLURM_REST_API_RB_NAME}")
+
+    rebuild_slurm_script_uri = f"s3://{bucket_name}/scripts/{REBUILD_SCRIPT_NAME}"
+    configure_slurmrestd_script_uri = f"s3://{bucket_name}/scripts/{CONFIGURE_SCRIPT_NAME}"
+    slurm_rest_api_rb_uri = f"s3://{bucket_name}/scripts/{SLURM_REST_API_RB_NAME}"
+
+    database_params = _get_slurm_database_config_parameters(database.cfn_outputs)
+    public_subnet_id = vpc_stack_for_database.get_public_subnet()
+    private_subnet_id = vpc_stack_for_database.get_private_subnet()
+
+    cluster_config = pcluster_config_reader(
+        public_subnet_id=public_subnet_id,
+        private_subnet_id=private_subnet_id,
+        bucket_name=bucket_name,
+        rebuild_slurm_script_uri=rebuild_slurm_script_uri,
+        configure_slurmrestd_script_uri=configure_slurmrestd_script_uri,
+        slurm_rest_api_rb_uri=slurm_rest_api_rb_uri,
+        **database_params,
+    )
+    cluster = clusters_factory(cluster_config)
+
+    rce = RemoteCommandExecutor(cluster)
+
+    with soft_assertions():
+        assert_systemd_service_running(rce, "slurmrestd")
+        _assert_slurmrestd_endpoint_responsive(rce, "ping")
+
+
+def _slurmrestd_request(rce, url_path, raise_on_error=True):
+    """Send an authenticated request to slurmrestd and return the parsed JSON response."""
+    cmd = (
+        "set -e; "
+        "TOKEN=$(sudo -u slurm /opt/slurm/bin/scontrol token lifespan=600 | awk -F= '{print $2}'); "
+        "USER=$(id -un); "
+        f"sudo curl -sS --unix-socket {SLURMRESTD_SOCKET} "
+        f'-H "X-SLURM-USER-TOKEN: ${{TOKEN}}" '
+        f'-H "X-SLURM-USER-NAME: ${{USER}}" '
+        f"http://localhost{url_path}"
+    )
+    result = rce.run_remote_command(cmd, raise_on_error=raise_on_error)
+    assert_that(result.return_code).described_as(
+        f"slurmrestd request to {url_path} failed. stderr={result.stderr}"
+    ).is_equal_to(0)
+    try:
+        return json.loads(result.stdout)
+    except ValueError as exc:
+        raise AssertionError(f"slurmrestd {url_path} did not return valid JSON: {result.stdout!r}") from exc
+
+
+def _get_slurm_api_version(rce):
+    """Query the slurmrestd OpenAPI spec to discover the latest available slurm API version."""
+    logging.info("Discovering slurmrestd API version from /openapi/v3")
+    spec = _slurmrestd_request(rce, "/openapi/v3")
+    paths = spec.get("paths", {}).keys()
+    # Extract version strings from paths like /slurm/v0.0.44/ping
+    versions = {m.group(1) for p in paths for m in [re.search(r"/slurm/(v\d+\.\d+\.\d+)/", p)] if m}
+    assert_that(versions).described_as("No slurm API versions found in /openapi/v3").is_not_empty()
+    latest = sorted(versions, key=lambda v: list(map(int, v.lstrip("v").split("."))))[-1]
+    logging.info("Detected slurmrestd API version: %s", latest)
+    return latest
+
+
+def _assert_slurmrestd_endpoint_responsive(rce, endpoint):
+    """
+    Hit a slurmrestd endpoint (e.g. ping, diag) from the head node using a JWT token
+    generated via `scontrol token`, and assert the response is a valid JSON document
+    reporting no errors.
+    """
+    slurm_api_version = _get_slurm_api_version(rce)
+    logging.info("Calling slurmrestd endpoint /slurm/%s/%s", slurm_api_version, endpoint)
+    payload = _slurmrestd_request(rce, f"/slurm/{slurm_api_version}/{endpoint}")
+
+    errors = payload.get("errors", [])
+    assert_that(errors).described_as(f"slurmrestd /{endpoint} returned errors: {errors}").is_empty()
+
+    warnings = payload.get("warnings", [])
+    assert_that(warnings).described_as(f"slurmrestd /{endpoint} returned warnings: {warnings}").is_empty()
+
+    pings = payload.get("pings", [])
+    assert_that(pings).described_as(f"slurmrestd /{endpoint} returned no pings").is_not_empty()
+    assert_that(pings[0].get("pinged")).described_as(
+        f"slurmrestd /{endpoint} ping status is not UP: {pings[0]}"
+    ).is_equal_to("UP")

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/configure_slurmrestd.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/configure_slurmrestd.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# OnNodeConfigured custom action for the test_slurm_rest_api integration test.
+#
+# Based on the upstream Slurm REST API postinstall script:
+#   https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/rest-api/postinstall.sh
+#
+# Differences from upstream:
+#   - Uses a local slurm_rest_api.rb (uploaded to S3 by the test) instead of downloading
+#     it from GitHub. The local copy includes an `apt-get update` before installing nginx
+#     on Debian/Ubuntu to avoid stale package index 404 errors.
+#
+# Arguments:
+#   $1 - S3 URI of the adapted slurm_rest_api.rb (e.g. s3://bucket/scripts/slurm_rest_api.rb)
+
+set -ex
+
+SLURM_REST_API_RB_S3_URI="${1:?Usage: configure_slurmrestd.sh <s3-uri-of-slurm_rest_api.rb>}"
+
+# Copy Slurm REST API configuration files and scripts
+tmp_dir=/tmp/slurm_rest_api
+mkdir -p $tmp_dir
+
+source_path=https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/rest-api
+files=(slurmrestd.service nginx.conf)
+for file in "${files[@]}"
+do
+    wget -qO- $source_path/$file > $tmp_dir/$file
+done
+
+rotate_jwt_path=/opt/parallelcluster/scripts/rotate_jwt.sh
+wget -qO- $source_path/rotate_jwt.sh > $rotate_jwt_path
+chmod +x $rotate_jwt_path
+
+# Download the adapted slurm_rest_api.rb from S3
+aws s3 cp "${SLURM_REST_API_RB_S3_URI}" $tmp_dir/slurm_rest_api.rb
+
+# Setup Slurm REST API
+sudo cinc-client \
+  --local-mode \
+  --config /etc/chef/client.rb \
+  --log_level auto \
+  --force-formatter \
+  --chef-zero-port 8889 \
+  -j /etc/chef/dna.json \
+  -z $tmp_dir/slurm_rest_api.rb

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/pcluster.config.yaml
@@ -1,0 +1,42 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+    AdditionalSecurityGroups:
+      - {{ database_client_security_group }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:{{ partition }}:iam::aws:policy/SecretsManagerReadWrite # Required to read/write the JWT token from Secrets Manager
+    S3Access:
+      - BucketName: {{ bucket_name }} # Required to download custom actions
+  Ssh:
+    KeyName: {{ key_name }}
+  CustomActions:
+    OnNodeStart:
+      Script: {{ rebuild_slurm_script_uri }}
+    OnNodeConfigured:
+      Script: {{ configure_slurmrestd_script_uri }}
+      Args:
+        - "{{ slurm_rest_api_rb_uri }}"
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmSettings:
+    Database:
+      Uri: {{ database_host }}
+      UserName: {{ database_admin_user }}
+      PasswordSecretArn: {{ database_secret_arn }}
+  SlurmQueues:
+    - Name: q1
+      ComputeResources:
+        - Name: cr1
+          Instances:
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
+          MinCount: 0
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/rebuild_slurm.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/rebuild_slurm.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# OnNodeStart custom action for the test_slurm_rest_api integration test.
+#
+# Rebuilds the Slurm installation shipped with ParallelCluster adding the http-parser
+# plugin so that slurmrestd is actually functional. Intentionally scoped to the build
+# step only: no Slurm service is started, no configuration file is touched.
+#
+# Steps:
+#   1. Uninstall the existing Slurm installation.
+#   2. Install http-parser from local sources.
+#   3. Reconfigure Slurm with `--with-http-parser=/usr/local/` and `--enable-slurmrestd`
+#      and reinstall.
+
+set -ex
+
+LOG_PREFIX="[rebuild_slurm]"
+SLURM_PREFIX="/opt/slurm"
+
+function log() { echo "${LOG_PREFIX} $*"; }
+function fail() { echo "${LOG_PREFIX} ERROR: $*" >&2; exit 1; }
+
+# Find a single directory matching a pattern under a base path.
+function find_dir() {
+  local base="$1" depth="$2" pattern="$3"
+  local result
+  result=$(find "${base}" -maxdepth "${depth}" -type d -name "${pattern}" 2>/dev/null | head -n1)
+  [ -n "${result}" ] || fail "${pattern} not found under ${base}"
+  echo "${result}"
+}
+
+log "Capturing installed Slurm version before rebuild"
+pre_rebuild_version=$(${SLURM_PREFIX}/sbin/slurmd --version | awk '{print $2}')
+[ -n "${pre_rebuild_version}" ] || fail "Could not determine the Slurm version from slurmd"
+log "Installed Slurm version before rebuild: ${pre_rebuild_version}"
+
+slurm_src_dir=$(find_dir /etc/chef/local-mode-cache/cache 1 'slurm-slurm-*')
+log "Using Slurm sources at ${slurm_src_dir}"
+
+cd "${slurm_src_dir}"
+
+COOKBOOK_VENV=$(find_dir /opt/parallelcluster/pyenv/versions 3 cookbook_virtualenv)
+
+log "Activating cookbook virtualenv at ${COOKBOOK_VENV}"
+source "${COOKBOOK_VENV}/bin/activate"
+
+log "Uninstalling current Slurm installation"
+make uninstall
+
+# Install http-parser from local sources into /usr/lib64 (AL2023 only)
+if grep -q "Amazon Linux 2023" /etc/os-release; then
+  log "Installing http-parser from local sources"
+  http_parser_src=$(find_dir /opt/parallelcluster/sources 1 'http-parser-*')
+  log "Using http-parser sources at ${http_parser_src}"
+  make -C "${http_parser_src}" PREFIX=/usr/local uninstall || true
+  make -C "${http_parser_src}"
+  make -C "${http_parser_src}" PREFIX=/usr LIBDIR=/usr/lib64 install
+fi
+
+log "Reconfiguring Slurm with http-parser and slurmrestd"
+./configure --prefix=${SLURM_PREFIX} \
+            --with-pmix=/opt/pmix \
+            --with-jwt=/opt/libjwt \
+            --with-http-parser=/usr \
+            --enable-slurmrestd
+
+CORES=$(grep -c ^processor /proc/cpuinfo)
+log "Rebuilding Slurm using ${CORES} cores"
+make -j "${CORES}"
+make install
+make install-contrib
+
+deactivate
+
+# Sanity-check that the http-parser plugin is now linked against libhttp_parser.
+ldd ${SLURM_PREFIX}/lib/slurm/http_parser_libhttp_parser.so | grep http_parser
+
+# Sanity-check that the rebuild installed the exact same Slurm version.
+log "Verifying the rebuilt Slurm version matches the source version"
+post_rebuild_version=$(${SLURM_PREFIX}/sbin/slurmd --version | awk '{print $2}')
+[ "${post_rebuild_version}" = "${pre_rebuild_version}" ] || fail "Slurm version mismatch after rebuild: before=${pre_rebuild_version} after=${post_rebuild_version}"
+log "Slurm ${post_rebuild_version} reinstalled successfully"

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/slurm_rest_api.rb
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/slurm_rest_api.rb
@@ -1,0 +1,195 @@
+# Adapted from the upstream aws-samples/aws-parallelcluster-post-install-scripts recipe:
+#   https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/rest-api/slurm_rest_api.rb
+#
+# Changes from upstream:
+#   - Run `apt-get update` before installing nginx on Debian/Ubuntu to avoid stale package
+#     index 404 errors.
+
+slurm_etc = '/opt/slurm/etc'
+slurm_conf = "#{slurm_etc}/slurm.conf"
+slurmdbd_conf = "#{slurm_etc}/slurmdbd.conf"
+socket_location = '/var/spool/socket'
+state_save_location = '/var/spool/slurm.state'
+key_location = "#{state_save_location}/jwt_hs256.key"
+token_name = "slurm_token_#{node['cluster']['stack_name']}"
+token_lifespan = 1800
+id = 2005
+
+if node['cluster']['node_type'] != 'HeadNode'
+  raise "Slurm REST API post-install script must be run on a HeadNode"
+end
+
+if !::File.exist?(slurmdbd_conf)
+  raise "#{slurmdbd_conf} not found. Slurm accounting may need to be enabled to use the Slurm REST API."
+end
+
+# Configure Slurm for JWT authentication
+ruby_block 'Create JWT key file' do
+  block do
+    shell_out!("dd if=/dev/random of=#{key_location} bs=32 count=1")
+  end
+end
+
+file key_location do
+  owner 'slurm'
+  group 'slurm'
+  mode '0600'
+end
+
+directory state_save_location do
+  owner 'slurm'
+  group 'slurm'
+  mode '0755'
+end
+
+ruby_block 'Add JWT configuration to slurm.conf' do
+  block do
+    file = Chef::Util::FileEdit.new(slurm_conf)
+    file.insert_line_after_match(/AuthType=*/, "AuthAltParameters=jwt_key=#{key_location}")
+    file.insert_line_after_match(/AuthType=*/, "AuthAltTypes=auth/jwt")
+    file.write_file
+  end
+  not_if "grep -q auth/jwt #{slurm_conf}"
+end
+
+ruby_block 'Add JWT configuration to slurmdbd.conf' do
+  block do
+    file = Chef::Util::FileEdit.new(slurmdbd_conf)
+    file.insert_line_after_match(/AuthType=*/, "AuthAltParameters=jwt_key=#{key_location}")
+    file.insert_line_after_match(/AuthType=*/, "AuthAltTypes=auth/jwt")
+    file.write_file
+  end
+  not_if "grep -q auth/jwt #{slurmdbd_conf}"
+end
+
+service 'slurmctld' do
+  action :restart
+end
+
+service 'slurmdbd' do
+  action :restart
+end
+
+ruby_block 'Generate JWT token and create/update AWS secret' do
+  block do
+
+    jwt_token = shell_out!("/opt/slurm/bin/scontrol token \
+      lifespan=#{token_lifespan} \
+      | grep -oP '^SLURM_JWT\\s*\\=\\s*\\K(.+)'").run_command.stdout
+
+    begin
+      shell_out!("aws secretsmanager create-secret \
+        --name #{token_name} \
+        --region #{node['cluster']['region']} \
+        --secret-string #{jwt_token}"
+      ).run_command
+      Chef::Log.warn("Created secret #{token_name}. This must be deleted manually on cluster deletion.")
+    rescue
+      shell_out!("aws secretsmanager update-secret \
+        --secret-id #{token_name} \
+        --region #{node['cluster']['region']} \
+        --secret-string #{jwt_token}"
+      ).run_command
+    end
+  end
+end
+
+cron 'rotate JWT token' do
+  minute '*/20'
+  command "/opt/parallelcluster/scripts/rotate_jwt.sh #{token_name} #{node['cluster']['region']} #{token_lifespan}"
+end
+
+# NGINX installation and configuration
+# On Debian/Ubuntu, refresh the package index first to avoid 404 errors from stale cached
+# package versions that have been superseded in the upstream repositories.
+execute 'apt-get update' do
+  command 'apt-get update'
+  only_if { platform_family?('debian') }
+end
+
+package 'nginx' do
+  action :install
+end
+
+ruby_block 'Generate self-signed key' do
+  block do
+    shell_out!("sudo openssl req -x509 -nodes -days 36500 -newkey rsa:2048 \
+      -keyout /etc/ssl/certs/nginx-selfsigned.key \
+      -out /etc/ssl/certs/nginx-selfsigned.crt \
+      -subj ""/CN=#{node['cluster']['stack_name']}"""
+    ).run_command
+  end
+end
+
+group 'nginx' do
+  comment 'nginx group'
+  gid id + 1
+  system true
+end
+
+user 'nginx' do
+  comment 'nginx user'
+  uid id + 1
+  gid id + 1
+  system true
+end
+
+file '/etc/nginx/nginx.conf' do
+  owner 'nginx'
+  group 'nginx'
+  mode '0644'
+  content ::File.open('/tmp/slurm_rest_api/nginx.conf').read
+end
+
+service 'nginx' do
+  action :start
+end
+
+# Enable slurmrestd
+group 'slurmrestd' do
+  comment 'slurmrestd group'
+  gid id
+  system true
+end
+
+user 'slurmrestd' do
+  comment 'slurmrestd user'
+  uid id
+  gid id
+  system true
+end
+
+directory socket_location do
+  owner 'nginx'
+  group 'nginx'
+  mode '0777'
+end
+
+file '/etc/systemd/system/slurmrestd.service' do
+  owner 'slurmrestd'
+  group 'slurmrestd'
+  mode '0644'
+  content ::File.open('/tmp/slurm_rest_api/slurmrestd.service').read
+end
+
+service 'slurmrestd' do
+  action :start
+end
+
+ruby_block 'Wait for slurmrestd' do
+  block do
+    iter=0
+    until ::File.exists?("#{socket_location}/slurmrestd.sock") || iter > 20 do
+      sleep 1
+      iter += 1
+    end
+    raise "Timeout waiting for slurmrestd startup" unless iter < 20
+  end
+end
+
+ruby_block 'Modify socket permissions' do
+  notifies :start, 'service[slurmrestd]', :before
+  block do
+    shell_out!("chmod 0666 #{socket_location}/slurmrestd.sock").run_command
+  end
+end


### PR DESCRIPTION
### Description of changes
Add end2end test to validate SLURM Rest API.
The cluster requires two custom actions:
* OnNodestart action: this is required to patch the SLURM installation so that slurmrestd can start. Without this patching action, slurmrestd would fail because it cannot find http-parser, which ia a required dependency.
* OnNodeConfigured action: this is the "standard" way to enable the SLURM Rest API, taken from the public AWS example.

the test validates that:
1. slurmrestd is running
2. SLIURM API is functional, by sending a request to the `ping` endpoint and checking the result is healthy. 

### Tests
SUCCESS `test_slurm_rest_api`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
