### PR TITLE
Fix cherry-pick workflow for fork PRs and comment on success

### DIFF
--- a/.github/workflows/cherry-pick-to-branch.yml
+++ b/.github/workflows/cherry-pick-to-branch.yml
@@ -88,6 +88,11 @@ jobs:
           TARGET_BRANCHES: ${{ steps.pr-info.outputs.target_branches }}
           REPO: ${{ github.repository }}
         run: |
+          # Fetch the PR's commits. They may live in a fork (different account),
+          # so they are not present in the base repo checkout. The refs/pull/*/head
+          # ref makes them available regardless of which fork the PR came from.
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+
           HAS_FAILURE=false
           for TARGET_BRANCH in ${TARGET_BRANCHES}; do
             CHERRY_PICK_BRANCH="cherry-pick/pr-${PR_NUMBER}-to-${TARGET_BRANCH}"
@@ -110,15 +115,17 @@ jobs:
 
             if [ "${CHERRY_PICK_FAILED}" = "false" ]; then
               git push origin "${CHERRY_PICK_BRANCH}"
-              gh pr create \
+              NEW_PR_URL=$(gh pr create \
                 --base "${TARGET_BRANCH}" \
                 --head "${CHERRY_PICK_BRANCH}" \
                 --title "Cherry-pick #${PR_NUMBER}: ${PR_TITLE}" \
                 --body "Automated cherry-pick of #${PR_NUMBER} from \`${SOURCE_BRANCH}\` to \`${TARGET_BRANCH}\`.
 
           Original PR by @${PR_AUTHOR}." \
-                --label "cherry-pick"
-              echo "✅ Cherry-pick PR to ${TARGET_BRANCH} created successfully"
+                --label "cherry-pick")
+              gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+                --body "✅ Cherry-pick to \`${TARGET_BRANCH}\` opened: ${NEW_PR_URL}"
+              echo "✅ Cherry-pick PR to ${TARGET_BRANCH} created successfully: ${NEW_PR_URL}"
             else
               HAS_FAILURE=true
               gh pr comment "${PR_NUMBER}" --repo "${REPO}" \


### PR DESCRIPTION
### Description of changes
The cherry-pick workflow failed with "fatal: bad object <sha>" when the source PR came from a fork in another account. The job checks out the base repo and only fetches the target branch, so the PR's commits were never present locally and the cherry-pick could not resolve them.

Fetch refs/pull/<n>/head before cherry-picking so the PR's original commits are available regardless of which fork they came from.

Also comment on the original PR when a cherry-pick succeeds, linking to the newly opened PR. This mirrors the existing failure comment and gives a clear per-target-branch status when a PR is backported to multiple branches.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
