### PR TITLE
Fix build image test for Rocky9 and Rhel9 by pinning to kernel 9.7

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -57,7 +57,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.7*_HVM*", "owners": RHEL_OWNERS},
-    "rocky9": {"name": "Rocky-9-EC2-Base-9.*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky9": {"name": "Rocky-9-EC2-Base-9.7*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
 # Remarkable AMIs are latest deep learning base AMI and FPGA developer AMI without pcluster infrastructure

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -56,7 +56,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "rocky8": {"name": "Rocky-8-EC2-Base-8.10*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
-    "rhel9": {"name": "RHEL-9.*_HVM*", "owners": RHEL_OWNERS},
+    "rhel9": {"name": "RHEL-9.7*_HVM*", "owners": RHEL_OWNERS},
     "rocky9": {"name": "Rocky-9-EC2-Base-9.*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -163,8 +163,11 @@ def test_build_image(
         base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
         if os in ["rocky9"]:
             enable_lustre_client = False
-    if os in ["alinux2", "alinux2023", "rocky9"]:
+    if os in ["alinux2", "alinux2023"]:
         update_os_packages = True
+
+    if os in ["rhel9", "rocky9"]:
+        update_os_packages = False
 
     enable_dcv = True
 


### PR DESCRIPTION
### Description of changes
* Fix build image test for Rocky9 and Rhel9
* Pin to 9.7 kernel and disable update of os packages
* Pinning the kernel because the efa installation does not support the 9.8 kernel

### Tests
* Ran build image test for rocky9 and rhel9

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
