### PR TITLE
[Test] When building the pcluster update-cluster command, omit the options that are set to None.

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -104,6 +104,8 @@ class Cluster:
         if wait:
             command.append("--wait")
         for k, val in kwargs.items():
+            if val is None:
+                continue
             if isinstance(val, (list, tuple)):
                 command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
             else:


### PR DESCRIPTION
### Description of changes
When building the pcluster update-cluster command, omit the options that are set to None.

This is to prevent wrong type exceptions as a "None" string has noe meaning and also mostly meaningless for the cli.

This change fixes the failure in test_tag_propagation, but it also useful to prevent future failures where we will be passing kwargs with None values.

### Tests
SUCCESS (same test that detected the failure)

```
test-suites:
  tags:
    test_tag_propagation.py::test_tag_propagation:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel9
        regions:
        - us-west-1
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
