### PR TITLE
[Test] In test_slurm_rest_api, remove the custom action meant to patch the Slurm build as it is not necessary anymore

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api.py
@@ -25,7 +25,6 @@ from tests.common.assertions import assert_no_errors_in_service_log, assert_syst
 # (aws-samples/aws-parallelcluster-post-install-scripts/rest-api).
 SLURMRESTD_SOCKET = "/var/spool/socket/slurmrestd.sock"
 
-REBUILD_SCRIPT_NAME = "rebuild_slurm.sh"
 CONFIGURE_SCRIPT_NAME = "configure_slurmrestd.sh"
 SLURM_REST_API_RB_NAME = "slurm_rest_api.rb"
 
@@ -48,11 +47,9 @@ def test_slurm_rest_api(
     """Verify that the Slurm REST API (slurmrestd) is functional on a cluster where it is enabled."""
     bucket_name = s3_bucket_factory()
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
-    bucket.upload_file(str(test_datadir / REBUILD_SCRIPT_NAME), f"scripts/{REBUILD_SCRIPT_NAME}")
     bucket.upload_file(str(test_datadir / CONFIGURE_SCRIPT_NAME), f"scripts/{CONFIGURE_SCRIPT_NAME}")
     bucket.upload_file(str(test_datadir / SLURM_REST_API_RB_NAME), f"scripts/{SLURM_REST_API_RB_NAME}")
 
-    rebuild_slurm_script_uri = f"s3://{bucket_name}/scripts/{REBUILD_SCRIPT_NAME}"
     configure_slurmrestd_script_uri = f"s3://{bucket_name}/scripts/{CONFIGURE_SCRIPT_NAME}"
     slurm_rest_api_rb_uri = f"s3://{bucket_name}/scripts/{SLURM_REST_API_RB_NAME}"
 
@@ -64,7 +61,6 @@ def test_slurm_rest_api(
         public_subnet_id=public_subnet_id,
         private_subnet_id=private_subnet_id,
         bucket_name=bucket_name,
-        rebuild_slurm_script_uri=rebuild_slurm_script_uri,
         configure_slurmrestd_script_uri=configure_slurmrestd_script_uri,
         slurm_rest_api_rb_uri=slurm_rest_api_rb_uri,
         **database_params,

--- a/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_rest_api/test_slurm_rest_api/pcluster.config.yaml
@@ -14,8 +14,6 @@ HeadNode:
   Ssh:
     KeyName: {{ key_name }}
   CustomActions:
-    OnNodeStart:
-      Script: {{ rebuild_slurm_script_uri }}
     OnNodeConfigured:
       Script: {{ configure_slurmrestd_script_uri }}
       Args:


### PR DESCRIPTION
### Description of changes
In test_slurm_rest_api, remove the custom action meant to patch the Slurm build as we have now fixed the build and it is no longer necessary.

**Why not removing the script `rebuild_slurm.sh` from the test config folder since it is now unused?**
Just because it is practical to have at hand the custom action to to patch slurm for future issues, ready to be used in an end2end test.


### Tests
SUCCESS `test_slurm_rest_api` (executed on AL2023, the only OS where we made change to cookbook)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
