### PR TITLE
[Test] Add integ test to execute custom investigations.

### DIFF
--- a/tests/integration-tests/configs/investigation.yaml
+++ b/tests/integration-tests/configs/investigation.yaml
@@ -1,0 +1,10 @@
+{%- import 'common.jinja2' as common with context -%}
+---
+test-suites:
+  investigation:
+    test_investigation.py::test_investigation:
+      dimensions:
+        - regions: [ "us-east-1" ]
+          instances: [ "t3.large" ]
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: [ "slurm" ]

--- a/tests/integration-tests/tests/investigation/__init__.py
+++ b/tests/integration-tests/tests/investigation/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/investigation/test_investigation.py
+++ b/tests/integration-tests/tests/investigation/test_investigation.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import boto3
+import pytest
+from remote_command_executor import RemoteCommandExecutor
+
+
+@pytest.mark.usefixtures("os", "scheduler", "instance")
+def test_investigation(
+    region,
+    scheduler,
+    pcluster_config_reader,
+    vpc_stack,
+    s3_bucket_factory,
+    test_datadir,
+    clusters_factory,
+    scheduler_commands_factory,
+):
+    """Create a cluster with custom actions on all node types and verify a job succeeds."""
+    logging.info("Starting investigation test")
+
+    # Create S3 bucket and upload custom action scripts
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "on_node_start.sh"), "scripts/on_node_start.sh")
+    bucket.upload_file(str(test_datadir / "on_node_configured.sh"), "scripts/on_node_configured.sh")
+
+    # Create the cluster
+    on_node_start_script = f"s3://{bucket_name}/scripts/on_node_start.sh"
+    on_node_configured_script = f"s3://{bucket_name}/scripts/on_node_configured.sh"
+    cluster_config = pcluster_config_reader(
+        bucket_name=bucket_name,
+        on_node_start_script=on_node_start_script,
+        on_node_configured_script=on_node_configured_script,
+    )
+    cluster = clusters_factory(cluster_config)
+
+    # Submit a dummy job and assert it succeeds
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    _assert_dummy_job_succeeds(scheduler_commands)
+
+    logging.info("Investigation test completed successfully")
+
+
+def _assert_dummy_job_succeeds(scheduler_commands):
+    """Submit a dummy job and assert it completes successfully."""
+    result = scheduler_commands.submit_command("hostname", nodes=1)
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)

--- a/tests/integration-tests/tests/investigation/test_investigation/test_investigation/on_node_configured.sh
+++ b/tests/integration-tests/tests/investigation/test_investigation/test_investigation/on_node_configured.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+echo "$(date +'%Y%m%d-%H%M%S-%s') START OnNodeConfigured $0"
+# Add here the custom logic you need for your investigation
+echo "$(date +'%Y%m%d-%H%M%S-%s') END OnNodeConfigured  $0"

--- a/tests/integration-tests/tests/investigation/test_investigation/test_investigation/on_node_start.sh
+++ b/tests/integration-tests/tests/investigation/test_investigation/test_investigation/on_node_start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+echo "$(date +'%Y%m%d-%H%M%S-%s') START OnNodeStart $0"
+# Add here the custom logic you need for your investigation
+echo "$(date +'%Y%m%d-%H%M%S-%s') END OnNodeStart  $0"

--- a/tests/integration-tests/tests/investigation/test_investigation/test_investigation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/investigation/test_investigation/test_investigation/pcluster.config.yaml
@@ -1,0 +1,55 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: "arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  CustomActions:
+    OnNodeStart:
+      Script: {{ on_node_start_script }}
+    OnNodeConfigured:
+      Script: {{ on_node_configured_script }}
+LoginNodes:
+  Pools:
+    - Name: login1
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: "arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      CustomActions:
+        OnNodeStart:
+          Script: {{ on_node_start_script }}
+        OnNodeConfigured:
+          Script: {{ on_node_configured_script }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: q1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: cr1
+          Instances:
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
+          MinCount: 1
+          MaxCount: 2
+      CustomActions:
+        OnNodeStart:
+          Script: {{ on_node_start_script }}
+        OnNodeConfigured:
+          Script: {{ on_node_configured_script }}
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}


### PR DESCRIPTION
### Description of changes
Add integ test to execute custom investigations. 
The test does nothing more that creating a cluster with onnodestart/configueed custom actions
This scaffolding is useful when we need to validate a customization across all the OSs at once. For example I used it to validate the mitigation to a CVE across the board.
This test is not meant to be included in our automated runs, but executed on demand.

### Tests
SUCCESS `test_investigation` on all OSs with the custom actions temporarily modified with the mitigation to a CVE.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
