### PR TITLE
[Test] In test_build_image, use flexible instance types to reduce the risk of ICEs.

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
@@ -19,4 +19,6 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource1
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}


### PR DESCRIPTION
### Description of changes
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/7358
Tested in source PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
