### PR TITLE
[release-3.15][integ-tests] Prevent integ-tests from hanging indefinitely

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -17,6 +17,8 @@ from assertpy import assert_that
 from retrying import retry
 from time_utils import minutes, seconds
 
+from tests.common.utils import is_blank
+
 
 class SchedulerCommands(metaclass=ABCMeta):
     """Define common scheduler commands."""
@@ -398,17 +400,24 @@ class SlurmCommands(SchedulerCommands):
             if match_stdout:
                 stdout = match_stdout.group(1)
                 logging.info("stdout:" + stdout)
-        if stderr is not None or stdout is not None:
-            if stderr == stdout:
-                result = self._remote_command_executor.run_remote_command(f'echo "stderr/stdout:" && cat {stderr}')
+        dump_timeout = 60
+        if not is_blank(stderr) or not is_blank(stdout):
+            if not is_blank(stderr) and stderr == stdout:
+                result = self._remote_command_executor.run_remote_command(
+                    f'echo "stderr/stdout:" && cat {stderr}', timeout=dump_timeout
+                )
                 logging.error(result.stdout)
             else:
-                if stderr is not None:
-                    stderr_result = self._remote_command_executor.run_remote_command(f'echo "stderr" && cat {stderr}')
+                if not is_blank(stderr):
+                    stderr_result = self._remote_command_executor.run_remote_command(
+                        f'echo "stderr" && cat {stderr}', timeout=dump_timeout
+                    )
                     logging.error(stderr_result.stdout)
 
-                if stdout is not None:
-                    stdout_result = self._remote_command_executor.run_remote_command(f'echo "stdout" && cat {stdout}')
+                if not is_blank(stdout):
+                    stdout_result = self._remote_command_executor.run_remote_command(
+                        f'echo "stdout" && cat {stdout}', timeout=dump_timeout
+                    )
                     logging.error(stdout_result.stdout)
         else:
             logging.error("Unable to retrieve job output.")

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -307,6 +307,11 @@ def get_sts_endpoint(region):
     return "https://sts.{0}.{1}".format(region, get_aws_domain(region))
 
 
+def is_blank(value):
+    """Return True if the value is None or an empty/whitespace-only string."""
+    return value is None or value.strip() == ""
+
+
 def generate_random_string():
     """
     Generate a random prefix that is 16 characters long.


### PR DESCRIPTION



### Description of changes
The test could hang indefinitely when dumping job output due to a weak condition and the lack of SSH timeout.

When this happens, it could also have impact on other tests. In fact, if the test hangs for too long, our watchdog mechanism would kill all the tests that are sharing the same VPC with this one as a way to protect from infinite test executions.

### References
* Cherry-pick from commit https://github.com/aws/aws-parallelcluster/commit/e21e4b54a79d3705c0cf0dcfbbe989aa9d4ac632

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
