### PR TITLE
[Test] Fix flexible instance type selection to match GPU spec per manufacturer

### DIFF
--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1016,6 +1016,16 @@ def or_regex(items: list):
     return "|".join(map(re.escape, items))
 
 
+def _get_gpu_spec(instance_type_data):
+    """Return the GPU configuration as a frozenset of (manufacturer, count) pairs.
+
+    This captures the full GPU structure so that instances match only when they have
+    the same count for each manufacturer (e.g. NVIDIA:1 won't match NVIDIA:0).
+    """
+    gpu_info = instance_type_data.get("GpuInfo", {})
+    return frozenset((gpu.get("Manufacturer", ""), gpu.get("Count", 0)) for gpu in gpu_info.get("Gpus", []))
+
+
 def get_similar_instance_types(instance_type: str, region: str = None, max_items: int = None):
     ec2 = boto3.client("ec2", region_name=region)
 
@@ -1030,7 +1040,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     target_vcpus = target["VCpuInfo"]["DefaultVCpus"]
     target_threads = target["VCpuInfo"]["DefaultThreadsPerCore"]
     target_has_efa = target.get("NetworkInfo", {}).get("EfaSupported", False)
-    target_has_gpu = "GpuInfo" in target
+    target_gpu_spec = _get_gpu_spec(target)
     target_inference_accelerators = target.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
 
     # Now query for similar instances using filters
@@ -1045,16 +1055,16 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
             {"Name": "supported-usage-class", "Values": ["on-demand", "spot"]},
         ],
     ):
-        # Filter for EFA support, GPU presence, and inference accelerator types
+        # Filter for EFA support, GPU configuration, and inference accelerator types
         for instance in page["InstanceTypes"]:
             instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
-            instance_has_gpu = "GpuInfo" in instance
+            instance_gpu_spec = _get_gpu_spec(instance)
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
                 instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
                 and instance_has_efa == target_has_efa
-                and instance_has_gpu == target_has_gpu
+                and instance_gpu_spec == target_gpu_spec
                 and instance_inference_accelerators == target_inference_accelerators
             ):
                 similar_instances.append(instance["InstanceType"])


### PR DESCRIPTION
### Description of changes
Fix flexible instance type selection to match GPU spec per manufacturer.

Before this fix the test fails cluster creation with error:

```
- Validation Failures:
	* ERROR - InstancesAcceleratorsValidator:
		Instance types listed under Compute Resource compute-resource1 must have the same number of GPUs ({'g4dn.2xlarge': 1, 'g6f.2xlarge': 0}).
```

### Tests
ONGOING `test_build_image`
Manually verified that the function is now able to determine the correct flexible instance types. In particular, `g6f.2xlarge` is not returned in the list of equivalent instance types anymore:

```
python get-similar-instance-types.py g4dn.2xlarge us-east-1 20

Found 5 similar instance types for g4dn.2xlarge:
  g5.2xlarge
  g7e.2xlarge
  g6.2xlarge
  g6e.2xlarge
  g4dn.2xlarge

aws ec2 describe-instance-types --region us-east-1 --instance-types g4dn.2xlarge g5.2xlarge g7e.2xlarge g6.2xlarge g6e.2xlarge --query 'InstanceTypes[].{InstanceType:InstanceType,GpuInfo:GpuInfo}' --output json 
[
    {
        "InstanceType": "g5.2xlarge",
        "GpuInfo": {
            "Gpus": [
                {
                    "Name": "A10G",
                    "Manufacturer": "NVIDIA",
                    "Count": 1,
                    "MemoryInfo": {
                        "SizeInMiB": 22888
                    }
                }
            ],
            "TotalGpuMemoryInMiB": 22888
        }
    },
    {
        "InstanceType": "g6.2xlarge",
        "GpuInfo": {
            "Gpus": [
                {
                    "Name": "L4",
                    "Manufacturer": "NVIDIA",
                    "Count": 1,
                    "MemoryInfo": {
                        "SizeInMiB": 22888
                    }
                }
            ],
            "TotalGpuMemoryInMiB": 22888
        }
    },
    {
        "InstanceType": "g7e.2xlarge",
        "GpuInfo": {
            "Gpus": [
                {
                    "Name": "RTX PRO Server 6000",
                    "Manufacturer": "NVIDIA",
                    "Count": 1,
                    "MemoryInfo": {
                        "SizeInMiB": 98304
                    }
                }
            ],
            "TotalGpuMemoryInMiB": 98304
        }
    },
    {
        "InstanceType": "g6e.2xlarge",
        "GpuInfo": {
            "Gpus": [
                {
                    "Name": "L40S",
                    "Manufacturer": "NVIDIA",
                    "Count": 1,
                    "MemoryInfo": {
                        "SizeInMiB": 45776
                    }
                }
            ],
            "TotalGpuMemoryInMiB": 45776
        }
    },
    {
        "InstanceType": "g4dn.2xlarge",
        "GpuInfo": {
            "Gpus": [
                {
                    "Name": "T4",
                    "Manufacturer": "NVIDIA",
                    "Count": 1,
                    "MemoryInfo": {
                        "SizeInMiB": 16384
                    }
                }
            ],
            "TotalGpuMemoryInMiB": 16384
        }
    }
]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
