### PR TITLE
[UpdateWorkflow] Make login node use head-node-driven orchestration for cluster updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 3.16.0
 ------
 
+**ENHANCEMENTS**
+- Improve cluster update resiliency on login nodes by reusing the head-node-driven orchestration already in place on compute nodes,
+  removing the dependency on cfn-hup and cfn-init.
+
 **CHANGES**
 - The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`, 
   consistent with the existing limit for `Database`. This prevents runtime failures caused by MySQL's table name length limit.
@@ -19,6 +23,7 @@ CHANGELOG
 - Fix race condition in load balancer lookup by using `tag:GetResources` to resolve load balancer ARNs by tags, 
   which used to cause cluster update failure on clusters with login nodes.
 - Fail `pcluster build-image` early when the downloaded cookbook version does not match the ParallelCluster CLI version.
+- Fix login nodes not mounting `/opt/parallelcluster/shared` when EFS is used as the internal shared storage type.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -48,6 +48,16 @@ datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
+  - path: /tmp/dna.json
+    permissions: '0644'
+    owner: root:root
+    content: |
+      ${DnaJson}
+  - path: /tmp/extra.json
+    permissions: '0644'
+    owner: root:root
+    content: |
+      ${ExtraJson}
   - path: /tmp/bootstrap.sh
     permissions: '0744'
     owner: root:root
@@ -77,8 +87,6 @@ write_files:
       [ -f /etc/parallelcluster/pcluster_cookbook_environment.sh ] && . /etc/parallelcluster/pcluster_cookbook_environment.sh
 
       [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
-
-      $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-init -s ${AWS::StackName} -v -c deployFiles -r ${LaunchTemplateResourceId} --region ${AWS::Region} --url ${CloudFormationUrl} --role ${CfnInitRole} || error_exit 'Failed to bootstrap the login node. Please check /var/log/cfn-init.log in the login node or in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs.'
 
       # Configure AWS CLI using the expected overrides, if any.
       [ -f /etc/profile.d/aws-cli-default-config.sh ] && . /etc/profile.d/aws-cli-default-config.sh
@@ -129,7 +137,10 @@ write_files:
         vendor_cookbook
       fi
       cd /tmp
+      mkdir -p /etc/chef/ohai/hints
+      touch /etc/chef/ohai/hints/ec2.json
 
+      jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )
       {
         CINC_CMD="cinc-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
         pushd /etc/chef &&

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1592,6 +1592,22 @@ class ClusterCdkStack:
                     }
                 }
 
+        # LoginPools record Name (for DescribeLaunchTemplateVersions lookup) and LogicalId
+        # (filename suffix for the shared dna.json, must match the login node's own
+        # launch_template_id). Id/Version are omitted to avoid a CloudFormation circular dependency:
+        # head node LT metadata -> LoginNodes nested stack -> head node.
+        if self.config.login_nodes and self.config.login_nodes.pools:
+            lt_config["LoginPools"] = {
+                pool.name: {
+                    "LaunchTemplate": {
+                        "Name": f"{self._stack_name}-{pool.name}",
+                        "Version": "$Latest",
+                        "LogicalId": f"LoginNodeLaunchTemplate{create_hash_suffix(pool.name)}",
+                    }
+                }
+                for pool in self.config.login_nodes.pools
+            }
+
         return lt_config
 
     # -- Conditions -------------------------------------------------------------------------------------------------- #

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -36,8 +36,6 @@ from pcluster.templates.cdk_builder_utils import (
 from pcluster.utils import (
     get_attr,
     get_http_tokens_setting,
-    get_resource_name_from_resource_arn,
-    get_service_endpoint,
     is_feature_supported,
 )
 
@@ -129,79 +127,7 @@ class Pool(Construct):
         ds_config = self._config.directory_service
         ds_generate_keys = str(ds_config.generate_ssh_keys_for_users).lower() if ds_config else "false"
 
-        if self._pool.instance_profile:
-            instance_profile_name = get_resource_name_from_resource_arn(self._pool.instance_profile)
-            instance_role_name = (
-                AWSApi.instance()
-                .iam.get_instance_profile(instance_profile_name)
-                .get("InstanceProfile")
-                .get("Roles")[0]
-                .get("RoleName")
-            )
-        elif self._pool.instance_role:
-            instance_role_name = get_resource_name_from_resource_arn(self._pool.instance_role)
-        else:
-            instance_role_name = self._instance_role.ref
-
         launch_template_id = f"LoginNodeLaunchTemplate{create_hash_suffix(self._pool.name)}"
-        launch_template = ec2.CfnLaunchTemplate(
-            Stack.of(self),
-            launch_template_id,
-            launch_template_name=f"{self.stack_name}-{self._pool.name}",
-            launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
-                block_device_mappings=self._launch_template_builder.get_block_device_mappings(
-                    self._pool.local_storage.root_volume,
-                    AWSApi.instance().ec2.describe_image(self._config.login_nodes_ami[self._pool.name]).device_name,
-                ),
-                image_id=self._config.login_nodes_ami[self._pool.name],
-                instance_type=self._pool.instance_type,
-                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
-                    http_tokens=get_http_tokens_setting(self._config.imds.imds_support)
-                ),
-                iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(name=self._instance_profile),
-                user_data=Fn.base64(
-                    Fn.sub(
-                        get_user_data_content("../resources/login_node/user_data.sh"),
-                        {
-                            **{
-                                "Timeout": str(
-                                    get_attr(
-                                        self._config,
-                                        "dev_settings.timeouts.compute_node_bootstrap_timeout",
-                                        NODE_BOOTSTRAP_TIMEOUT,
-                                    )
-                                ),
-                                "AutoScalingGroupName": f"{self._login_nodes_stack_id}-AutoScalingGroup",
-                                "LaunchingLifecycleHookName": (
-                                    f"{self._login_nodes_stack_id}-LoginNodesLaunchingLifecycleHook"
-                                ),
-                                "LaunchTemplateResourceId": launch_template_id,
-                                "CloudFormationUrl": get_service_endpoint("cloudformation", self._config.region),
-                                "CfnInitRole": instance_role_name,
-                            },
-                            **get_common_user_data_env(self._pool, self._config),
-                        },
-                    )
-                ),
-                network_interfaces=login_nodes_pool_lt_nw_interface,
-                tag_specifications=[
-                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
-                        resource_type="instance",
-                        tags=get_default_instance_tags(
-                            self.stack_name, self._config, self._pool, "LoginNode", self._shared_storage_infos
-                        )
-                        + [CfnTag(key=PCLUSTER_LOGIN_NODES_POOL_NAME_TAG, value=self._pool.name)]
-                        + get_custom_tags(self._config),
-                    ),
-                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
-                        resource_type="volume",
-                        tags=get_default_volume_tags(self.stack_name, "LoginNode")
-                        + [CfnTag(key=PCLUSTER_LOGIN_NODES_POOL_NAME_TAG, value=self._pool.name)]
-                        + get_custom_tags(self._config),
-                    ),
-                ],
-            ),
-        )
 
         dna_json = json.dumps(
             {
@@ -299,65 +225,66 @@ class Pool(Construct):
                     "launch_template_id": launch_template_id,
                 }
             },
-            indent=4,
+            indent=None,  # Keep indent as None for compact sizing and proper parsing in user_data.sh
         )
 
-        cfn_init = {
-            "configSets": {
-                "deployFiles": ["deployConfigFiles"],
-                "update": ["deployConfigFiles", "chefUpdate"],
-            },
-            "deployConfigFiles": {
-                "files": {
-                    # A nosec comment is appended to the following line in order to disable the B108 check.
-                    # The file is needed by the product
-                    # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
-                    "/tmp/dna.json": {  # nosec B108
-                        "content": dna_json,
-                        "mode": "000644",
-                        "owner": "root",
-                        "group": "root",
-                        "encoding": "plain",
-                    },
-                    # A nosec comment is appended to the following line in order to disable the B108 check.
-                    # The file is needed by the product
-                    # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
-                    "/tmp/extra.json": {  # nosec B108
-                        "mode": "000644",
-                        "owner": "root",
-                        "group": "root",
-                        "content": self._config.extra_chef_attributes,
-                    },
-                },
-                "commands": {
-                    "mkdir": {"command": "mkdir -p /etc/chef/ohai/hints"},
-                    "touch": {"command": "touch /etc/chef/ohai/hints/ec2.json"},
-                    "jq": {
-                        "command": (
-                            'jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json '
-                            '|| ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )'
+        launch_template = ec2.CfnLaunchTemplate(
+            Stack.of(self),
+            launch_template_id,
+            launch_template_name=f"{self.stack_name}-{self._pool.name}",
+            launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
+                block_device_mappings=self._launch_template_builder.get_block_device_mappings(
+                    self._pool.local_storage.root_volume,
+                    AWSApi.instance().ec2.describe_image(self._config.login_nodes_ami[self._pool.name]).device_name,
+                ),
+                image_id=self._config.login_nodes_ami[self._pool.name],
+                instance_type=self._pool.instance_type,
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
+                    http_tokens=get_http_tokens_setting(self._config.imds.imds_support)
+                ),
+                iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(name=self._instance_profile),
+                user_data=Fn.base64(
+                    Fn.sub(
+                        get_user_data_content("../resources/login_node/user_data.sh"),
+                        {
+                            **{
+                                "Timeout": str(
+                                    get_attr(
+                                        self._config,
+                                        "dev_settings.timeouts.compute_node_bootstrap_timeout",
+                                        NODE_BOOTSTRAP_TIMEOUT,
+                                    )
+                                ),
+                                "AutoScalingGroupName": f"{self._login_nodes_stack_id}-AutoScalingGroup",
+                                "LaunchingLifecycleHookName": (
+                                    f"{self._login_nodes_stack_id}-LoginNodesLaunchingLifecycleHook"
+                                ),
+                                "DnaJson": dna_json,
+                                "ExtraJson": self._config.extra_chef_attributes,
+                            },
+                            **get_common_user_data_env(self._pool, self._config),
+                        },
+                    )
+                ),
+                network_interfaces=login_nodes_pool_lt_nw_interface,
+                tag_specifications=[
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="instance",
+                        tags=get_default_instance_tags(
+                            self.stack_name, self._config, self._pool, "LoginNode", self._shared_storage_infos
                         )
-                    },
-                },
-            },
-            "chefUpdate": {
-                "commands": {
-                    "chef": {
-                        "command": (
-                            ". /etc/parallelcluster/pcluster_cookbook_environment.sh; "
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
-                            " --logfile /var/log/chef-client.log --force-formatter --no-color"
-                            " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
-                            " --override-runlist aws-parallelcluster-entrypoints::update &&"
-                            " /opt/parallelcluster/scripts/fetch_and_run -postupdate"
-                        ),
-                        "cwd": "/etc/chef",
-                    }
-                }
-            },
-        }
-
-        launch_template.add_metadata("AWS::CloudFormation::Init", cfn_init)
+                        + [CfnTag(key=PCLUSTER_LOGIN_NODES_POOL_NAME_TAG, value=self._pool.name)]
+                        + get_custom_tags(self._config),
+                    ),
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="volume",
+                        tags=get_default_volume_tags(self.stack_name, "LoginNode")
+                        + [CfnTag(key=PCLUSTER_LOGIN_NODES_POOL_NAME_TAG, value=self._pool.name)]
+                        + get_custom_tags(self._config),
+                    ),
+                ],
+            ),
+        )
 
         return launch_template
 

--- a/cli/src/pcluster/validators/dev_settings_validators.py
+++ b/cli/src/pcluster/validators/dev_settings_validators.py
@@ -14,7 +14,6 @@ from pcluster.validators.common import FailureLevel, Validator
 from pcluster.validators.utils import dig, is_boolean_string, str_to_bool
 
 EXTRA_CHEF_ATTRIBUTES_PATH = "DevSettings/Cookbook/ExtraChefAttributes"
-ATTR_IN_PLACE_UPDATE_ON_FLEET_ENABLED = "in_place_update_on_fleet_enabled"
 ATTR_RECONFIGURE_TIMEOUT = "cluster.slurm.reconfigure_timeout"
 ATTR_CLUSTER_READINESS_CHECK_ENABLED = "cluster.cluster_readiness_check_enabled"
 ATTR_CLUSTER_READINESS_CHECK_IGNORE_FAILURE = "cluster.cluster_readiness_check_ignore_failure"
@@ -35,39 +34,9 @@ class ExtraChefAttributesValidator(Validator):
             return
 
         attrs = json.loads(extra_chef_attributes)
-        self._validate_in_place_update_on_fleet_enabled(attrs)
         self._validate_slurm_reconfigure_timeout(attrs)
         self._validate_cluster_readiness_check_enabled(attrs)
         self._validate_cluster_readiness_check_ignore_failure(attrs)
-
-    def _validate_in_place_update_on_fleet_enabled(self, extra_chef_attributes: dict = None):
-        """Validate attribute cluster.in_place_update_on_fleet_enabled.
-
-        It returns an error if the attribute is set to a non-boolean value.
-        It returns a warning if the in-place update is disabled.
-
-        Args:
-            extra_chef_attributes: Dictionary of Chef attributes to validate.
-        """
-        in_place_update_on_fleet_enabled = dig(extra_chef_attributes, "cluster", ATTR_IN_PLACE_UPDATE_ON_FLEET_ENABLED)
-
-        if in_place_update_on_fleet_enabled is None:
-            return
-
-        if not is_boolean_string(str(in_place_update_on_fleet_enabled)):
-            self._add_failure(
-                f"Invalid value in {EXTRA_CHEF_ATTRIBUTES_PATH}: "
-                f"attribute '{ATTR_IN_PLACE_UPDATE_ON_FLEET_ENABLED}' must be a boolean value.",
-                FailureLevel.ERROR,
-            )
-            return
-
-        if str_to_bool(str(in_place_update_on_fleet_enabled)) is False:
-            self._add_failure(
-                "When in-place updates are disabled, cluster updates are applied "
-                "by replacing compute and login nodes according to the selected QueueUpdateStrategy.",
-                FailureLevel.WARNING,
-            )
 
     def _validate_cluster_readiness_check_enabled(self, extra_chef_attributes: dict = None):
         """Validate attribute cluster.cluster_readiness_check_enabled.

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -590,8 +590,14 @@ class LoginNodeLTAssertion:
         if self.custom_tags:
             for tag in self.custom_tags:
                 assert tag in properties["LaunchTemplateData"]["TagSpecifications"][0]["Tags"]
+        # The new login node bootstrap delivers dna.json/extra.json via cloud-init write_files
+        # rather than cfn-init, so the LT should not carry any AWS::CloudFormation::Init metadata
+        # and the user_data substitutions must include DnaJson/ExtraJson.
+        assert "Metadata" not in resources or "AWS::CloudFormation::Init" not in resources.get("Metadata", {})
+        lt_user_data_variables = properties["LaunchTemplateData"]["UserData"]["Fn::Base64"]["Fn::Sub"][1]
+        assert "DnaJson" in lt_user_data_variables
+        assert "ExtraJson" in lt_user_data_variables
         if self.user_data_variables:
-            lt_user_data_variables = properties["LaunchTemplateData"]["UserData"]["Fn::Base64"]["Fn::Sub"][1]
             for k, v in self.user_data_variables.items():
                 assert_that(lt_user_data_variables[k]).is_equal_to(v)
 
@@ -610,10 +616,11 @@ class LoginNodeLTAssertion:
                     # Managed instance profile
                     iam_instance_profile_name={"Ref": "InstanceProfileA50bdea9651dc48c"},
                     user_data_variables={
-                        "CloudFormationUrl": "https://cloudformation.us-east-1.amazonaws.com",
-                        "LaunchTemplateResourceId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
-                        # Name of the managed role name within the managed instance profile
-                        "CfnInitRole": {"Ref": "RoleA50bdea9651dc48c"},
+                        "ProxyServer": "NONE",
+                        "AutoScalingGroupName": "clustername-testloginnodespool1-AutoScalingGroup",
+                        "LaunchingLifecycleHookName": (
+                            "clustername-testloginnodespool1-LoginNodesLaunchingLifecycleHook"
+                        ),
                     },
                 ),
                 NetworkInterfaceLTAssertion(no_of_network_interfaces=1, subnet_id="subnet-12345678"),
@@ -631,10 +638,11 @@ class LoginNodeLTAssertion:
                     # Custom instance profile
                     iam_instance_profile_name="INSTANCE_PROFILE_NAME",
                     user_data_variables={
-                        "CloudFormationUrl": "https://cloudformation.us-east-1.amazonaws.com",
-                        "LaunchTemplateResourceId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
-                        # Name of the custom role within the custom instance profile
-                        "CfnInitRole": "Mocked-RoleName",
+                        "ProxyServer": "NONE",
+                        "AutoScalingGroupName": "clustername-testloginnodespool1-AutoScalingGroup",
+                        "LaunchingLifecycleHookName": (
+                            "clustername-testloginnodespool1-LoginNodesLaunchingLifecycleHook"
+                        ),
                     },
                 ),
                 NetworkInterfaceLTAssertion(no_of_network_interfaces=1, subnet_id="subnet-12345678"),
@@ -652,10 +660,11 @@ class LoginNodeLTAssertion:
                     # Managed instance profile containing the custom instance role
                     iam_instance_profile_name={"Ref": "InstanceProfileA50bdea9651dc48c"},
                     user_data_variables={
-                        "CloudFormationUrl": "https://cloudformation.us-east-1.amazonaws.com",
-                        "LaunchTemplateResourceId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
-                        # Name of the custom role
-                        "CfnInitRole": "ROLE_NAME",
+                        "ProxyServer": "NONE",
+                        "AutoScalingGroupName": "clustername-testloginnodespool1-AutoScalingGroup",
+                        "LaunchingLifecycleHookName": (
+                            "clustername-testloginnodespool1-LoginNodesLaunchingLifecycleHook"
+                        ),
                     },
                 ),
                 NetworkInterfaceLTAssertion(no_of_network_interfaces=1, subnet_id="subnet-12345678"),
@@ -673,10 +682,11 @@ class LoginNodeLTAssertion:
                     # Managed instance profile
                     iam_instance_profile_name={"Ref": "InstanceProfileA50bdea9651dc48c"},
                     user_data_variables={
-                        "CloudFormationUrl": "https://cloudformation.us-east-1.amazonaws.com",
-                        "LaunchTemplateResourceId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
-                        # Name of the managed role name within the managed instance profile
-                        "CfnInitRole": {"Ref": "RoleA50bdea9651dc48c"},
+                        "ProxyServer": "NONE",
+                        "AutoScalingGroupName": "clustername-testloginnodespool1-AutoScalingGroup",
+                        "LaunchingLifecycleHookName": (
+                            "clustername-testloginnodespool1-LoginNodesLaunchingLifecycleHook"
+                        ),
                     },
                 ),
                 NetworkInterfaceLTAssertion(no_of_network_interfaces=1, subnet_id="subnet-12345678"),
@@ -698,10 +708,11 @@ class LoginNodeLTAssertion:
                         {"Key": "rs:project", "Value": "solutions"},
                     ],
                     user_data_variables={
-                        "CloudFormationUrl": "https://cloudformation.us-east-1.amazonaws.com",
-                        "LaunchTemplateResourceId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
-                        # Name of the managed role name within the managed instance profile
-                        "CfnInitRole": {"Ref": "RoleA50bdea9651dc48c"},
+                        "ProxyServer": "NONE",
+                        "AutoScalingGroupName": "clustername-testloginnodespool1-AutoScalingGroup",
+                        "LaunchingLifecycleHookName": (
+                            "clustername-testloginnodespool1-LoginNodesLaunchingLifecycleHook"
+                        ),
                     },
                 ),
                 NetworkInterfaceLTAssertion(no_of_network_interfaces=1, subnet_id="subnet-12345678"),
@@ -1104,6 +1115,50 @@ def _get_cfn_init_file_content(template, resource, file):
     content_separator = content_join[0]
     content_elements = content_join[1]
     return content_separator.join(str(elem) for elem in content_elements)
+
+
+@pytest.mark.parametrize(
+    "config_file_name, expected_login_pools",
+    [
+        (
+            "test-login-nodes-stack.yaml",
+            {
+                "testloginnodespool1": {
+                    "LaunchTemplate": {
+                        "Name": "clustername-testloginnodespool1",
+                        "Version": "$Latest",
+                        "LogicalId": "LoginNodeLaunchTemplateA50bdea9651dc48c",
+                    }
+                }
+            },
+        ),
+        ("no-login-nodes-stack.yaml", None),
+    ],
+)
+def test_launch_templates_config_login_pools(
+    mocker, pcluster_config_reader, test_datadir, config_file_name, expected_login_pools
+):
+    """The head node launch-templates-config.json carries LoginPools with Name/Version/LogicalId."""
+    rendered_config_file = pcluster_config_reader(config_file_name)
+    generated_template, _ = get_generated_template_and_cdk_assets(mocker, rendered_config_file, test_datadir)
+
+    cfn_init = generated_template["Resources"]["HeadNodeLaunchTemplate"]["Metadata"]["AWS::CloudFormation::Init"]
+    content = cfn_init["deployConfigFiles"]["files"]["/opt/parallelcluster/shared/launch-templates-config.json"][
+        "content"
+    ]
+    # The content embeds CFN tokens (Ref/GetAtt) for the compute fleet, so CDK serializes it
+    # as an Fn::Join. Stringify the whole content and assert on the LoginPools literals, which
+    # are plain strings preserved verbatim.
+    content_blob = json.dumps(content, default=str)
+    if expected_login_pools is None:
+        assert_that(content_blob).does_not_contain("LoginPools")
+    else:
+        for _, pool in expected_login_pools.items():
+            lt = pool["LaunchTemplate"]
+            assert_that(content_blob).contains("LoginPools")
+            assert_that(content_blob).contains(lt["Name"])
+            assert_that(content_blob).contains(lt["Version"])
+            assert_that(content_blob).contains(lt["LogicalId"])
 
 
 @freeze_time("2021-01-01T01:01:01")

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_launch_templates_config_login_pools/no-login-nodes-stack.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_launch_templates_config_login_pools/no-login-nodes-stack.yaml
@@ -1,0 +1,21 @@
+Region: eu-west-1
+Image:
+  Os: alinux2023
+HeadNode:
+  InstanceType: t3.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue1
+    ComputeResources:
+    - Name: testcomputeresource
+      InstanceType: c4.xlarge
+      MinCount: 0
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - subnet-12345678

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_launch_templates_config_login_pools/test-login-nodes-stack.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_launch_templates_config_login_pools/test-login-nodes-stack.yaml
@@ -1,0 +1,30 @@
+Region: eu-west-1
+Image:
+  Os: alinux2023
+LoginNodes:
+  Pools:
+  - Name: testloginnodespool1
+    InstanceType: t3.micro
+    Count: 2
+    GracetimePeriod: 120
+    Networking:
+      SubnetIds:
+      - subnet-12345678
+HeadNode:
+  InstanceType: t3.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue1
+    ComputeResources:
+    - Name: testcomputeresource
+      InstanceType: c4.xlarge
+      MinCount: 0
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - subnet-12345678

--- a/cli/tests/pcluster/templates/test_login_nodes_stack.py
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack.py
@@ -1,6 +1,8 @@
+import email
 import json
 
 import pytest
+import yaml
 from assertpy import assert_that
 from freezegun import freeze_time
 
@@ -41,29 +43,46 @@ def test_login_nodes_dna_json(
     login_node_lt_id = "LoginNodeLaunchTemplate2736fab291f04e69"
     login_node_lt_asset = get_asset_content_with_resource_name(cdk_assets, login_node_lt_id)
     login_node_lt = login_node_lt_asset["Resources"][login_node_lt_id]
-    login_node_cfn_init_files = login_node_lt["Metadata"]["AWS::CloudFormation::Init"]["deployConfigFiles"]["files"]
-    login_node_dna_json = login_node_cfn_init_files["/tmp/dna.json"]
-    login_node_extra_json = login_node_cfn_init_files["/tmp/extra.json"]
+    login_node_user_data = login_node_lt["Properties"]["LaunchTemplateData"]["UserData"]["Fn::Base64"]["Fn::Sub"]
+    login_node_user_data_template = login_node_user_data[0]
+    login_node_user_data_substitutions = login_node_user_data[1]
+
+    login_node_dna_json = render_join(login_node_user_data_substitutions["DnaJson"]["Fn::Join"])
+    login_node_extra_json = login_node_user_data_substitutions["ExtraJson"]
 
     # Expected dna.json and extra.json
     expected_login_node_dna_json = load_json_dict(test_datadir / expected_login_node_dna_json_file_name)
     expected_login_node_extra_json = load_json_dict(test_datadir / expected_login_node_extra_json_file_name)
-    expected_owner = expected_group = "root"
-    expected_mode = "000644"
 
     # Assertions on dna.json
-    rendered_dna_json_content = render_join(login_node_dna_json["content"]["Fn::Join"])
-    rendered_dna_json_content_as_json = json.loads(rendered_dna_json_content)
-    assert_that(login_node_dna_json["owner"]).is_equal_to(expected_owner)
-    assert_that(login_node_dna_json["group"]).is_equal_to(expected_group)
-    assert_that(login_node_dna_json["mode"]).is_equal_to(expected_mode)
-    assert_that(rendered_dna_json_content_as_json).is_equal_to(expected_login_node_dna_json)
+    assert_that(json.loads(login_node_dna_json)).is_equal_to(expected_login_node_dna_json)
 
     # Assertions on extra.json
-    assert_that(login_node_extra_json["owner"]).is_equal_to(expected_owner)
-    assert_that(login_node_extra_json["group"]).is_equal_to(expected_group)
-    assert_that(login_node_extra_json["mode"]).is_equal_to(expected_mode)
-    assert_that(json.loads(login_node_extra_json["content"])).is_equal_to(expected_login_node_extra_json)
+    assert_that(json.loads(login_node_extra_json)).is_equal_to(expected_login_node_extra_json)
+
+    # Assertions on the cloud-init write_files directives that materialize dna.json and
+    # extra.json to check they are created with the correct ownership and permissions.
+    expected_owner = "root:root"
+    expected_permissions = "0644"
+
+    _assert_write_files_directive(login_node_user_data_template, "/tmp/dna.json", expected_owner, expected_permissions)
+    _assert_write_files_directive(
+        login_node_user_data_template, "/tmp/extra.json", expected_owner, expected_permissions
+    )
+
+
+def _assert_write_files_directive(mime_user_data: str, path: str, expected_owner: str, expected_permissions: str):
+    """Assert the cloud-init write_files directive for the given path exists with the expected ownership/permissions."""
+    message = email.message_from_string(mime_user_data)
+    directive = None
+    for part in message.walk():
+        if part.get_content_type() == "text/cloud-config":
+            write_files = yaml.safe_load(part.get_payload()).get("write_files") or []
+            directive = next((d for d in write_files if d.get("path") == path), None)
+            break
+    assert_that(directive).is_not_none()
+    assert_that(directive["owner"]).is_equal_to(expected_owner)
+    assert_that(directive["permissions"]).is_equal_to(expected_permissions)
 
 
 def render_join(elem: dict):

--- a/cli/tests/pcluster/validators/test_dev_settings_validators.py
+++ b/cli/tests/pcluster/validators/test_dev_settings_validators.py
@@ -18,62 +18,6 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
 @pytest.mark.parametrize(
     "extra_chef_attributes, expected_message, expected_failure_level",
     [
-        pytest.param(None, None, None, id="No extra chef attributes"),
-        pytest.param('{"other_attribute": "value"}', None, None, id="in_place_update_on_fleet_enabled not set"),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": "true"}}',
-            None,
-            None,
-            id="in_place_update_true_string 'true' passes",
-        ),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": true}}',
-            None,
-            None,
-            id="in_place_update_true_string true passes",
-        ),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": "false"}}',
-            "When in-place updates are disabled, cluster updates are applied "
-            "by replacing compute and login nodes according to the selected QueueUpdateStrategy.",
-            FailureLevel.WARNING,
-            id="in_place_update_true_string 'false' throws a warning",
-        ),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": false}}',
-            "When in-place updates are disabled, cluster updates are applied "
-            "by replacing compute and login nodes according to the selected QueueUpdateStrategy.",
-            FailureLevel.WARNING,
-            id="in_place_update_true_string false throws a warning",
-        ),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": "invalid"}}',
-            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
-            "attribute 'in_place_update_on_fleet_enabled' must be a boolean value.",
-            FailureLevel.ERROR,
-            id="in_place_update_true_string invalid (string) throws an error",
-        ),
-        pytest.param(
-            '{"cluster": {"in_place_update_on_fleet_enabled": 123}}',
-            "Invalid value in DevSettings/Cookbook/ExtraChefAttributes: "
-            "attribute 'in_place_update_on_fleet_enabled' must be a boolean value.",
-            FailureLevel.ERROR,
-            id="n_place_update_true_string invalid (number) throws an error",
-        ),
-    ],
-)
-def test_extra_chef_attributes_validator_in_place_update(
-    extra_chef_attributes, expected_message, expected_failure_level
-):
-    actual_failures = ExtraChefAttributesValidator().execute(extra_chef_attributes=extra_chef_attributes)
-    assert_failure_messages(actual_failures, expected_message)
-    if expected_failure_level:
-        assert_failure_level(actual_failures, expected_failure_level)
-
-
-@pytest.mark.parametrize(
-    "extra_chef_attributes, expected_message, expected_failure_level",
-    [
         pytest.param(
             '{"cluster": {"slurm": {"reconfigure_timeout": 600}}}',
             None,

--- a/tests/integration-tests/tests/update/test_update_race_conditions.py
+++ b/tests/integration-tests/tests/update/test_update_race_conditions.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import json
 import logging
-import re
 import time
 from datetime import datetime, timezone
 
@@ -36,19 +35,19 @@ PHASE_ON_NODE_START = "OnNodeStart"
 PHASE_ON_NODE_CONFIGURED = "OnNodeConfigured"
 SERVICE_MANAGEMENT_CMD_BY_NODE_TYPE = {
     NODE_TYPE_COMPUTE: "systemctl",
-    NODE_TYPE_LOGIN: "/opt/parallelcluster/pyenv/versions/*/envs/cookbook_virtualenv/bin/supervisorctl",
+    NODE_TYPE_LOGIN: "systemctl",
 }
 UPDATE_DETECTION_SERVICE_BY_NODE_TYPE = {
     NODE_TYPE_COMPUTE: "pcluster-check-update.timer",
-    NODE_TYPE_LOGIN: "cfn-hup",
+    NODE_TYPE_LOGIN: "pcluster-check-update.timer",
 }
 UPDATE_ACTION_SCRIPT_BY_NODE_TYPE = {
     NODE_TYPE_COMPUTE: "/opt/parallelcluster/scripts/cfn-hup-update-action.sh",
-    NODE_TYPE_LOGIN: "/opt/parallelcluster/pyenv/versions/*/envs/cfn_bootstrap_virtualenv/bin/cfn-init",
+    NODE_TYPE_LOGIN: "/opt/parallelcluster/scripts/cfn-hup-update-action.sh",
 }
 LOG_FILE_BY_NODE_TYPE = {
     NODE_TYPE_COMPUTE: "/var/log/parallelcluster/pcluster-check-update.log",
-    NODE_TYPE_LOGIN: "/var/log/cfn-hup.log",
+    NODE_TYPE_LOGIN: "/var/log/parallelcluster/pcluster-check-update.log",
 }
 
 
@@ -151,9 +150,6 @@ def wait_for_login_nodes_lt_update_complete(cluster, region, after_utc=None):
 def wait_for_node_update_failure(rce, cluster, node_type, node_id, os, after_utc=None):
     node_rce = get_node_rce(rce, cluster, node_type, node_id)
     log_file = LOG_FILE_BY_NODE_TYPE[node_type]
-    # cfn-hup logs use "%Y-%m-%d %H:%M:%S" format, so convert ISO timestamps for awk comparison
-    if after_utc and node_type == NODE_TYPE_LOGIN:
-        after_utc = after_utc.replace("T", " ").split(".")[0]
     match, lines = match_regex_in_log(
         node_rce,
         log_file,
@@ -386,46 +382,6 @@ def assert_update_recipe_executed_on_old_nodes(snapshot, update_submitted_at, ex
         ).is_not_empty()
 
 
-def is_update_failure_only_due_to_known_race_condition(rce, instance_ids: list, after_utc: str):
-    """Check if the last readiness check failure was caused only by the given instance IDs by inspecting the
-    errors returned by the cluster readiness check in /var/log/chef-client.log
-    Returns True if all wrong-record instance IDs are in the provided set.
-    Returns False if there are no wrong records or if other instance IDs are present.
-    """
-    found, lines = match_regex_in_log(
-        rce,
-        "/var/log/chef-client.log",
-        r"Retrying execution of execute\[Check cluster readiness\], 0 attempt left",
-        after_utc=after_utc,
-        nlines_after_match=50,
-    )
-    if not found:
-        logger.info(
-            "No final readiness check retry found in chef-client.log after the update. "
-            "The cluster update failure, if observed, is not caused by the known race condition."
-        )
-        return False
-
-    logger.info(f"Found last readiness check retry: {lines}")
-
-    wrong_records_match = re.search(r"\* wrong records \(1\):.*", lines)
-    if not wrong_records_match:
-        logger.info(
-            "No '* wrong records (1):' line found in the last readiness check retry output. "
-            "The cluster update failure, if observed, is not caused by the known race condition."
-        )
-        return False
-
-    wrong_records_line = wrong_records_match.group()
-    instance_ids_with_wrong_record = set(re.findall(r"'(i-[0-9a-f]+)'", wrong_records_line))
-    logger.info(
-        f"Readiness check wrong records: {wrong_records_line}. "
-        f"Instance IDs with wrong records: {instance_ids_with_wrong_record}. "
-        f"Instance IDs with expected failure: {instance_ids}"
-    )
-    return instance_ids_with_wrong_record == set(instance_ids)
-
-
 # CN_1: a dynamic compute node that completes the bootstrap after the readiness check
 # CN_2: a dynamic compute node that completes the bootstrap at the second-last iteration of the readiness check
 # CN_3: a static node that fails the update due to a transient failure
@@ -448,9 +404,9 @@ def test_update_race_conditions(
     s3_bucket_factory,
 ):
     """
-    Test that a cluster update succeeds despite concurrent race conditions on compute and login nodes.
+    Test that a cluster update succeeds despite exposure to the risk of race conditions on compute and login nodes.
 
-    Race conditions under test:
+    The test verifies that all the known race conditions below are solved:
         * [RaceCondition 1] A node that completes the bootstrap after the update is not able to execute the update.
            We know this could happen when DNA files are removed at the end of a successful update.
         * [RaceCondition 2] A node that completes the bootstrap close to the end of the readiness check can cause
@@ -460,8 +416,8 @@ def test_update_race_conditions(
         * [RaceCondition 4] A node that faces a transient failure in the detection of the update does not retry
            the update.
         * [RaceCondition 5] A login node that is started before the update but completes the config phase during
-           the update will skip the update. This happens because cfn-hup will see the updated
-           launch template and will think thereafter that it has deployed the updated config,
+           the update will skip the update. This happens because the update detection mechanism will see the
+           updated launch template and will think thereafter that it has deployed the updated config,
            even if it did not.
 
     The test creates a cluster with 2 static compute nodes, 1 login node, and capacity for dynamic
@@ -474,8 +430,8 @@ def test_update_race_conditions(
         CN_3 (q1-st-cr1-1): static node, transient failure injected in the execution of its update before update 2.
         CN_4 (q1-st-cr1-2): static node, transient failure injected in the detection of its update before update 2.
         LN_1: login node terminated and replaced by a slow-bootstrapping one before update 2.
-        LN_2: an existing login node with a transient update execution failure (chmod -x cfn-init).
-        LN_3: an existing login node with update detection blocked (cfn-hup stopped).
+        LN_2: an existing login node with a transient update execution failure (chmod -x of the update action script).
+        LN_3: an existing login node with update detection blocked (pcluster-check-update.timer stopped).
 
     Update 1: validates race condition #1
         [RaceCondition 1]  CN_1 is launched with its bootstrap blocked before the update is submitted. The update
@@ -495,10 +451,10 @@ def test_update_race_conditions(
         - [RaceCondition 5] A login node is terminated and replaced by a slow-bootstrapping one (blocked in
           OnNodeStart). After the login node Launch Template is updated in CloudFormation, the
           slow login node is unblocked so it completes bootstrap with the already-updated LT.
-          This node is exposed to a race condition where it bootstraps with the old LT, but when cfn-hup starts
-          it detects the new LT and will think thereafter to have deplpoyed the updated LT.
-          As a result, when the login node ends the bootstrap, it will not detect the update
-          because cfn-hup thinks it already has deployed the updated config.
+          This node is exposed to a race condition where it bootstraps with the old LT, but when the update
+          detection mechanism starts it detects the new LT and will think thereafter to have deployed the
+          updated LT. As a result, when the login node ends the bootstrap, it will not detect the update
+          because the update detection mechanism thinks it already has deployed the updated config.
 
     Verifications (soft assertions - all run even if some fail):
         - The cluster stack reaches UPDATE_COMPLETE.
@@ -663,17 +619,9 @@ def test_update_race_conditions(
     logger.info(f"Cluster snapshot:\n{json.dumps(cluster_snapshot, indent=2)}")
 
     with soft_assertions():
-        # TODO: Once [RaceCondition 5] will be fixed, we will require cluster stack to always be in UPDATE_COMPLETE
-        if actual_cluster_stack_status != "UPDATE_COMPLETE":
-            if is_update_failure_only_due_to_known_race_condition(rce, [login_node_1_id], update_2_submit_time):
-                logger.warning(
-                    f"Cluster stack status is {actual_cluster_stack_status} but the readiness check failed "
-                    f"only because of {login_node_1_id} (known RaceCondition 5, not blocking the test)"
-                )
-            else:
-                assert_that(actual_cluster_stack_status).described_as(
-                    f"Cluster stack status should be UPDATE_COMPLETE, but it is {actual_cluster_stack_status}"
-                ).is_equal_to("UPDATE_COMPLETE")
+        assert_that(actual_cluster_stack_status).described_as(
+            f"Cluster stack status should be UPDATE_COMPLETE, but it is {actual_cluster_stack_status}"
+        ).is_equal_to("UPDATE_COMPLETE")
         assert_that(is_late_node_updated).described_as(
             f"Compute node {CN_1} completed the bootstrap after update 1 and did not apply the expected update"
         ).is_true()


### PR DESCRIPTION
**This PR depends on https://github.com/aws/aws-parallelcluster-cookbook/pull/3188**

### Description of changes
Make login node use head-node-driven orchestration for the update workflow.

With this change, login nodes do not depend on cfn-hup/cfn-init anymore and mirror the same update mechanism already adopted for compute nodes. With this change we expect the update workflow to be more resilient.

The changes in this PR mirrors the changes made for compute fleet in the following PRs:
1. https://github.com/aws/aws-parallelcluster-cookbook/pull/3070: this is the core change that removes cfn-hup
1. https://github.com/aws/aws-parallelcluster-cookbook/pull/2875: change in cookbook to remove cfn-init, required by change #1
1. https://github.com/aws/aws-parallelcluster/pull/6655: change in cli to remove cfn-init, required by change #1
1. https://github.com/aws/aws-parallelcluster-cookbook/pull/3093: minor change related to logs


In particular:
1. files that used ot be written by cfn-init arer now written by user datab directives, such as dna.json.
2. parameters and permissions required by cfn-init are removed from the login nodes launch template
3. login nodes launch templates identifications are included in `launch-templates-config.json`
4. the validation of the chef attribute `in_place_update_on_fleet_enabled` is removed as the attribute is not used anymore (see https://github.com/aws/aws-parallelcluster-cookbook/pull/3188)

#### Notes
1. See comments "Note for the reviewer" for specific explanations about non obvious changes.

### Tests
* SUCCESS
```
test-suites:
  update:
    test_update.py::test_update_slurm:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
    test_update.py::test_dynamic_file_systems_update_rollback:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
    test_update.py::test_login_nodes_update:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
    test_update_rollback_failure.py::test_update_rollback_failure:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
    test_update_race_conditions.py::test_update_race_conditions:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
