### PR TITLE
[Test] In test_slurm_rest_api add assertion to verify that slurmrestd does not emit any error.

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -80,6 +80,15 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False,
             assert_that(log).does_not_contain(error_level)
 
 
+def assert_no_errors_in_service_log(remote_command_executor: RemoteCommandExecutor, service_name: str):
+    """Assert that the systemd journal for a given service contains no error-level entries."""
+    __tracebackhide__ = True
+    logging.info("Checking %s journal for error-level entries", service_name)
+    log = remote_command_executor.run_remote_command(f"sudo journalctl -u {service_name} --no-pager", hide=True).stdout
+    error_lines = [line for line in log.splitlines() if re.search(r"fail|error|critical", line, re.IGNORECASE)]
+    assert_that(error_lines).described_as(f"Found error-level entries in {service_name} journal logs").is_empty()
+
+
 def assert_no_msg_in_logs(remote_command_executor: RemoteCommandExecutor, log_files: List[str], log_msg: List[str]):
     """Assert log msgs are not in logs."""
     __tracebackhide__ = True

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
@@ -19,7 +19,7 @@ from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutor
 from utils import to_snake_case
 
-from tests.common.assertions import assert_systemd_service_running
+from tests.common.assertions import assert_no_errors_in_service_log, assert_systemd_service_running
 
 # slurmrestd listens on this unix socket when configured via the upstream postinstall script
 # (aws-samples/aws-parallelcluster-post-install-scripts/rest-api).
@@ -76,6 +76,7 @@ def test_slurm_rest_api(
     with soft_assertions():
         assert_systemd_service_running(rce, "slurmrestd")
         _assert_slurmrestd_endpoint_responsive(rce, "ping")
+        assert_no_errors_in_service_log(rce, "slurmrestd")
 
 
 def _slurmrestd_request(rce, url_path, raise_on_error=True):


### PR DESCRIPTION
### Description of changes
In test_slurm_rest_api add assertion to verify that slurmrestd does not emit any error.

### Tests
* happy path: SUCCESS `test_slurm_rest_api`
* unhappy path: ONGOIN `test_slurm_rest_api` with injected errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
