### PR TITLE
[integ-tests-framework] Shuffle candidate_regions to balance tests across regions

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import os
+import random
 import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
@@ -339,6 +340,7 @@ def _check_or_create_capacity_reservations(config_file, os_parameters, instance_
                 "us-west-2",
                 "us-east-1",
             ]
+            random.shuffle(candidate_regions)
             if not _create_capacity_reservations(az_for_capacity_reservation, candidate_regions, specs, var):
                 # If failed to create reservation, use use1-az6 to avoid making the test yaml syntactically wrong.
                 logging.info("Failed to create capacity reservation for %s. Using use1-az6", var)


### PR DESCRIPTION
### Description of changes

Cherry picked from https://github.com/aws/aws-parallelcluster/pull/7372

_check_or_create_capacity_reservations iterated candidate_regions in a fixed order and returned on the first region where reservation succeeded. Because ap-northeast-2 was always first, most tests that needed a capacity reservation ended up clustered there, causing slow test run.

Shuffle the list before use so reservations are distributed across all candidate regions.


### Tests
* Tests will run after PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
