### PR TITLE
[Test] Prevent known_hosts from growing indefinitely from bastion SSH connections in integration tests.

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -83,11 +83,10 @@ class RemoteCommandExecutor:
             },
         }
         if bastion:
+            ssh_opts = f"-i {cluster.ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
             # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
-            run_command(
-                f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname", timeout=30, shell=True
-            )
-            connection_kwargs["gateway"] = f"ssh -W %h:%p -A -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion}"
+            run_command(f"ssh {ssh_opts} {bastion} hostname", timeout=30, shell=True)
+            connection_kwargs["gateway"] = f"ssh -W %h:%p -A {ssh_opts} {bastion}"
             connection_kwargs["forward_agent"] = True
             connection_kwargs["connect_kwargs"]["banner_timeout"] = 60
         logging.info(


### PR DESCRIPTION
### Description of changes
Prevent known_hosts from growing indefinitely from bastion SSH connections in integration tests.
In particular, we added the SSH option UserKnownHostsFile=/dev/null so that the head node key is not persisted into the test runner's known_hosts file. Without this change, the known_hosts file grows indefinitely.

It is safe to add this option because such connections are ephemeral and we are already ignoring the verification of keys through the use of option StrictHostKeyChecking=no.

### Tests
SUCCESS `test_cluster_in_private_subnet`:
* before this fix, the execution of this test was adding 2 entries in the known_hosts file
* after this fix, the test succeeded without adding any new entry to the known_hosts file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
