### PR TITLE
[Bug] Validate the Cookbook Version with Pcluster CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 - Fix clustermgtd failing to detect compute node bootstrap timeouts, which prevented the cluster from entering protected mode.
 - Fix race condition in load balancer lookup by using `tag:GetResources` to resolve load balancer ARNs by tags, 
   which used to cause cluster update failure on clusters with login nodes.
+- Fail `pcluster build-image` early when the downloaded cookbook version does not match the ParallelCluster CLI version.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -251,6 +251,11 @@ phases:
             - |
               set -ex
               . /opt/parallelcluster/system_info
+
+              # Validate cookbook version matches expected ParallelCluster version
+              ACTUAL_COOKBOOK_VER=$(awk -F\' '/^version/{print $2}' /etc/chef/cookbooks/aws-parallelcluster-entrypoints/metadata.rb)
+              [ "${!ACTUAL_COOKBOOK_VER}" = "${CfnParamCookbookVersion}" ] || { echo "Cookbook version mismatch: expected ${CfnParamCookbookVersion}, found ${!ACTUAL_COOKBOOK_VER}"; exit 1; }
+
               echo "Calling chef-client with /etc/parallelcluster/image_dna.json"
               cat /etc/parallelcluster/image_dna.json
               cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster-entrypoints::install


### PR DESCRIPTION
### Description of changes


ParallelCluster writes `/opt/parallelcluster/.bootstrapped` during AMI creation to record the ParallelCluster CLI version used to build the AMI. The edge case is that an incorrectly versioned cookbook can be uploaded under the expected name, and `pcluster build-image` will not catch the mismatch — it produces a successful AMI even though the cookbook on disk does not match the CLI version.

This fix validates the cookbook version against the ParallelCluster CLI version at build time so we fail fast. Without it, the failure only surfaces later during cluster creation, when the chef-client log shows the loaded cookbook version differs from the value in `/opt/parallelcluster/.bootstrapped` file.

Now it will fail with 
```
Stdout: ERROR: Cookbook version mismatch. Expected 3.16.0 but found 3.15.1 in cookbook metadata. The downloaded cookbook does not match the expected ParallelCluster version.
2026-05-27T21:25:52.168Z
CmdExecution: Command execution has been completed
2026-05-27T21:25:52.168Z
CmdExecution: [ ERROR ] Command execution has resulted in an error
2026-05-27T21:25:52.168Z

```

### Tests
* Build image with Cookbook Version different from Pcluster CLI version
* Build Image with same Cookbook Version and Pcluster CLI version

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
