### PR TITLE
[Test] Fix test_slurm_cli_commands by removing cfn-init log from the list of expected log streams for login nodes and increasing log stream coverage.

### DIFF
--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -785,7 +785,7 @@ def check_pcluster_list_cluster_log_streams(cluster, os, expected_log_streams=No
         expected_log_streams = {
             "HeadNode": {"cfn-init", "cloud-init", "clustermgtd", "chef-client", "slurmctld", "supervisord"},
             "ComputeNode": {"syslog" if os.startswith("ubuntu") else "system-messages", "computemgtd", "supervisord"},
-            "LoginNode": {"cfn-init", "cloud-init", "chef-client", "supervisord"},
+            "LoginNode": {"cloud-init", "chef-client", "supervisord"},
         }
 
     # check there are the logs of all the instances

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -782,10 +782,38 @@ def check_pcluster_list_cluster_log_streams(cluster, os, expected_log_streams=No
 
     stream_names = cluster.get_all_log_stream_names()
     if not expected_log_streams:
+        syslog = "syslog" if os.startswith("ubuntu") else "system-messages"
         expected_log_streams = {
-            "HeadNode": {"cfn-init", "cloud-init", "clustermgtd", "chef-client", "slurmctld", "supervisord"},
-            "ComputeNode": {"syslog" if os.startswith("ubuntu") else "system-messages", "computemgtd", "supervisord"},
-            "LoginNode": {"cloud-init", "chef-client", "supervisord"},
+            "HeadNode": {
+                "cfn-hup",
+                "cfn-init",
+                "chef-client",
+                "cloud-init",
+                "clustermgtd",
+                "clustermgtd_events",
+                "clusterstatusmgtd",
+                "slurmctld",
+                "supervisord",
+                syslog,
+            },
+            "ComputeNode": {
+                "chef-client",
+                "cloud-init",
+                "cloud-init-output",
+                "computemgtd",
+                "pcluster-check-update",
+                "slurmd",
+                "supervisord",
+                syslog,
+            },
+            "LoginNode": {
+                "chef-client",
+                "cloud-init",
+                "cloud-init-output",
+                "pcluster-check-update",
+                "supervisord",
+                syslog,
+            },
         }
 
     # check there are the logs of all the instances


### PR DESCRIPTION
**THIS PR DEPENDS ON https://github.com/aws/aws-parallelcluster-cookbook/pull/3196**

### Description of changes
Fix test_slurm_cli_commands by:
1.  removing cfn-init log from the list of expected log streams for login nodes. As part of the changes made to the update workflow in https://github.com/aws/aws-parallelcluster-cookbook/pull/3188, cfn-init is not used anymore in login nodes, so we expect no cfn-init logs for them.
2. increasing log stream coverage (it now checks\ all the expected log streams).

### Tests
SUCCESS

```
test-suites:
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - instances:
            - c5.xlarge
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
