### PR TITLE
[GH] In GitHub Worklows install yq from GitHub release rather than snap store to workaround snap store outages

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -37,7 +37,7 @@ jobs:
         java-version: 11
     - run: |
         sudo npm install -g redoc-cli
-        sudo snap install yq
+        sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
     - name: Modifiy Code to Change version
       run: ./util/bump-version.sh  --version ${{ inputs.pcluster-version }}
         

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -37,7 +37,7 @@ jobs:
         java-version: 11
     - run: |
         sudo npm install -g redoc-cli
-        sudo apt-get install yq
+        sudo snap install yq
     - name: Modifiy Code to Change version
       run: ./util/bump-version.sh  --version ${{ inputs.pcluster-version }}
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           java-version: 11
       - run: |
           sudo npm install -g redoc-cli
-          sudo snap install yq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
       - working-directory: api
         run: ./gradlew buildSmithyModel openApiValidate redoc
       - name: Verify Generation of OpenAPI Specs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           java-version: 11
       - run: |
           sudo npm install -g redoc-cli
-          sudo apt-get install yq
+          sudo snap install yq
       - working-directory: api
         run: ./gradlew buildSmithyModel openApiValidate redoc
       - name: Verify Generation of OpenAPI Specs


### PR DESCRIPTION
### Description of changes
In GitHub Worklows install yq from GitHub release rather than snap store to workaround snap store outages

This reverts commit eb9cc133c5667b07772115b51c21d32b2abb4e0b.
We must revert this commit because we need a specific flavour of yq, which is vended by snap store but not in apt-get.

We now install the required flavor of yq from the github releases rather than snap store to unblock the Gh workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
