### PR TITLE
[Test Metric Bug]Fix test reporting missing failures when region is from fixture

### DIFF
--- a/tests/integration-tests/conftest_utils.py
+++ b/tests/integration-tests/conftest_utils.py
@@ -42,10 +42,19 @@ def add_properties_to_report(item: pytest.Item):
     props = []
 
     # Add properties for test dimensions, obtained from fixtures passed to tests
+    # Try funcargs first, fall back to callspec.params (needed for @pytest.mark.usefixtures)
     for dimension in DIMENSIONS_MARKER_ARGS:
         value = item.funcargs.get(dimension)
+        if value and dimension == "region":
+            logging.info(f"region={value} (from funcargs) for {item.nodeid}")
+        if not value and hasattr(item, "callspec"):
+            value = item.callspec.params.get(dimension)
+            if value and dimension == "region":
+                logging.info(f"region={value} (from callspec.params) for {item.nodeid}")
         if value:
             props.append((dimension, value))
+        elif dimension == "region":
+            logging.warning(f"region=None for {item.nodeid}")
 
     # Add property for feature tested, obtained from filename containing the test
     props.append(("feature", extract_tested_component_from_filename(item)))
@@ -335,7 +344,10 @@ def _get_launch_time(logs, instance_id):
 
 
 def get_reporting_region(region: str):
-    """Get partition for the given region. If region is None, consider the region set in the environment."""
+    """Get partition for the given region. If region is None, fall back to DEFAULT_REPORTING_REGION."""
+    if not region:
+        logging.warning("Region is None in get_reporting_region, falling back to default reporting region")
+        return DEFAULT_REPORTING_REGION
     curr_partition = next(
         (partition for region_prefix, partition in PARTITION_MAP.items() if region.startswith(region_prefix)),
         DEFAULT_PARTITION,


### PR DESCRIPTION

### Description of changes
Fix test reporting missing failures when region is from fixture

Tests using @pytest.mark.usefixtures("region") instead of declaring region as a direct function parameter could have region=None in user_properties. This caused get_reporting_region() to crash with AttributeError on NoneType.startswith(), silently dropping the test result from DDB and Slack reporting.

Fix add_properties_to_report to fall back to item.callspec.params when item.funcargs doesn't contain the dimension. This extracts the region from the test's parametrization (e.g. us-east-2 from test_cluster_delete_retain[us-east-2-c5.xlarge-ubuntu2404-None-official]).

Also add a defensive None check in get_reporting_region to prevent crashes if region is still unavailable for any edge case.

Add logs


### Tests
* test_cluster_delete_retain

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
