### PR TITLE
[integ-tests] Fix assert_no_errors_in_logs to skip ICE-caused "setting nodes to DOWN" errors

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -54,6 +54,26 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False,
         "Our system will be working on provisioning additional capacity",
     ]
 
+    # EC2 error codes that the node daemons treat as Insufficient Capacity Errors (ICE).
+    # Mirrors SlurmNode.EC2_ICE_ERROR_CODES from aws-parallelcluster-node, plus the
+    # "LimitedInstanceCapacity" code used for partial all-or-nothing/best-effort launches.
+    ice_error_codes = {
+        "InsufficientInstanceCapacity",
+        "InsufficientHostCapacity",
+        "InsufficientReservedInstanceCapacity",
+        "MaxSpotInstanceCountExceeded",
+        "Unsupported",
+        "SpotMaxPriceTooLow",
+        "UnfulfillableCapacity",
+        "InsufficientCapacity",
+        "LimitedInstanceCapacity",
+    }
+    # Emitted by the resume program (resume.py) when one or more nodes fail to launch. The line
+    # itself carries no EC2 error code, so the line-level ice_patterns filter cannot match it.
+    # The code only appears on the companion "(Code:<error_code>)Failure when resuming nodes"
+    # line written by _handle_failed_nodes.
+    setting_nodes_down_pattern = "Failed to launch following nodes, setting nodes to DOWN"
+
     patterns_to_ignore = []
     if skip_ice:
         patterns_to_ignore += ice_patterns
@@ -70,9 +90,17 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False,
     for log_file in log_files:
         log_file_user = remote_command_executor.get_user_to_operate_on_file(log_file)
         log = remote_command_executor.run_remote_command(f"sudo -u {log_file_user} cat {log_file}", hide=True).stdout
-        log = "\n".join(
-            [line for line in log.splitlines() if not any(pattern in line for pattern in patterns_to_ignore)]
-        )
+        lines = log.splitlines()
+
+        if skip_ice:
+            # Pair the untagged "setting nodes to DOWN" ERROR line with the "(Code:<error_code>)"
+            # reasons in the same log file. Ignore the line only when every error code found in
+            # this file is an ICE code, otherwise keep it so genuine non-ICE failures still fail.
+            error_codes = set(re.findall(r"\(Code:(\w+)\)", log))
+            if error_codes and error_codes.issubset(ice_error_codes):
+                lines = [line for line in lines if setting_nodes_down_pattern not in line]
+
+        log = "\n".join(line for line in lines if not any(pattern in line for pattern in patterns_to_ignore))
         for error_level in ["CRITICAL", "ERROR"]:
             assert_that(log).does_not_contain(error_level)
 


### PR DESCRIPTION
### Description of changes

When skip_ice=True, assert_no_errors_in_logs filtered log lines by matching EC2 capacity message fragments (e.g. "InsufficientInstanceCapacity") against each line. This caught the root-cause ERRORs, but missed the downstream ERROR:
```
  ERROR - Failed to launch following nodes, setting nodes to DOWN: [...]
```
That line carries no capacity keyword or error code, so it was never filtered. The EC2 error code only appears on the companion INFO line written by _handle_failed_nodes ("(Code:InsufficientInstanceCapacity)Failure when resuming nodes..."). As a result, tests calling skip_ice=True could still fail intermittently whenever ICE struck on the dynamic-node resume path.

This change pairs the untagged "setting nodes to DOWN" ERROR with the "(Code:<error_code>)" reasons found in the same log file. When skip_ice is set, the line is ignored only if at least one code is present and every code in that file is a known ICE code; otherwise the line is kept so genuine non-ICE launch failures still fail the assertion.

The ICE code set mirrors SlurmNode.EC2_ICE_ERROR_CODES from aws-parallelcluster-node plus LimitedInstanceCapacity (used for partial all-or-nothing/best-effort launches).

### Tests
* Tests will run after PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
