### PR TITLE
[Test] Fix intermittent failure in test_dynamic_file_system_update.

### DIFF
--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -71,7 +71,8 @@ Parameters:
     Default: ''
   SubnetTwo:
     Description: ID of the Subnet (second Availability Zone) where the storage will be deployed.
-    Type: AWS::EC2::Subnet::Id
+    # The type has to be String to allow empty values.
+    Type: String
     Default: ''
   SubnetThree:
     Description: ID of the Subnet (third Availability Zone) where the storage will be deployed.
@@ -115,6 +116,9 @@ Parameters:
 Conditions:
   CreateEbs: !Equals [!Ref CreateEbs, 'true']
   CreateEfs: !Equals [!Ref CreateEfs, 'true']
+  CreateMountTargetResourceEfs0SubnetTwo: !And
+    - !Equals [!Ref CreateEfs, 'true']
+    - !Not [!Equals [!Ref SubnetTwo, '']]
   CreateMountTargetResourceEfs0SubnetThree: !And
     - !Equals [!Ref CreateEfs, 'true']
     - !Not [!Equals [!Ref SubnetThree, '']]
@@ -157,7 +161,7 @@ Resources:
       SubnetId: !Ref SubnetOne
   MountTargetResourceEfs0SubnetTwo:
     Type: 'AWS::EFS::MountTarget'
-    Condition: CreateEfs
+    Condition: CreateMountTargetResourceEfs0SubnetTwo
     Properties:
       FileSystemId: !Ref EfsFileSystem
       SecurityGroups:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -14,7 +14,6 @@ import os
 import os.path as os_path
 import re
 import time
-from collections import defaultdict
 from datetime import datetime
 
 import boto3
@@ -1004,14 +1003,11 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack: CfnV
         if request.config.getoption(option):
             stack = CfnStack(name=request.config.getoption(option), region=region, template=None)
         else:
-            # Choose subnets from different availability zones
-            subnet_ids = vpc_stack.get_all_public_subnets() + vpc_stack.get_all_private_subnets()
-            subnets = boto3.client("ec2").describe_subnets(SubnetIds=subnet_ids)["Subnets"]
-            subnets_by_az = defaultdict(list)
-            for subnet in subnets:
-                subnets_by_az[subnet["AvailabilityZone"]].append(subnet["SubnetId"])
-            azs = [az for az in subnets_by_az.keys()]
-            one_subnet_per_az = [subnets_by_az[az][0] for az in azs]
+            # Deploy the storage in the private subnet used by the cluster compute nodes.
+            # The head node, login nodes and compute nodes all live in the same Availability Zone,
+            # so a single EFS mount target in the compute node subnet covers every node in the cluster.
+            # The other single-AZ storage resources (FSx, File Cache, EBS) are co-located there as well.
+            compute_subnet_id = vpc_stack.get_private_subnet()
 
             # The EBS volume must be placed in the same AZ where the head node is.
             # The head node is deployed in the public subnet.
@@ -1029,12 +1025,9 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack: CfnV
             params = [
                 # Networking
                 {"ParameterKey": "Vpc", "ParameterValue": vpc},
-                {"ParameterKey": "SubnetOne", "ParameterValue": one_subnet_per_az[0]},
-                {"ParameterKey": "SubnetTwo", "ParameterValue": one_subnet_per_az[1]},
-                {
-                    "ParameterKey": "SubnetThree",
-                    "ParameterValue": "" if len(one_subnet_per_az) == 2 else one_subnet_per_az[2],
-                },
+                {"ParameterKey": "SubnetOne", "ParameterValue": compute_subnet_id},
+                {"ParameterKey": "SubnetTwo", "ParameterValue": ""},
+                {"ParameterKey": "SubnetThree", "ParameterValue": ""},
                 # EBS
                 {"ParameterKey": "CreateEbs", "ParameterValue": "true"},
                 {"ParameterKey": "EbsVolumeAz", "ParameterValue": ebs_volume_az},


### PR DESCRIPTION
### Description of changes
Fix intermittent failure in test_dynamic_file_system_update.
The test could fail because the external EFS has chances to deploy mount targets in AZs that are not used by the cluster. 
With this fix we deploy the storage in the private subnets used by the compute nodes (one per AZ), so that the external EFS has a mount target in every AZ used by the cluster.

### Tests
SUCCEEDED
```
test-suites:
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
