### PR TITLE
[GH] Replace snap with apt-get in GitHub workflows to prevent impact from snap outages.

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -37,7 +37,7 @@ jobs:
         java-version: 11
     - run: |
         sudo npm install -g redoc-cli
-        sudo snap install yq
+        sudo apt-get install yq
     - name: Modifiy Code to Change version
       run: ./util/bump-version.sh  --version ${{ inputs.pcluster-version }}
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           java-version: 11
       - run: |
           sudo npm install -g redoc-cli
-          sudo snap install yq
+          sudo apt-get install yq
       - working-directory: api
         run: ./gradlew buildSmithyModel openApiValidate redoc
       - name: Verify Generation of OpenAPI Specs


### PR DESCRIPTION
### Description of changes
Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/7366

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
