### PR TITLE
[Integ-test] Fix test_slurm_custom_partitions intermittent failure by restore the protected failure count

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -379,6 +379,13 @@ def test_slurm_custom_partitions(
         assert_that(scheduler_commands.get_partition_state(partition=partition)).is_equal_to(expected_state)
 
     logging.info("Checking pcluster start...")
+    # Restore the protected failure count to its default before starting the fleet. The failing job left dynamic nodes
+    # still powering up when the fleet was stopped; with a short clustermgtd cleanup window they can survive stop/start
+    # with a stale nodeaddr. On the first poll after start, clustermgtd re-counts them as bootstrap failures and, with
+    # the lowered count of 2, re-enters protected mode, flipping the pcluster-managed partitions back to INACTIVE and
+    # making this test intermittently fail. The default count is high enough that the few leftover nodes cannot reach
+    # the threshold in a single poll.
+    set_protected_failure_count(remote_command_executor, 10)
     for partition in custom_partitions:
         scheduler_commands.set_partition_state(partition, "INACTIVE")
     cluster.start()


### PR DESCRIPTION
### Description of changes
* Fix test_slurm_custom_partitions intermittent failure by restore the protected failure count

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
