### PR TITLE
Fix test_build_image for rhel9 by pinning parent image

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -53,7 +53,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "rocky8": {"name": "Rocky-8-EC2-Base-8.10*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
-    "rhel9": {"name": "RHEL-9.*_HVM*", "owners": RHEL_OWNERS},
+    "rhel9": {"name": "RHEL-9.7*_HVM*", "owners": RHEL_OWNERS},
     "rocky9": {"name": "Rocky-9-EC2-Base-9.*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -164,6 +164,8 @@ def test_build_image(
             enable_lustre_client = False
     if os in ["alinux2", "alinux2023", "rocky9"]:
         update_os_packages = True
+    if os in ["rhel9"]:
+        update_os_packages = False
 
     enable_dcv = True
 


### PR DESCRIPTION
### Description of changes
* Fix test_build_image for rhel9 by pinning parent image to 9.7
* Set update_os_packages to false for rhel9
* This fixes the failing efa installtion that occurs with rhel 9.8

### Tests
* Ran test_build_image for rhel9

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
