### PR TITLE
[Test] Add test runner option `--retain-on-failure` to retain tests on failure

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -45,7 +45,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--no-delete] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run]
                       [--iam-user-role-stack-name IAM_USER_ROLE_STACK_NAME] [--directory-stack-name DIRECTORY_STACK_NAME] [--slurm-database-stack-name SLURM_DATABASE_STACK_NAME] [--slurm-dbd-stack-name SLURM_DBD_STACK_NAME] [--munge-key-secret-arn MUNGE_KEY_SECRET_ARN]
                       [--external-shared-storage-stack-name EXTERNAL_SHARED_STORAGE_STACK_NAME] [--bucket-name BUCKET_NAME] [--custom-security-groups-stack-name CUSTOM_SECURITY_GROUPS_STACK_NAME] [--force-run-instances] [--force-elastic-ip] [--retain-ad-stack] [--proxy-stack PROXY_STACK]
-                      [--build-image-roles-stack BUILD_IMAGE_ROLES_STACK] [--api-stack API_STACK]
+                      [--build-image-roles-stack BUILD_IMAGE_ROLES_STACK] [--api-stack API_STACK] [--retain-on-failure N] 
 
 Run integration tests suite.
 
@@ -164,6 +164,8 @@ Debugging/Development options:
                         Name of an existing vpc stack. (default: None)
   --cluster CLUSTER     Use an existing cluster instead of creating one. (default: None)
   --no-delete           Don't delete stacks after tests are complete. (default: False)
+  --retain-on-failure N Retain cluster, VPC, IAM, and S3 bucket stacks for up to N failing tests
+                        (0=disabled, max 5). (default: 0)
   --delete-logs-on-success
                         delete CloudWatch logs when a test succeeds (default: False)
   --stackname-suffix STACKNAME_SUFFIX
@@ -496,6 +498,16 @@ This preserves any stacks created for the test:
 python -m test_runner \
   ...
   --no-delete
+```
+
+Alternatively, use `--retain-on-failure N` to only preserve resources when a test fails.
+This is useful in CI where you want automatic cleanup on success but need the stacks
+available for debugging on failure. Resources are retained for up to N failing tests (max 5):
+
+```bash
+python -m test_runner \
+  ...
+  --retain-on-failure 1
 ```
 
 Then when you have a vpc stack and cluster, reference them when starting a test:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -41,7 +41,13 @@ from conftest_markers import (
 )
 from conftest_networking import unmarshal_az_override
 from conftest_tests_config import apply_cli_dimensions_filtering, parametrize_from_config, remove_disabled_tests
-from conftest_utils import add_filename_markers, get_reporting_region
+from conftest_utils import (
+    add_filename_markers,
+    get_reporting_region,
+    is_region_retained,
+    register_retained_stack,
+    retain_resources_on_teardown,
+)
 from constants import SCHEDULERS_SUPPORTING_IMDS_SECURED, NodeType
 from filelock import FileLock
 from framework.credential_providers import aws_credential_provider, register_cli_credentials_for_region
@@ -171,6 +177,12 @@ def pytest_addoption(parser):
         "--no-delete", action="store_true", default=False, help="Don't delete stacks after tests are complete."
     )
     parser.addoption(
+        "--retain-on-failure",
+        type=int,
+        default=0,
+        help="Retain cluster, VPC, IAM, and S3 bucket stacks for up to N failing tests (0=disabled, max 5).",
+    )
+    parser.addoption(
         "--retain-ad-stack", action="store_true", default=False, help="Retain AD stack and corresponding VPC stack."
     )
     parser.addoption("--benchmarks", action="store_true", default=False, help="enable benchmark tests")
@@ -262,6 +274,11 @@ def pytest_generate_tests(metafunc):
 
 def pytest_configure(config):
     """This hook is called for every plugin and initial conftest file after command line options have been parsed."""
+    # Validate --retain-on-failure range
+    retain_on_failure = config.getoption("retain_on_failure", default=0)
+    if retain_on_failure < 0 or retain_on_failure > 5:
+        raise pytest.UsageError("--retain-on-failure must be between 0 and 5")
+
     # read tests config file if used
     if config.getoption("tests_config_file", None):
         config.option.tests_config = read_config_file(config.getoption("tests_config_file"), config=config)
@@ -441,12 +458,15 @@ def clusters_factory(request, region):
         return cluster
 
     yield _cluster_factory
-    if not request.config.getoption("no_delete"):
+    if not retain_resources_on_teardown(request, scope="class"):
         try:
             test_passed = request.node.rep_call.passed
         except AttributeError:
             test_passed = False
         factory.destroy_all_clusters(test_passed=test_passed)
+    else:
+        for cluster in factory._ClustersFactory__created_clusters.values():
+            register_retained_stack(request, cluster.cfn_stack_arn)
 
 
 @pytest.fixture(scope="class")
@@ -936,14 +956,20 @@ def cfn_stacks_factory(request):
     """Define a fixture to manage the creation and destruction of CloudFormation stacks."""
     factory = CfnStacksFactory(request.config.getoption("credential"))
     yield factory
-    if not request.config.getoption("no_delete"):
-        excluded_stacks = []
-        if request.config.getoption("retain_ad_stack"):
-            excluded_stacks.extend(["vpc", "SimpleAD", "MicrosoftAD"])
-            logging.warning("Skipping deletion of AD and VPC stacks because --retain-ad-stack option is set")
-        factory.delete_all_stacks(excluded_stacks)
-    else:
+    if request.config.getoption("no_delete"):
         logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
+        return
+    excluded_stacks = []
+    if request.config.getoption("retain_ad_stack"):
+        excluded_stacks.extend(["vpc", "SimpleAD", "MicrosoftAD"])
+        logging.warning("Skipping deletion of AD and VPC stacks because --retain-ad-stack option is set")
+    if request.config.getoption("retain_on_failure"):
+        for stack in factory._CfnStacksFactory__created_stacks.values():
+            if is_region_retained(request, stack.region):
+                excluded_stacks.append(stack.name)
+                register_retained_stack(request, stack.cfn_stack_id)
+                logging.warning("Retaining stack %s because a test in region %s was retained", stack.name, stack.region)
+    factory.delete_all_stacks(excluded_stacks)
 
 
 @pytest.fixture()
@@ -1028,10 +1054,19 @@ def initialize_cli_creds(request):
 
         yield cli_creds
 
-        if not request.config.getoption("no_delete"):
-            stack_factory.delete_all_stacks()
-        else:
+        if request.config.getoption("no_delete"):
             logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
+        elif request.config.getoption("retain_on_failure"):
+            for stack in stack_factory._CfnStacksFactory__created_stacks.values():
+                if is_region_retained(request, stack.region):
+                    register_retained_stack(request, stack.cfn_stack_id)
+                    logging.warning(
+                        "Retaining IAM stack %s because a test in region %s was retained", stack.name, stack.region
+                    )
+                else:
+                    stack_factory.delete_stack(stack.name, stack.region)
+        else:
+            stack_factory.delete_all_stacks()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -1135,6 +1170,8 @@ def s3_bucket_factory(request, region):
     for bucket in created_buckets:
         if request.config.getoption("no_delete"):
             logging.info(f"Not deleting S3 bucket {bucket[0]}")
+        elif request.config.getoption("retain_on_failure") and is_region_retained(request, bucket[1]):
+            logging.info(f"Not deleting S3 bucket {bucket[0]} because a test in region {bucket[1]} was retained")
         else:
             logging.info(f"Deleting S3 bucket {bucket[0]}")
             try:
@@ -1178,6 +1215,8 @@ def s3_bucket_factory_shared(request):
     for bucket in created_buckets:
         if request.config.getoption("no_delete"):
             logging.info(f"Not deleting S3 bucket {bucket[0]}")
+        elif request.config.getoption("retain_on_failure") and is_region_retained(request, bucket[1]):
+            logging.info(f"Not deleting S3 bucket {bucket[0]} because a test in region {bucket[1]} was retained")
         else:
             logging.info(f"Deleting S3 bucket {bucket[0]}")
             try:

--- a/tests/integration-tests/conftest_runtest_hooks.py
+++ b/tests/integration-tests/conftest_runtest_hooks.py
@@ -76,6 +76,13 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     setattr(item, "rep_" + rep.when, rep)
 
     if rep.when in ["setup", "call"] and rep.failed:
+        # Track failures at the session level so fixtures with a scope larger than "function"
+        # can decide whether to retain resources when --retain-on-failure is set.
+        failed_tests = getattr(item.session, "_pcluster_failed_tests", None)
+        if failed_tests is None:
+            failed_tests = set()
+            item.session._pcluster_failed_tests = failed_tests
+        failed_tests.add(item.nodeid)
         # TODO clean this up to not use the exception info here.  Reassigning the
         # call to setup messes up timestamps for setup vs call.  For now this will
         # count setup errors in the call phase as failures. We should probably make this

--- a/tests/integration-tests/conftest_utils.py
+++ b/tests/integration-tests/conftest_utils.py
@@ -13,6 +13,7 @@
 import logging
 import os
 import re
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List
@@ -356,3 +357,164 @@ def get_reporting_region(region: str):
         (region for partition, region in REPORTING_REGION_MAP.items() if partition == curr_partition),
         DEFAULT_REPORTING_REGION,
     )
+
+
+def _any_test_failed_in_session(request):
+    """Return True if any test in the session has recorded a failure (used for scope>function fixtures)."""
+    return bool(getattr(request.session, "_pcluster_failed_tests", None))
+
+
+def _current_test_failed(request):
+    """Return True if the current test item has failed during setup or call phases."""
+    for phase in ("setup", "call"):
+        rep = getattr(request.node, f"rep_{phase}", None)
+        if rep is not None and rep.failed:
+            return True
+    return False
+
+
+def _get_retain_counter_path(request):
+    """Return the path to the shared file used to track retained test failures across xdist workers.
+
+    The file is placed in the parent of output_dir to ensure it is shared across regions,
+    since each region gets its own output_dir subdirectory.
+    """
+    output_dir = request.config.getoption("output_dir", default=tempfile.gettempdir())
+    # output_dir is typically <base>/OUT_DIR/<region>; go up to the base so all regions share the file
+    parent_dir = os.path.dirname(output_dir) if output_dir else tempfile.gettempdir()
+    return os.path.join(parent_dir, ".retain_on_failure_tests")
+
+
+def _get_retained_stacks_path(request):
+    """Return the path to the file listing stack names that should not be deleted by cleanup."""
+    output_dir = request.config.getoption("output_dir", default=tempfile.gettempdir())
+    parent_dir = os.path.dirname(output_dir) if output_dir else tempfile.gettempdir()
+    return os.path.join(parent_dir, ".retained_stacks")
+
+
+def register_retained_stack(request, stack_arn):
+    """Register a stack ARN as retained so the Jenkins cleanup script skips it."""
+    stacks_path = _get_retained_stacks_path(request)
+    lock_path = stacks_path + ".lock"
+
+    with FileLock(lock_path):
+        if os.path.exists(stacks_path):
+            with open(stacks_path, "r") as f:
+                retained_stacks = set(line.strip() for line in f if line.strip())
+        else:
+            retained_stacks = set()
+
+        retained_stacks.add(stack_arn)
+        with open(stacks_path, "w") as f:
+            f.write("\n".join(retained_stacks) + "\n")
+
+    logging.info("Registered stack %s for retention", stack_arn)
+
+
+def _record_test_id_for_retention(request, test_id):
+    """Check if this test is already registered for retention, or register it if within the limit.
+
+    Uses a file lock to coordinate across xdist workers.
+    Returns (recorded, current_count, max_retain).
+    """
+    max_retain = request.config.getoption("retain_on_failure")
+    counter_path = _get_retain_counter_path(request)
+    lock_path = counter_path + ".lock"
+
+    with FileLock(lock_path):
+        if os.path.exists(counter_path):
+            with open(counter_path, "r") as f:
+                retained_tests = set(line.strip() for line in f if line.strip())
+        else:
+            retained_tests = set()
+
+        # Already registered — allow retention without incrementing
+        if test_id in retained_tests:
+            return True, len(retained_tests), max_retain
+
+        # Limit reached — deny
+        if len(retained_tests) >= max_retain:
+            return False, len(retained_tests), max_retain
+
+        # Register this test
+        retained_tests.add(test_id)
+        with open(counter_path, "w") as f:
+            f.write("\n".join(retained_tests) + "\n")
+
+        return True, len(retained_tests), max_retain
+
+
+def is_stack_retained(request, stack_arn):
+    """Check if a specific stack ARN is registered in the retained stacks file."""
+    stacks_path = _get_retained_stacks_path(request)
+    lock_path = stacks_path + ".lock"
+
+    with FileLock(lock_path):
+        if os.path.exists(stacks_path):
+            with open(stacks_path, "r") as f:
+                retained_stacks = set(line.strip() for line in f if line.strip())
+            return stack_arn in retained_stacks
+    return False
+
+
+def is_region_retained(request, region):
+    """Check if any retained stack belongs to the given region.
+
+    Stack ARNs contain the region: arn:aws:cloudformation:<region>:<account>:stack/...
+    """
+    stacks_path = _get_retained_stacks_path(request)
+    lock_path = stacks_path + ".lock"
+
+    with FileLock(lock_path):
+        if os.path.exists(stacks_path):
+            with open(stacks_path, "r") as f:
+                retained_stacks = set(line.strip() for line in f if line.strip())
+            for arn in retained_stacks:
+                # ARN format: arn:aws:cloudformation:<region>:<account>:stack/<name>/<id>
+                parts = arn.split(":")
+                if len(parts) >= 4 and parts[3] == region:
+                    return True
+    return False
+
+
+def retain_resources_on_teardown(request, scope="function"):
+    """Return True when resources should be retained on teardown based on CLI options.
+
+    - Always True when --no-delete is set.
+    - True when --retain-on-failure > 0 and there is a failure in the current scope,
+      but only up to --retain-on-failure failed tests (shared across xdist workers):
+        * For function/class-scoped fixtures, the failure is taken from the current test item
+          and the test is registered in the shared retain file.
+    """
+    if request.config.getoption("no_delete"):
+        return True
+    if request.config.getoption("retain_on_failure"):
+        # For function/class-scoped fixtures, check if the current test failed
+        # and register it for retention if within the limit.
+        if scope == "function":
+            failed = _current_test_failed(request)
+            test_id = request.node.nodeid
+        else:
+            failed = _any_test_failed_in_session(request)
+            failed_tests = getattr(request.session, "_pcluster_failed_tests", None)
+            test_id = next(iter(failed_tests)) if failed_tests else "unknown"
+
+        if not failed:
+            return False
+
+        within_limit, current_count, max_retain = _record_test_id_for_retention(request, test_id)
+        if within_limit:
+            logging.warning(
+                "Retaining resources because --retain-on-failure is set and a test failed (%d/%d)",
+                current_count,
+                max_retain,
+            )
+            return True
+        else:
+            logging.info(
+                "Not retaining resources: retain-on-failure limit reached (%d/%d)",
+                current_count,
+                max_retain,
+            )
+            return False
+    return False

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -419,6 +419,12 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("no_delete"),
     )
     debug_group.add_argument(
+        "--retain-on-failure",
+        type=int,
+        help="Retain cluster, VPC, IAM, and S3 bucket stacks for up to N failing tests (0=disabled, max 5).",
+        default=TEST_DEFAULTS.get("retain_on_failure"),
+    )
+    debug_group.add_argument(
         "--delete-logs-on-success",
         help="delete CloudWatch logs when a test succeeds",
         action="store_true",
@@ -725,6 +731,9 @@ def _set_custom_stack_args(args, pytest_args):  # noqa: C901
 
     if args.no_delete:
         pytest_args.append("--no-delete")
+
+    if args.retain_on_failure:
+        pytest_args.extend(["--retain-on-failure", str(args.retain_on_failure)])
 
     if args.force_run_instances:
         pytest_args.append("--force-run-instances")


### PR DESCRIPTION
### Description of changes
Add test runner option `--retain-on-failure [N]` to retain `N` tests on failure.
This test feature is useful to capture intermittent failures in a controlled way and retain the broken environments that are affected to facilitate investigations.

A recent example where it was necessary was the intermittent dcv session launcher failure, but it can also useful to capture the intermittent NFS port binding failure.

When the option is active, the test generates two files in the test workspace, that are used to both synchronize processes on the retention decision and also to facilitate the discovery of retained resources for the technician that is invetsigating the failure:
* `.retain_on_failure_tests`: contains the list of failed tests for which resources have been retained.
* `.retained_stacks`: contains the list of stack ARNs that have been retained.

**NOTES**
1. This PR requires a corresponding change in Jenkins to make it work so it will not cleanup the resources that are supposed to be retained.

### Tests
Executed 4 parallel instances of `test_dcv_configuration` with injected failures in all of them in the following scenarios:
  * w/o `--retain-on-failure`: failures are reported as usual, but no test stack is retained.
  * w/ `--retain-on-failure 1`: failures are reported as usual, cluster/vpc/iam stack retained for one single test failure.
  * w/ `--retain-on-failure 2`: failures are reported as usual, cluster/vpc/iam stack retained for two test failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
