### PR TITLE
[Test] Restore default HeadNodeBootstrapTimeout in test_fsx_lustre_configuration_options

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -1,6 +1,3 @@
-DevSettings:
-  Timeouts:
-    HeadNodeBootstrapTimeout: 2400  # Increasing Timeout as FSX takes 20+ minutes to create if throttled
 Image:
   Os: {{ os }}
 HeadNode:


### PR DESCRIPTION
### Description of changes

- Revert commit d011a582d, which set `HeadNodeBootstrapTimeout: 2400` (40 min) in `test_fsx_lustre_configuration_options` to work around FSX throttling. With the underlying 3.14 bootstrap regression fixed (NetworkManager / IPv6), the relaxed timeout is no longer needed and was masking bootstrap-time regressions integ tests are meant to detect.

### Tests
* `test_fsx_lustre_configuration_options` passed on al2, rhel9, rocky9.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
