### PR TITLE
Check that resolved path is still in dstdir for export logs

### DIFF
--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -230,6 +230,10 @@ class CloudWatchLogsExporter:
             decompressed_path = decompressed_path.replace(
                 r"{unwanted_path_segment}{sep}".format(unwanted_path_segment=prefix, sep=os.path.sep), ""
             )
+            decompressed_path = os.path.realpath(decompressed_path)
+            if not decompressed_path.startswith(os.path.realpath(destdir) + os.sep):
+                LOGGER.warning("Skipping unsafe S3 key (path traversal detected): %s", archive_object.key)
+                continue
             compressed_path = f"{decompressed_path}.gz"
 
             LOGGER.debug("Downloading object with key=%s to %s", archive_object.key, compressed_path)


### PR DESCRIPTION
### Description of changes
* Check that resolved path is still in dstdir for export logs
* Fixes bug where an attacker-controlled S3 object key could be used to escape the intended local export directory and overwrite an arbitrary file in the security context of the user or automation account running the export command.

### Tests
* Ran `pcluster export-cluster-logs`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
