### PR TITLE
[GH] Fix script injection vulnerability in workflow checkers

### DIFF
--- a/.github/workflows/security_exclusions_checker.yml
+++ b/.github/workflows/security_exclusions_checker.yml
@@ -12,9 +12,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check for nosec/nosemgrep in added lines
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        if git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^+" | grep -qP '\bnosec\b|\bnosemgrep\b'; then
+        if git diff "origin/${BASE_REF}...HEAD" | grep "^+" | grep -qP '\bnosec\b|\bnosemgrep\b'; then
           echo "::error::Found nosec or nosemgrep annotations in added lines"
-          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^+" | grep -P '\bnosec\b|\bnosemgrep\b'
+          git diff "origin/${BASE_REF}...HEAD" | grep "^+" | grep -P '\bnosec\b|\bnosemgrep\b'
           exit 1
         fi

--- a/.github/workflows/unsafe_patterns_checker.yml
+++ b/.github/workflows/unsafe_patterns_checker.yml
@@ -12,9 +12,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check for disallowed URL suffixes in added lines
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        if git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^+" | grep -qP 'amazonaws\.com|amazonaws\.com\.cn|c2s\.ic\.gov|sc2s\.sgov\.gov'; then
+        if git diff "origin/${BASE_REF}...HEAD" | grep "^+" | grep -qP 'amazonaws\.com|amazonaws\.com\.cn|c2s\.ic\.gov|sc2s\.sgov\.gov'; then
           echo "::error::Found disallowed URL suffixes in added lines"
-          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^+" | grep -P 'amazonaws\.com|amazonaws\.com\.cn|c2s\.ic\.gov|sc2s\.sgov\.gov'
+          git diff "origin/${BASE_REF}...HEAD" | grep "^+" | grep -P 'amazonaws\.com|amazonaws\.com\.cn|c2s\.ic\.gov|sc2s\.sgov\.gov'
           exit 1
         fi


### PR DESCRIPTION

### Description of changes
* Use intermediate environment variables for github.event.pull_request.base.ref instead of inline ${{ }} expressions in run scripts, following GitHub's recommended mitigation for script injection attacks.

Reference: https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
