### PR TITLE
Make cherry-pick workflow manually triggered via workflow_dispatch

### DIFF
--- a/.github/workflows/cherry-pick-to-branch.yml
+++ b/.github/workflows/cherry-pick-to-branch.yml
@@ -1,21 +1,19 @@
 name: Cherry-pick to branch
 
 on:
-  pull_request:
-    types: [labeled, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Number of the PR to cherry-pick"
+        required: true
+        type: string
+      target_branches:
+        description: "Space-separated list of target branches to cherry-pick into"
+        required: true
+        type: string
 
 jobs:
   cherry-pick:
-    # Run when:
-    # 1. A cherry-pick:* label is added to a merged PR — triggers immediately
-    # 2. A PR with cherry-pick:* labels is merged — triggers at merge time
-    if: >
-      (github.event.action == 'labeled' &&
-       startsWith(github.event.label.name, 'cherry-pick:') &&
-       github.event.pull_request.merged == true) ||
-      (github.event.action == 'closed' &&
-       github.event.pull_request.merged == true &&
-       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick:'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,28 +23,18 @@ jobs:
         id: pr-info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          SOURCE_BRANCH: ${{ github.event.pull_request.base.ref }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          EVENT_ACTION: ${{ github.event.action }}
-          LABEL_NAME: ${{ github.event.label.name }}
-          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          TARGET_BRANCHES: ${{ inputs.target_branches }}
           REPO: ${{ github.repository }}
         run: |
-          # Determine target branches from cherry-pick:* labels
-          if [ "${EVENT_ACTION}" = "labeled" ]; then
-            # Single label was just added
-            TARGET_BRANCHES="${LABEL_NAME#cherry-pick:}"
-          else
-            # PR was closed/merged — pick up all cherry-pick:* labels
-            LABELS=$(echo "${LABELS_JSON}" | jq -r '.[] | select(startswith("cherry-pick:"))')
-            TARGET_BRANCHES=""
-            for LABEL in $LABELS; do
-              TARGET="${LABEL#cherry-pick:}"
-              TARGET_BRANCHES="${TARGET_BRANCHES}${TARGET} "
-            done
-          fi
+          # workflow_dispatch has no PR event payload, so fetch everything we need
+          # about the PR from the API.
+          PR_JSON=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json baseRefName,title,author,commits)
+
+          SOURCE_BRANCH=$(echo "${PR_JSON}" | jq -r '.baseRefName')
+          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title')
+          PR_AUTHOR=$(echo "${PR_JSON}" | jq -r '.author.login')
 
           # Validate target branches contain only safe characters
           for BRANCH in ${TARGET_BRANCHES}; do
@@ -57,7 +45,7 @@ jobs:
           done
 
           # Get all commit SHAs from the PR
-          COMMITS=$(gh pr view "$PR_NUMBER" --repo "${REPO}" --json commits --jq '.commits[].oid' | tr '\n' ' ')
+          COMMITS=$(echo "${PR_JSON}" | jq -r '.commits[].oid' | tr '\n' ' ')
 
           echo "commits=${COMMITS}" >> "$GITHUB_OUTPUT"
           echo "source_branch=${SOURCE_BRANCH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description of changes
Switch the cherry-pick workflow from the pull_request (labeled/closed) trigger to workflow_dispatch with two required inputs: pr_number and target_branches.

Motivation: pull_request runs triggered from a fork receive a read-only GITHUB_TOKEN regardless of the declared permissions, so gh pr create and gh pr comment failed with "Resource not accessible by integration" for fork PRs. workflow_dispatch runs in the base-repo context with a writable token, so those calls work for fork PRs too. Manual dispatch also makes backports an explicit, deliberate action.

Details:
- Replace event-payload fields with a single gh pr view call to fetch baseRefName, title, author, and commits.
- Take target branches directly from the target_branches input instead of deriving them from cherry-pick:* labels.
- Drop the merged-state check: a human triggers the run, so the workflow no longer needs to enforce that the PR was merged.

### Tests
* Tested in my fork.
* Test in AWS fork will be done after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
