### PR TITLE
[Test] Reduce the risk of export-logs "Resource limit exceeded" failures in parallel tests.

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -36,7 +36,7 @@ from utils import (
     retry_if_subprocess_error,
 )
 
-from tests.common.utils import read_remote_file
+from tests.common.utils import read_remote_file, wait_for_no_active_export_tasks
 
 TAG_CLUSTER_NAME = "parallelcluster:cluster-name"
 TAG_NODE_TYPE = "parallelcluster:node-type"
@@ -367,6 +367,12 @@ class Cluster:
 
         return None
 
+    @retry(
+        wait_random_min=seconds(10),
+        wait_random_max=seconds(20),
+        stop_max_delay=minutes(10),
+        retry_on_exception=lambda e: "Resource limit exceeded" in str(e.stderr),
+    )
     def export_logs(self, bucket=None, output_file=None, bucket_prefix=None, filters=None):
         """Run pcluster export-cluster-logs and return the result."""
         cmd_args = ["pcluster", "export-cluster-logs", "--cluster-name", self.name]
@@ -378,6 +384,7 @@ class Cluster:
             cmd_args += ["--bucket-prefix", bucket_prefix]
         if filters:
             cmd_args += ["--filters", filters]
+        wait_for_no_active_export_tasks(self.region)
         try:
             result = run_pcluster_command(cmd_args, log_error=False, custom_cli_credentials=self.custom_cli_credentials)
             response = json.loads(result.stdout)

--- a/tests/integration-tests/images_factory.py
+++ b/tests/integration-tests/images_factory.py
@@ -14,7 +14,11 @@ import logging
 
 import yaml
 from framework.credential_providers import run_pcluster_command
+from retrying import retry
+from time_utils import minutes, seconds
 from utils import kebab_case
+
+from tests.common.utils import wait_for_no_active_export_tasks
 
 
 class Image:
@@ -111,14 +115,26 @@ class Image:
             self._update_image_info(response)
         return response
 
+    @retry(
+        wait_random_min=seconds(10),
+        wait_random_max=seconds(20),
+        stop_max_delay=minutes(10),
+        retry_on_exception=lambda e: "Resource limit exceeded" in str(e.stderr),
+    )
     def export_logs(self, **args):
         """Export the logs from the image build process."""
         logging.info("Get image %s build log.", self.image_id)
         command = ["pcluster", "export-image-logs", "--region", self.region, "--image-id", self.image_id]
         for k, val in args.items():
-            command.extend([f"--{kebab_case(k)}", str(val)])
-        result = run_pcluster_command(command)
-        return json.loads(result.stdout)
+            if val is not None:
+                command.extend([f"--{kebab_case(k)}", str(val)])
+        wait_for_no_active_export_tasks(self.region)
+        try:
+            result = run_pcluster_command(command)
+            return json.loads(result.stdout)
+        except Exception as e:
+            logging.error("Failed exporting image logs with error: %s", getattr(e, "stderr", str(e)).strip())
+            raise
 
     def get_log_events(self, log_stream_name, **args):
         """Get image build log events."""

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -24,8 +24,6 @@ from assertpy import assert_that
 from dateutil.parser import parse as date_parse
 from framework.credential_providers import run_pcluster_command
 from remote_command_executor import RemoteCommandExecutor
-from retrying import retry
-from time_utils import minutes, seconds
 from utils import (
     check_pcluster_list_cluster_log_streams,
     check_status,
@@ -38,7 +36,6 @@ from tests.common.assertions import assert_no_errors_in_logs, wait_for_num_insta
 from tests.common.utils import (
     get_installed_parallelcluster_version,
     retrieve_latest_ami,
-    wait_for_no_active_export_tasks,
 )
 
 
@@ -367,14 +364,12 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, use_pcluster_
 
     # test with a prefix and an output file
     bucket_prefix = "test_prefix"
-    wait_for_no_active_export_tasks(cluster.region)
-    retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
+    _test_export_log_files_are_expected(
         cluster, bucket_name if not use_pcluster_bucket else None, instance_ids, bucket_prefix
     )
 
     # test export-cluster-logs with filter option
-    wait_for_no_active_export_tasks(cluster.region)
-    retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(_test_export_log_files_are_expected)(
+    _test_export_log_files_are_expected(
         cluster,
         bucket_name if not use_pcluster_bucket else None,
         headnode_instance_id,
@@ -392,10 +387,7 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, use_pcluster_
     assert_that(bucket_cleaned_up).is_true()
 
     # test without a prefix or output file
-    wait_for_no_active_export_tasks(cluster.region)
-    ret = retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(cluster.export_logs)(
-        bucket=bucket_name if not use_pcluster_bucket else None
-    )
+    ret = cluster.export_logs(bucket=bucket_name if not use_pcluster_bucket else None)
     assert_that(ret).contains_key("url")
     filename = ret["url"].split(".tar.gz")[0].split("/")[-1] + ".tar.gz"
     archive_found = True

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -714,7 +714,7 @@ def wait_for_no_active_export_tasks(region):
     active_statuses = ("RUNNING", "PENDING")
     logs_client = boto3.client("logs", region_name=region)
     max_wait = 300  # 5 minutes
-    poll_interval = 10
+    poll_interval = random.randint(10, 20)
     elapsed = 0
     while elapsed < max_wait:
         active_tasks = []

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -44,7 +44,6 @@ from tests.common.utils import (
     get_installed_parallelcluster_version,
     retrieve_latest_ami,
     upload_github_artifacts_to_s3,
-    wait_for_no_active_export_tasks,
 )
 from tests.proxy.test_proxy import proxy_stack_factory  # noqa: F401
 
@@ -254,9 +253,7 @@ def test_build_image(
         _test_list_image_log_streams(image)
         _test_get_image_log_events(image)
         _test_list_images(image)
-        wait_for_no_active_export_tasks(region)
         _test_export_logs(s3_bucket_factory, image, region)
-        wait_for_no_active_export_tasks(region)
         _test_export_logs(s3_bucket_factory, image, region, True)
 
     _test_cluster_creation(
@@ -437,6 +434,7 @@ def _set_s3_bucket_policy(bucket_name, partition, region):
 
 
 def _test_export_logs(s3_bucket_factory, image, region, use_pcluster_bucket=False):
+    bucket_name = None
     if not use_pcluster_bucket:
         bucket_name = s3_bucket_factory()
         logging.info("bucket is %s", bucket_name)
@@ -451,14 +449,11 @@ def _test_export_logs(s3_bucket_factory, image, region, use_pcluster_bucket=Fals
         output_file = f"{tempdir}/testfile.tar.gz"
         bucket_prefix = "test_prefix"
 
-        if not use_pcluster_bucket:
-            ret = retry(wait_fixed=seconds(20), stop_max_delay=minutes(10))(image.export_logs)(
-                bucket=bucket_name, output_file=output_file, bucket_prefix=bucket_prefix
-            )
-        else:
-            ret = retry(wait_fixed=seconds(20), stop_max_delay=minutes(10))(image.export_logs)(
-                output_file=output_file, bucket_prefix=bucket_prefix
-            )
+        ret = image.export_logs(
+            bucket=bucket_name,
+            output_file=output_file,
+            bucket_prefix=bucket_prefix,
+        )
 
         assert_that(ret["path"]).contains(output_file)
 
@@ -717,8 +712,6 @@ def _export_image_logs(image, output_dir):
     os.makedirs(log_dir, exist_ok=True)
     output_file = os.path.join(log_dir, f"{image.image_id}-logs.tar.gz")
     try:
-        # Each account can only have one active CloudWatch Logs export task per region at a time.
-        wait_for_no_active_export_tasks(image.region)
         ret = image.export_logs(output_file=output_file)
         logging.info(f"Full image build log exported to {ret.get('path', output_file)}")
     except Exception as e:


### PR DESCRIPTION
### Description of changes
Reduce the risk of `test_cli_commands` and `test_build_image` failures caused by "Resource limit exceeded" when exporting logs.

CloudWatch Logs allows only one active export task per account per region. When parallel tests compete for this slot, the previous approach; calling `wait_for_no_active_export_tasks` once before a retry loop; left a race window: a parallel test could start an export after the wait, causing every retry to fail without ever re-checking.

Changes:

- **Wait before every export attempt.** `wait_for_no_active_export_tasks` now lives inside `Cluster.export_logs` and `Image.export_logs`, right before the pcluster command. On retry, the wait re-executes, so each attempt verifies the slot is free before firing.

- **Increased retry budget from 3 to 10 minutes.** The old window was shorter than a typical export task duration (2–5 minutes), so retries would exhaust before the competing task finished.

- **Random jitter (10–20s) on both the wait polling and the retry delay.** Prevents thundering herd; parallel tests desynchronize naturally instead of colliding in lockstep on a fixed cadence.

- **Log every failure before retrying.** Each failed attempt logs the error, giving clear evidence in test output when retries occur.


### Tests
SUCCESS 2 parallel `test_cli_commands` + 2 `test_build_image` (so that we expose 4 instances competing for logs export).
Also tested the unhappy path in `test_build_image` where the logs are exported in case of failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
