### PR TITLE
[CLI] Add CreateFleet instance info retrieval timeout configurable via DevSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
   which used to cause cluster update failure on clusters with login nodes.
 - Fail `pcluster build-image` early when the downloaded cookbook version does not match the ParallelCluster CLI version.
 - Fix login nodes not mounting `/opt/parallelcluster/shared` when EFS is used as the internal shared storage type.
+- Fix an issue where compute nodes are incorrectly replaced when launching a large number of nodes due to eventual consistency.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -36,6 +36,7 @@ from pcluster.config.common import (
 )
 from pcluster.constants import (
     CIDR_ALL_IPS,
+    COMPUTE_INSTANCE_INFO_TIMEOUT,
     CW_ALARMS_ENABLED_DEFAULT,
     CW_DASHBOARD_ENABLED_DEFAULT,
     CW_LOGS_ENABLED_DEFAULT,
@@ -1189,13 +1190,21 @@ class AmiSearchFilters(Resource):
 class Timeouts(Resource):
     """Represent the configuration for node boostrap timeout."""
 
-    def __init__(self, head_node_bootstrap_timeout: int = None, compute_node_bootstrap_timeout: int = None):
+    def __init__(
+        self,
+        head_node_bootstrap_timeout: int = None,
+        compute_node_bootstrap_timeout: int = None,
+        compute_instance_info_timeout: int = None,
+    ):
         super().__init__()
         self.head_node_bootstrap_timeout = Resource.init_param(
             head_node_bootstrap_timeout, default=NODE_BOOTSTRAP_TIMEOUT
         )
         self.compute_node_bootstrap_timeout = Resource.init_param(
             compute_node_bootstrap_timeout, default=NODE_BOOTSTRAP_TIMEOUT
+        )
+        self.compute_instance_info_timeout = Resource.init_param(
+            compute_instance_info_timeout, default=COMPUTE_INSTANCE_INFO_TIMEOUT
         )
 
 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -236,6 +236,10 @@ NODEJS_INCOMPATIBLE_VERSION_RANGE = ["13.0.0", "13.6.0"]
 
 NODE_BOOTSTRAP_TIMEOUT = 2100
 
+# Default time budget (seconds) for retrieving EC2 instance info after a CreateFleet launch,
+# to tolerate EC2 API eventual consistency.
+COMPUTE_INSTANCE_INFO_TIMEOUT = 90
+
 # DirectoryService
 DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1103,6 +1103,9 @@ class TimeoutsSchema(BaseSchema):
     compute_node_bootstrap_timeout = fields.Int(
         validate=validate.Range(min=1), metadata={"update_policy": UpdatePolicy.SUPPORTED}
     )
+    compute_instance_info_timeout = fields.Int(
+        validate=validate.Range(min=1), metadata={"update_policy": UpdatePolicy.SUPPORTED}
+    )
 
     @post_load()
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -329,6 +329,7 @@ DevSettings:
   Timeouts:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)
+    ComputeInstanceInfoTimeout: 95  # Default 90 (seconds)
   ComputeStartupTimeMetricEnabled: false
 DeploymentSettings:
   DisableSudoAccessForDefaultUser: True


### PR DESCRIPTION
### Description of changes
Exposes the CreateFleet post-launch `DescribeInstances` retry timeout as a devsetting under `DevSettings/Timeouts/ComputeInstanceInfoTimeout` (default 90s).

When a compute resource uses CreateFleet (flexible instance types), the node package retries `DescribeInstances` after launch to tolerate EC2 API eventual consistency. This change lets that timeout be tuned from the cluster config:

```yaml
DevSettings:
  Timeouts:
    ComputeInstanceInfoTimeout: 90  # seconds
```

### Tests
* Unit tests passed

### References
* https://github.com/aws/aws-parallelcluster-node/pull/694

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
