### PR TITLE
[Test] Mitigate the risk of ICE in test_build_image using the dynamic capacity reservation.

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -81,14 +81,22 @@ test-suites:
           oss: ["alinux2"]
     test_createami.py::test_build_image:
       dimensions:
-        - regions: ["eu-west-3"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rhel9 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: ["rhel8", "rhel9"]
           schedulers: [ "slurm" ]
-          oss: ["ubuntu2404", "alinux2", "alinux2023"]
-        - regions: ["us-east-1"] # This region has to have first stage AMIs.
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: ["rocky8", "rhel8", "rhel9", "rocky9", "ubuntu2204"]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_alinux2023 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: ["alinux2023", "alinux2"]
+          schedulers: [ "slurm" ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_ubuntu2404 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: [ "ubuntu2404", "ubuntu2204" ]
+          schedulers: [ "slurm" ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rocky9 }} ]
+          instances: [ "g4dn.2xlarge" ]
+          oss: [ "rocky8", "rocky9" ]
+          schedulers: [ "slurm" ]
     test_createami.py::test_build_image_custom_components:
       # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
       # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)


### PR DESCRIPTION
### Description of changes
Mitigate the risk of ICE in test_build_image using the dynamic capacity reservation.
We already use this same mechanism and configuration in develop integ tests, where it is successful.
We are simply applying this same approach to the released integ tests.

### Tests
ONGOING `test_build_image` with the given config

The test creates the expected odcr:
```
  warnings.warn(warning, PythonDeprecationWarning)
2026-05-05 20:24:09,550 - INFO - credentials - Found credentials from IAM Role: Jenkins-JenkinsInstanceRoleCommercialDev-8FI894AW867Q
2026-05-05 20:24:13,864 - INFO - config_renderer - Checking capacity reservation for g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rocky9
2026-05-05 20:24:15,112 - INFO - config_renderer - Capacity reservation for 4 g4dn.2xlarge on Linux/UNIX created in apne2-az1
2026-05-05 20:24:15,112 - INFO - config_renderer - Created reservations for all instance types in apne2-az1
2026-05-05 20:24:15,113 - INFO - config_renderer - Checking capacity reservation for g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rhel9
2026-05-05 20:24:16,511 - INFO - config_renderer - Capacity reservation for 4 g4dn.2xlarge on Red Hat Enterprise Linux created in apne2-az1
2026-05-05 20:24:16,511 - INFO - config_renderer - Created reservations for all instance types in apne2-az1
2026-05-05 20:24:16,513 - INFO - config_renderer - Checking capacity reservation for g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_alinux2023
2026-05-05 20:24:17,801 - INFO - config_renderer - Capacity reservation for 4 g4dn.2xlarge on Linux/UNIX created in apne2-az1
2026-05-05 20:24:17,801 - INFO - config_renderer - Created reservations for all instance types in apne2-az1
2026-05-05 20:24:17,803 - INFO - config_renderer - Checking capacity reservation for g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_ubuntu2404
2026-05-05 20:24:19,090 - INFO - config_renderer - Capacity reservation for 4 g4dn.2xlarge on Linux/UNIX created in apne2-az1
2026-05-05 20:24:19,091 - INFO - config_renderer - Created reservations for all instance types in apne2-az1
```

and the tests are configured to consume them:

```
2026-05-05 20:24:19,612 - INFO - test_runner - Found valid config file:
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - rhel8
        - rhel9
        regions:
        - apne2-az1
        schedulers:
        - slurm
      - instances:
        - g4dn.2xlarge
        oss:
        - alinux2023
        - alinux2
        regions:
        - apne2-az1
        schedulers:
        - slurm
      - instances:
        - g4dn.2xlarge
        oss:
        - ubuntu2404
        - ubuntu2204
        regions:
        - apne2-az1
        schedulers:
        - slurm
      - instances:
        - g4dn.2xlarge
        oss:
        - rocky8
        - rocky9
        regions:
        - apne2-az1
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
