### PR TITLE
[Test] In test_update_race_conditions, align the update action script to the new name.

### DIFF
--- a/tests/integration-tests/tests/update/test_update_race_conditions.py
+++ b/tests/integration-tests/tests/update/test_update_race_conditions.py
@@ -42,8 +42,8 @@ UPDATE_DETECTION_SERVICE_BY_NODE_TYPE = {
     NODE_TYPE_LOGIN: "pcluster-check-update.timer",
 }
 UPDATE_ACTION_SCRIPT_BY_NODE_TYPE = {
-    NODE_TYPE_COMPUTE: "/opt/parallelcluster/scripts/cfn-hup-update-action.sh",
-    NODE_TYPE_LOGIN: "/opt/parallelcluster/scripts/cfn-hup-update-action.sh",
+    NODE_TYPE_COMPUTE: "/opt/parallelcluster/scripts/cluster-update-action.sh",
+    NODE_TYPE_LOGIN: "/opt/parallelcluster/scripts/cluster-update-action.sh",
 }
 LOG_FILE_BY_NODE_TYPE = {
     NODE_TYPE_COMPUTE: "/var/log/parallelcluster/pcluster-check-update.log",


### PR DESCRIPTION
**THIS PR DEPENDS ON https://github.com/aws/aws-parallelcluster-cookbook/pull/3196**

### Description of changes
In test_update_race_conditions, align the update action script to the new name.
This is required as we changed the script name in https://github.com/aws/aws-parallelcluster-cookbook/pull/3196

Without this fix the test would fail with error:

```
remote_command_executor.RemoteCommandExecutionError: Command exited with status 1.
=== stdout ===
chmod: cannot access '/opt/parallelcluster/scripts/cfn-hup-update-action.sh': No such file or directory
```

### Tests
SUCCESS

```
test-suites:
  update:
    test_update_race_conditions.py::test_update_race_conditions:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
