### PR TITLE
[Test] Exclude instance types with fractional GPUS from the instance types lookup.

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -151,6 +151,7 @@ def _get_instance_type_parameters():  # noqa: C901
                             else:
                                 gpu_instances.append(instance_type["InstanceType"])
 
+            logging.info(f"Selected GPU instance types: {gpu_instances}")
             xlarge_sorted = sorted(xlarge_instances)
             gpu_sorted = sorted(gpu_instances)
             today_number = (date.today() - date(2020, 1, 1)).days

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -136,7 +136,7 @@ def _get_instance_type_parameters():  # noqa: C901
                 gpu_instance_type_batch = all_gpu_list[i : i + batch_size]  # noqa: E203
                 for page in paginator.paginate(InstanceTypes=gpu_instance_type_batch):
                     for instance_type in page["InstanceTypes"]:
-                        if _is_nvidia_gpu_instance_type(instance_type) and "g6f" not in instance_type["InstanceType"]:
+                        if _is_nvidia_gpu_instance_type(instance_type):
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
                             ) >= 4 and _is_current_instance_type_generation(
@@ -181,11 +181,13 @@ def _get_instance_type_parameters():  # noqa: C901
 
 
 def _is_nvidia_gpu_instance_type(instance_type):
-    return (
-        instance_type.get("GpuInfo")
-        and instance_type.get("GpuInfo").get("Gpus")
-        and instance_type.get("GpuInfo").get("Gpus")[0].get("Manufacturer") == "NVIDIA"
-    )
+    """
+    Return True if the instance type exposes a full NVIDIA GPU.
+
+    Fractional-GPU instances (e.g. g6f, gr6f) are filtered out.
+    """
+    gpu = next(iter((instance_type.get("GpuInfo") or {}).get("Gpus") or []), {})
+    return gpu.get("Manufacturer") == "NVIDIA" and (gpu.get("Count") or 0) >= 1
 
 
 def _is_current_instance_type_generation(excluded_instance_type_prefixes, instance_type):


### PR DESCRIPTION
### Description of changes
Exclude instance types with fractional GPUS from the instance types lookup.
The exclusion is required because we do not support instance types with fractional GPUs.

### Tests
Dryrun `test_cluster_with_gpu_health_checks` to trigger the instance type selection. The selected instance types are all non fractional GPUs.

```
2026-05-05 16:21:30,534 - INFO - config_renderer - Selected GPU instance types: ['gr6.8xlarge', 'g6e.4xlarge', 'g5.8xlarge', 'g4dn.2xlarge', 'g6e.xlarge', 'g4dn.12xlarge', 'g5g.8xlarge', 'g5g.xlarge', 'g6e.16xlarge', 'g5.12xlarge', 'g7e.2xlarge', 'g4dn.xlarge', 'g4dn.16xlarge', 'g6.xlarge', 'g6e.12xlarge', 'p5.4xlarge', 'g5g.4xlarge', 'g4dn.4xlarge', 'g7e.8xlarge', 'g6.4xlarge', 'g7e.4xlarge', 'g6.12xlarge', 'g6e.8xlarge', 'g6.16xlarge', 'g6.2xlarge', 'g7e.12xlarge', 'g5g.2xlarge', 'gr6.4xlarge', 'g4dn.8xlarge', 'g5g.16xlarge', 'g5.4xlarge', 'g6.8xlarge', 'g5.xlarge', 'g5.16xlarge', 'g6e.2xlarge', 'g5g.metal', 'g5.2xlarge']
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
