### PR TITLE
[integ-tests] Compute wrong_version dynamically in test_build_image_wrong_pcluster_version

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -625,7 +625,10 @@ def test_build_image_wrong_pcluster_version(
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
-    wrong_version = "3.9.3"
+    # Compute a wrong version that is 2 minor versions before the current one, with patch set to 0.
+    # For example, if the current version is 3.15.1, the wrong_version is 3.13.0.
+    major, minor, _ = (int(part) for part in current_version.split("."))
+    wrong_version = f"{major}.{minor - 2}.0"
     logging.info("Asserting wrong_version is different from current_version")
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.


### PR DESCRIPTION
### Description of changes

The test previously hardcoded wrong_version = "3.9.3". As releases progress, the AMI baked with that version can get deprecated, causing the test to fail for reasons unrelated to the version-check logic it is meant to verify.

Compute wrong_version dynamically relative to the installed ParallelCluster version instead: take the current major.minor, subtract 2 from the minor, and set the patch to 0 (e.g. 3.15.1 -> 3.13.0).

### Tests
* `test_build_image_wrong_pcluster_version` passed 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
