### PR TITLE
[Test] Tolerate intermittent dcvsessionlauncher crash on g5g instances on AL23 associated to known issue in DCV

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -59,7 +59,7 @@ INSTANCE_TOLERATED_CRASH_PATTERNS = {
     # and when it does the test already fails the check specific to the connectivity.
     "g5g": [
         re.compile(
-            r"dcvsessionlauncher.*SIGSEGV.*g_subprocess_send_signal.*dcv/libgio",
+            r".*dcvsession.*SEGV.*g_subprocess_send_signal.*libgio",
             re.DOTALL,
         ),
     ],


### PR DESCRIPTION
### Description of changes
In DCV tests, tolerate harmless crash associated to known bug in DCV.
When this crash creates a problem for pcluster, the test will capture the impact with another soft assertion that capture the dcv connection failure.

We are already tolerating this crash, but the regex was not able to match the crash signature on AL2023.

### Tests
SUCCESS `test_dcv_configuration` on UBU22, Ubu24, AL23. Verified that the test capotures and tolerate the crash:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
