### PR TITLE
[Test] Exclude instance types with fractional GPUS from the instance types lookup.

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -81,14 +81,14 @@ test-suites:
           oss: ["alinux2"]
     test_createami.py::test_build_image:
       dimensions:
-        - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_NOPG_rhel9 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: {{ RHEL_OS_X86 }}
           schedulers: [ "slurm" ]
-          oss: ["ubuntu2404", "alinux2", "alinux2023"]
-        - regions: ["us-east-1"] # This region has to have first stage AMIs.
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["rocky8", "rhel8", "rhel9", "rocky9", "ubuntu2204"]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_6_INSTANCES_2_HOURS_NOPG_ubuntu2404 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: {{ NO_RHEL_OS_X86 }}
+          schedulers: [ "slurm" ]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -142,7 +142,7 @@ test-suites:
   networking:
     test_cluster_networking.py::test_existing_eip:
       dimensions:
-        - regions: ["me-south-1"]
+        - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
@@ -222,7 +222,7 @@ test-suites:
   spot:
     test_spot.py::test_spot_default:
       dimensions:
-        - regions: ["me-south-1"]
+        - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2404"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -289,6 +289,12 @@ test-suites:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu2204"]
+    test_update_race_conditions.py::test_update_race_conditions:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu2404"]
+          schedulers: ["slurm"]
   ultraserver:
     test_gb200.py::test_gb200:
       dimensions:

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
@@ -19,4 +19,6 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource1
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}

--- a/tests/integration-tests/tests/update/test_update_race_conditions.py
+++ b/tests/integration-tests/tests/update/test_update_race_conditions.py
@@ -148,22 +148,27 @@ def wait_for_login_nodes_lt_update_complete(cluster, region, after_utc=None):
 
 
 @retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
-def wait_for_node_update_failure(rce, cluster, node_type, node_id, after_utc=None):
+def wait_for_node_update_failure(rce, cluster, node_type, node_id, os, after_utc=None):
     node_rce = get_node_rce(rce, cluster, node_type, node_id)
-    log_file = LOG_FILE_BY_NODE_TYPE[node_type]
-    # cfn-hup logs use "%Y-%m-%d %H:%M:%S" format, so convert ISO timestamps for awk comparison
-    if after_utc and node_type == NODE_TYPE_LOGIN:
-        after_utc = after_utc.replace("T", " ").split(".")[0]
-    match, lines = match_regex_in_log(
-        node_rce,
-        log_file,
-        r"(?i)Permission denied",
-        after_utc=after_utc,
-    )
-    if not match:
-        raise Exception(
-            f"No evidence of update failure in {log_file} on {node_type} {node_id} yet. Last lines: {lines}"
+    # On AL2 (systemd 219), StandardOutput=append: is not supported, so pcluster-check-update.log stays empty
+    # and the logs are pushed to the journal, which is persisted in /var/log/messages.
+    if os == "alinux2" and node_type == NODE_TYPE_COMPUTE:
+        match, lines = match_regex_in_log(
+            node_rce, "/var/log/messages", r"pcluster-check-update\.sh.*(?i)Permission denied"
         )
+    else:
+        log_file = LOG_FILE_BY_NODE_TYPE[node_type]
+        # cfn-hup logs use "%Y-%m-%d %H:%M:%S" format, so convert ISO timestamps for awk comparison
+        if after_utc and node_type == NODE_TYPE_LOGIN:
+            after_utc = after_utc.replace("T", " ").split(".")[0]
+        match, lines = match_regex_in_log(
+            node_rce,
+            log_file,
+            r"(?i)Permission denied",
+            after_utc=after_utc,
+        )
+    if not match:
+        raise Exception(f"No evidence of update failure on {node_type} {node_id} yet. Last lines: {lines}")
     logger.info(
         f"Found evidence of update failure on {node_type} {node_id} due to missing execute permissions: {lines}"
     )
@@ -442,6 +447,7 @@ CN_4 = "q1-st-cr1-2"
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_update_race_conditions(
     region,
+    os,
     pcluster_config_reader,
     clusters_factory,
     test_datadir,
@@ -610,13 +616,13 @@ def test_update_race_conditions(
     logger.info(f"Login node {login_node_1_id} unblocked")
 
     logger.info(f"Waiting for compute node {CN_3} to fail the update due to transient failure")
-    wait_for_node_update_failure(rce, cluster, NODE_TYPE_COMPUTE, CN_3)
+    wait_for_node_update_failure(rce, cluster, NODE_TYPE_COMPUTE, CN_3, os)
     logger.info(f"Transient update failure detected on compute node {CN_3}")
     remove_transient_update_failure(rce, cluster, NODE_TYPE_COMPUTE, CN_3)
     logger.info(f"Removed transient failure for compute node {CN_3}. If it retries, it will succeed the update.")
 
     logger.info(f"Waiting for login node {login_node_2_id} to fail the update due to transient failure")
-    wait_for_node_update_failure(rce, cluster, NODE_TYPE_LOGIN, login_node_2_id, after_utc=update_2_submit_time)
+    wait_for_node_update_failure(rce, cluster, NODE_TYPE_LOGIN, login_node_2_id, os, after_utc=update_2_submit_time)
     logger.info(f"Transient update failure detected on login node {login_node_2_id}")
     remove_transient_update_failure(rce, cluster, NODE_TYPE_LOGIN, login_node_2_id)
     logger.info(

--- a/tests/integration-tests/tests/update/test_update_race_conditions.py
+++ b/tests/integration-tests/tests/update/test_update_race_conditions.py
@@ -170,6 +170,19 @@ def wait_for_node_update_failure(rce, cluster, node_type, node_id, after_utc=Non
 
 
 @retry(wait_fixed=seconds(10), stop_max_delay=minutes(30))
+def wait_for_head_node_update_recipe_complete(rce, after_utc=None):
+    match, matched_content = match_regex_in_log(
+        rce,
+        "/var/log/chef-client.log",
+        r"Cinc Client Run complete",
+        after_utc=after_utc,
+    )
+    if not match:
+        raise Exception("Head node chef-client run has not completed yet.")
+    logger.info(f"Head node chef-client run completed: {matched_content}")
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(30))
 def wait_for_stack_rollback_complete(cluster):
     client = boto3.client("cloudformation", region_name=cluster.region)
     stack_status = client.describe_stacks(StackName=cluster.name)["Stacks"][0]["StackStatus"]
@@ -375,32 +388,44 @@ def assert_update_recipe_executed_on_old_nodes(snapshot, update_submitted_at, ex
         ).is_not_empty()
 
 
-def is_update_failure_only_due_to_known_race_condition(rce, instance_ids, after_utc):
-    """Check if the last readiness check failure was caused only by the given instance IDs.
-
-    Parses the last "wrong records (1)" line from /var/log/chef-client.log after the given timestamp
-    and extracts the instance IDs listed there.
+def is_update_failure_only_due_to_known_race_condition(rce, instance_ids: list, after_utc: str):
+    """Check if the last readiness check failure was caused only by the given instance IDs by inspecting the
+    errors returned by the cluster readiness check in /var/log/chef-client.log
     Returns True if all wrong-record instance IDs are in the provided set.
     Returns False if there are no wrong records or if other instance IDs are present.
     """
-    found, output = match_regex_in_log(
+    found, lines = match_regex_in_log(
         rce,
         "/var/log/chef-client.log",
-        r"wrong records \(1\):.*",
+        r"Retrying execution of execute\[Check cluster readiness\], 0 attempt left",
         after_utc=after_utc,
+        nlines_after_match=50,
     )
     if not found:
         logger.info(
-            "No 'wrong records (1)' line found in chef-client.log after the update. "
+            "No final readiness check retry found in chef-client.log after the update. "
             "The cluster update failure, if observed, is not caused by the known race condition."
         )
         return False
-    instande_ids_with_wrong_record = set(re.findall(r"'(i-[0-9a-f]+)'", output))
+
+    logger.info(f"Found last readiness check retry: {lines}")
+
+    wrong_records_match = re.search(r"\* wrong records \(1\):.*", lines)
+    if not wrong_records_match:
+        logger.info(
+            "No '* wrong records (1):' line found in the last readiness check retry output. "
+            "The cluster update failure, if observed, is not caused by the known race condition."
+        )
+        return False
+
+    wrong_records_line = wrong_records_match.group()
+    instance_ids_with_wrong_record = set(re.findall(r"'(i-[0-9a-f]+)'", wrong_records_line))
     logger.info(
-        f"Readiness check wrong records: {output}. "
-        f"Instance IDs with wrong records: {instande_ids_with_wrong_record}"
+        f"Readiness check wrong records: {wrong_records_line}. "
+        f"Instance IDs with wrong records: {instance_ids_with_wrong_record}. "
+        f"Instance IDs with expected failure: {instance_ids}"
     )
-    return instande_ids_with_wrong_record == set(instance_ids)
+    return instance_ids_with_wrong_record == set(instance_ids)
 
 
 # CN_1: a dynamic compute node that completes the bootstrap after the readiness check
@@ -626,6 +651,14 @@ def test_update_race_conditions(
 
     logger.info("Verifications started")
     logger.info(f"Cluster stack status is: {actual_cluster_stack_status}")
+
+    # Known Issue: when the cluster stack reaches the state UPDATE_ROLLBACK_COMPLETE,
+    # the head node may not have completed the update recipe yet.
+    # So, before collecting the cluster snapshot we must wait for it to prevent false positive test failures.
+    if actual_cluster_stack_status == "UPDATE_ROLLBACK_COMPLETE":
+        logger.info("Waiting for head node to complete the update recipe before collecting the cluster snapshot")
+        wait_for_head_node_update_recipe_complete(rce, after_utc=update_2_submit_time)
+
     logger.info("Collecting cluster nodes snapshot")
     cluster_snapshot = get_cluster_nodes_snapshot(cluster)
     logger.info(f"Cluster snapshot:\n{json.dumps(cluster_snapshot, indent=2)}")
@@ -633,7 +666,7 @@ def test_update_race_conditions(
     with soft_assertions():
         # TODO: Once [RaceCondition 5] will be fixed, we will require cluster stack to always be in UPDATE_COMPLETE
         if actual_cluster_stack_status != "UPDATE_COMPLETE":
-            if is_update_failure_only_due_to_known_race_condition(rce, {login_node_1_id}, update_2_submit_time):
+            if is_update_failure_only_due_to_known_race_condition(rce, [login_node_1_id], update_2_submit_time):
                 logger.warning(
                     f"Cluster stack status is {actual_cluster_stack_status} but the readiness check failed "
                     f"only because of {login_node_1_id} (known RaceCondition 5, not blocking the test)"

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1141,12 +1141,28 @@ def get_file_mtime_age_seconds(remote_command_executor, file_path):
     return current_time - mtime
 
 
+# Matches ISO-like timestamps at the start of a log line, with or without brackets.
+# Examples: [2026-03-19T02:44:01+00:00], 2026-03-19 02:44:01, 2026-03-19T02:44:01.000Z
+_LOG_TIMESTAMP_RE = re.compile(r"^\[?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})")
+
+
+def get_log_after_timestamp(log_content: str, after_utc: str) -> str:
+    after_utc_prefix = after_utc[:19].replace(" ", "T")
+    lines = log_content.splitlines()
+    for i, line in enumerate(lines):
+        m = _LOG_TIMESTAMP_RE.match(line)
+        if m and m.group(1).replace(" ", "T") >= after_utc_prefix:
+            return "\n".join(lines[i:])
+    return ""
+
+
 def match_regex_in_log(
     rce,
     log_file: str,
     pattern: str,
     nlines: int = 50,
     after_utc: str = None,
+    nlines_after_match: int = 0,
 ) -> tuple[bool, str]:
     """
     Search for a regex pattern in a remote log file, optionally filtering to lines after a UTC timestamp.
@@ -1158,22 +1174,27 @@ def match_regex_in_log(
         nlines: Number of lines from the end of the log to return if pattern is not found. Defaults to 50.
         after_utc: Optional UTC timestamp string in ISO format (e.g. "2026-03-10T15:00:00.000Z"). Only lines at or after
            this timestamp are considered. If None, searches the entire log.
+        nlines_after_match: Number of lines to include after the matched line when the pattern is found. Defaults to 0
+           (only the matched line is returned).
 
     Returns:
         A tuple containing:
             - bool: True if the pattern was found, False otherwise.
-            - str: The matched string if found, or the last `nlines` lines of the log if not found.
+            - str: If found, the full line containing the match plus the next `nlines_after_match` lines.
+                   If not found, the last `nlines` lines of the log.
     """
-    if after_utc:
-        cmd = f"awk '$0 >= \"{after_utc}\"' {log_file} 2>/dev/null || echo ''"
-        result = rce.run_remote_command(cmd, raise_on_error=False)
-    else:
-        result = rce.run_remote_command(f"cat {log_file}")
+    result = rce.run_remote_command(f"cat {log_file}")
     log_content = result.stdout
+
+    if after_utc:
+        log_content = get_log_after_timestamp(log_content, after_utc)
 
     match = re.search(pattern, log_content)
     if match:
-        return True, match.group()
+        # Find the start of the line containing the match, then take nlines_after_match additional lines
+        match_line_start = log_content.rfind("\n", 0, match.start()) + 1
+        result_lines = log_content[match_line_start:].splitlines()[: 1 + nlines_after_match]
+        return True, "\n".join(result_lines)
     else:
         last_lines = "\n".join(log_content.splitlines()[-nlines:])
         return False, last_lines

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1183,7 +1183,7 @@ def match_regex_in_log(
             - str: If found, the full line containing the match plus the next `nlines_after_match` lines.
                    If not found, the last `nlines` lines of the log.
     """
-    result = rce.run_remote_command(f"cat {log_file}")
+    result = rce.run_remote_command(f"sudo cat {log_file}")
     log_content = result.stdout
 
     if after_utc:

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -1016,6 +1016,16 @@ def or_regex(items: list):
     return "|".join(map(re.escape, items))
 
 
+def _get_gpu_spec(instance_type_data):
+    """Return the GPU configuration as a frozenset of (manufacturer, count) pairs.
+
+    This captures the full GPU structure so that instances match only when they have
+    the same count for each manufacturer (e.g. NVIDIA:1 won't match NVIDIA:0).
+    """
+    gpu_info = instance_type_data.get("GpuInfo", {})
+    return frozenset((gpu.get("Manufacturer", ""), gpu.get("Count", 0)) for gpu in gpu_info.get("Gpus", []))
+
+
 def get_similar_instance_types(instance_type: str, region: str = None, max_items: int = None):
     ec2 = boto3.client("ec2", region_name=region)
 
@@ -1030,7 +1040,7 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
     target_vcpus = target["VCpuInfo"]["DefaultVCpus"]
     target_threads = target["VCpuInfo"]["DefaultThreadsPerCore"]
     target_has_efa = target.get("NetworkInfo", {}).get("EfaSupported", False)
-    target_has_gpu = "GpuInfo" in target
+    target_gpu_spec = _get_gpu_spec(target)
     target_inference_accelerators = target.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
 
     # Now query for similar instances using filters
@@ -1045,16 +1055,16 @@ def get_similar_instance_types(instance_type: str, region: str = None, max_items
             {"Name": "supported-usage-class", "Values": ["on-demand", "spot"]},
         ],
     ):
-        # Filter for EFA support, GPU presence, and inference accelerator types
+        # Filter for EFA support, GPU configuration, and inference accelerator types
         for instance in page["InstanceTypes"]:
             instance_prefix = instance["InstanceType"].split(".")[0]
             instance_has_efa = instance.get("NetworkInfo", {}).get("EfaSupported", False)
-            instance_has_gpu = "GpuInfo" in instance
+            instance_gpu_spec = _get_gpu_spec(instance)
             instance_inference_accelerators = instance.get("InferenceAcceleratorInfo", {}).get("Accelerators", [])
             if (
                 instance_prefix not in EXCLUDED_INSTANCE_TYPE_PREFIXES
                 and instance_has_efa == target_has_efa
-                and instance_has_gpu == target_has_gpu
+                and instance_gpu_spec == target_gpu_spec
                 and instance_inference_accelerators == target_inference_accelerators
             ):
                 similar_instances.append(instance["InstanceType"])


### PR DESCRIPTION
### Description of changes
Exclude instance types with fractional GPUS from the instance types lookup.
The exclusion is required because we do not support instance types with fractional GPUs.

### Tests
Dryrun `test_cluster_with_gpu_health_checks` to trigger the instance type selection. The selected instance types are all non fractional GPUs.

```
2026-05-05 16:21:30,534 - INFO - config_renderer - Selected GPU instance types: ['gr6.8xlarge', 'g6e.4xlarge', 'g5.8xlarge', 'g4dn.2xlarge', 'g6e.xlarge', 'g4dn.12xlarge', 'g5g.8xlarge', 'g5g.xlarge', 'g6e.16xlarge', 'g5.12xlarge', 'g7e.2xlarge', 'g4dn.xlarge', 'g4dn.16xlarge', 'g6.xlarge', 'g6e.12xlarge', 'p5.4xlarge', 'g5g.4xlarge', 'g4dn.4xlarge', 'g7e.8xlarge', 'g6.4xlarge', 'g7e.4xlarge', 'g6.12xlarge', 'g6e.8xlarge', 'g6.16xlarge', 'g6.2xlarge', 'g7e.12xlarge', 'g5g.2xlarge', 'gr6.4xlarge', 'g4dn.8xlarge', 'g5g.16xlarge', 'g5.4xlarge', 'g6.8xlarge', 'g5.xlarge', 'g5.16xlarge', 'g6e.2xlarge', 'g5g.metal', 'g5.2xlarge']
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
