### PR TITLE
[Test] Allow execution of test dfsm at scale through the use of optional test dimension

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1744,6 +1744,18 @@ def scheduler_commands_factory(scheduler):
     return partial(get_scheduler_commands, scheduler=scheduler)
 
 
+@pytest.fixture()
+def flags():
+    """
+    Return the list of flags enabled for the test.
+
+    This is the default value used when the 'flags' dimension is not specified in the tests config file.
+    When the 'flags' dimension is specified, this fixture is overridden by the parametrization performed in
+    conftest_tests_config.parametrize_from_config.
+    """
+    return []
+
+
 @pytest.fixture(scope="class")
 def fsx_factory(vpc_stack: CfnVpcStack, cfn_stacks_factory, request, region, key_name):
     """

--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -45,6 +45,10 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
     has_benchmarks = _has_benchmarks(configured_dimensions_items)
     if has_benchmarks:
         argnames.append("benchmarks")
+    # Add and only add flags parametrization when necessary.
+    has_flags = _has_flags(configured_dimensions_items)
+    if has_flags:
+        argnames.append("flags")
     argvalues = []
     for item in configured_dimensions_items:
         dimensions_values = []
@@ -57,6 +61,9 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
         if has_benchmarks:
             benchmarks_value = [item.get("benchmarks")]  # the benchmarks list is treated as a single item in a list
             dimensions_values.append(benchmarks_value)
+        if has_flags:
+            flags_value = [item.get("flags") or []]  # the flags list is treated as a single item in a list
+            dimensions_values.append(flags_value)
         argvalues.extend(list(product(*dimensions_values)))
 
     argvalues, argnames = unmarshal_az_params(argvalues, argnames)  # adds 'az_id' extra fixture
@@ -68,6 +75,13 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
 def _has_benchmarks(configured_dimensions_items):
     for item in configured_dimensions_items:
         if item.get("benchmarks"):
+            return True
+    return False
+
+
+def _has_flags(configured_dimensions_items):
+    for item in configured_dimensions_items:
+        if item.get("flags"):
             return True
     return False
 

--- a/tests/integration-tests/framework/tests_configuration/config_schema.yaml
+++ b/tests/integration-tests/framework/tests_configuration/config_schema.yaml
@@ -63,3 +63,8 @@ mapping:
                         sequence:
                           - type: any
                             required: true
+                      flags:
+                        type: seq
+                        required: false
+                        sequence:
+                          - type: str

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1068,9 +1068,10 @@ def remove_none_items(items: list):
 
 
 @pytest.mark.usefixtures("instance")
-def test_dynamic_file_systems_update(
+def test_dynamic_file_systems_update(  # noqa: C901
     region,
     os,
+    instance,
     pcluster_config_reader,
     ami_copy,
     clusters_factory,
@@ -1082,12 +1083,32 @@ def test_dynamic_file_systems_update(
     test_datadir,
     delete_storage_on_teardown,
     external_shared_storage_stack,
+    flags,
 ):
     """Test update shared storages."""
 
+    # When the "at_scale" flag is enabled, the test runs against a large cluster, i.e. 50 queues with 10 static
+    # compute nodes each and 10 login node pools with 100 login nodes per pool.
+    # Otherwise, it runs against a minimal cluster.
+    at_scale = "at_scale" in flags
+    login_nodes_pools_count = 10 if at_scale else 1
+    running_login_nodes_count = 10 if at_scale else 1
+    static_compute_min_count = 10 if at_scale else 1
+    static_compute_max_count = static_compute_min_count + 1
+    queue_count = 50 if at_scale else 2
+    head_node_instance_type = "c5.4xlarge" if at_scale else instance
+    login_node_pools = [f"login-{i + 1}" for i in range(login_nodes_pools_count)]
+
     # Create cluster without any shared storage.
     init_config_file = pcluster_config_reader(
-        config_file="pcluster.config.yaml", output_file="pcluster.config.no-shared-storage.yaml", login_nodes_count=1
+        config_file="pcluster.config.yaml",
+        output_file="pcluster.config.no-shared-storage.yaml",
+        login_nodes_count=running_login_nodes_count,
+        login_nodes_pools_count=login_nodes_pools_count,
+        static_compute_min_count=static_compute_min_count,
+        static_compute_max_count=static_compute_max_count,
+        queue_count=queue_count,
+        head_node_instance_type=head_node_instance_type,
     )
     cluster = clusters_factory(init_config_file, wait=False)
 
@@ -1166,7 +1187,12 @@ def test_dynamic_file_systems_update(
         existing_file_cache_id=existing_file_cache_id,
         bucket_name=bucket_name,
         queue_update_strategy="DRAIN",
-        login_nodes_count=1,
+        login_nodes_count=running_login_nodes_count,
+        login_nodes_pools_count=login_nodes_pools_count,
+        static_compute_min_count=static_compute_min_count,
+        static_compute_max_count=static_compute_max_count,
+        queue_count=queue_count,
+        head_node_instance_type=head_node_instance_type,
     )
 
     cluster.update(update_cluster_config)
@@ -1210,7 +1236,7 @@ def test_dynamic_file_systems_update(
             scheduler_commands,
             partitions=["queue1", "queue2"],
             cluster=cluster,
-            login_node_pools=["login"],
+            login_node_pools=login_node_pools,
         )
 
     # # Update cluster to stop login nodes
@@ -1231,6 +1257,11 @@ def test_dynamic_file_systems_update(
         bucket_name=bucket_name,
         queue_update_strategy="DRAIN",
         login_nodes_count=0,
+        login_nodes_pools_count=login_nodes_pools_count,
+        static_compute_min_count=static_compute_min_count,
+        static_compute_max_count=static_compute_max_count,
+        queue_count=queue_count,
+        head_node_instance_type=head_node_instance_type,
     )
 
     cluster.update(update_cluster_config)
@@ -1273,6 +1304,11 @@ def test_dynamic_file_systems_update(
         new_efs_deletion_policy="Retain",
         queue_update_strategy="DRAIN",
         login_nodes_count=0,
+        login_nodes_pools_count=login_nodes_pools_count,
+        static_compute_min_count=static_compute_min_count,
+        static_compute_max_count=static_compute_max_count,
+        queue_count=queue_count,
+        head_node_instance_type=head_node_instance_type,
     )
 
     cluster.update(update_cluster_config)
@@ -1323,10 +1359,14 @@ def test_dynamic_file_systems_update(
     logging.info("Checking the status of compute nodes in queue1")
     # Compute nodes in queue1 are expected to be in drain
     # because the static compute node has a job running.
+    queue1_expected_states = ["draining", "draining!", "drained*", "drained"]
+    if at_scale:
+        # At scale only one static node in queue1 has a running job (hence draining), while all the other
+        # static nodes have no jobs running and are therefore replaced (idle) or under replacement
+        # (drained, draining).
+        queue1_expected_states += ["idle", "idle%", "idle~"]
     queue1_nodes = scheduler_commands.get_compute_nodes("queue1")
-    assert_compute_node_states(
-        scheduler_commands, queue1_nodes, expected_states=["draining", "draining!", "drained*", "drained"]
-    )
+    assert_compute_node_states(scheduler_commands, queue1_nodes, expected_states=queue1_expected_states)
 
     logging.info("Checking the status of compute nodes in queue2")
     # All compute nodes in queue2 are expected to be in idle or drained
@@ -1383,7 +1423,12 @@ def test_dynamic_file_systems_update(
         )
 
     logging.info("Checking that newly mounted storage is not visible on compute nodes with jobs running (queue1)")
-    for node_name in queue1_nodes:
+    # At scale only one static node in queue1 actually runs a job and is therefore retained (without the new
+    # storage). All the other static nodes have no jobs running and get replaced, hence they mount the new storage.
+    nodes_with_running_jobs = (
+        [scheduler_commands.get_job_info(queue1_job_id, field="NodeList")] if at_scale else queue1_nodes
+    )
+    for node_name in nodes_with_running_jobs:
         _test_directory_not_mounted(
             remote_command_executor, mount_dirs_requiring_replacement, node_type="compute", node_name=node_name
         )

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update.yaml
@@ -2,7 +2,7 @@ Image:
   Os: {{ os }}
 HeadNode:
   SharedStorageType: {{ shared_headnode_storage_type }}
-  InstanceType: {{ instance }}
+  InstanceType: {{ head_node_instance_type }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -12,13 +12,15 @@ HeadNode:
       - BucketName: {{ bucket_name }}
 LoginNodes:
   Pools:
-    - Name: login
+{% for i in range(login_nodes_pools_count) %}
+    - Name: login-{{ i + 1 }}
       InstanceType: {{ instance }}
       Count: {{ login_nodes_count }}
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
       GracetimePeriod: 3
+{% endfor %}
 Scheduling:
   {% if queue_update_strategy %}
   SlurmSettings:
@@ -26,32 +28,23 @@ Scheduling:
   {% endif %}
   Scheduler: slurm
   SlurmQueues:
-    - Name: queue1
+{% for i in range(queue_count) %}
+    - Name: queue{{ i + 1 }}
       Iam:
         S3Access:
           - BucketName: {{ bucket_name }}
       ComputeResources:
-        - Name: queue1-i1
+        - Name: queue{{ i + 1 }}-i1
           Instances:
-            - InstanceType: {{ instance }}
-          MinCount: 1
-          MaxCount: 2
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
+          MinCount: {{ static_compute_min_count }}
+          MaxCount: {{ static_compute_max_count }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-    - Name: queue2
-      Iam:
-        S3Access:
-          - BucketName: {{ bucket_name }}
-      ComputeResources:
-        - Name: queue2-i1
-          Instances:
-            - InstanceType: {{ instance }}
-          MinCount: 1
-          MaxCount: 2
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
+{% endfor %}
 SharedStorage:
 {% if new_raid_mount_dir %}
   - MountDir: {{ new_raid_mount_dir }}

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
@@ -2,40 +2,36 @@ Image:
   Os: {{ os }}
 HeadNode:
   SharedStorageType: {{ shared_headnode_storage_type }}
-  InstanceType: {{ instance }}
+  InstanceType: {{ head_node_instance_type }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
 LoginNodes:
   Pools:
-    - Name: login
+{% for i in range(login_nodes_pools_count) %}
+    - Name: login-{{ i + 1 }}
       InstanceType: {{ instance }}
       Count: {{ login_nodes_count }}
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
       GracetimePeriod: 3
+{% endfor %}
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
-    - Name: queue1
+{% for i in range(queue_count) %}
+    - Name: queue{{ i + 1 }}
       ComputeResources:
-        - Name: queue1-i1
+        - Name: queue{{ i + 1 }}-i1
           Instances:
-            - InstanceType: {{ instance }}
-          MinCount: 1
-          MaxCount: 2
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
+          MinCount: {{ static_compute_min_count }}
+          MaxCount: {{ static_compute_max_count }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-    - Name: queue2
-      ComputeResources:
-        - Name: queue2-i1
-          Instances:
-            - InstanceType: {{ instance }}
-          MinCount: 1
-          MaxCount: 2
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
+{% endfor %}


### PR DESCRIPTION
### Description of changes
Allow execution of test dfsm at scale through the use of optional test dimension.
When executed at scale the test deploys a cluster with:
* 10 login nodes pool, having 10 nodes each
* 50 queues with 10 nodes each

This is a medium cluster, not a large one (100 login nodes + 500 compute nodes). However, the critical scaling aspect we are trying to test is the retrieval of launch templates, which depends on the number of queues and pools not on the number of nodes. We are using hundreds of nodes just to stress more the system,. but the critical aspect for the update is the number of launch templates to retrieve.


With this PR we are introducing a new option al test config dimension `flags` that is meant to inject custom behaviors in tests. An example of usage is to execute a test at scale. 

### Tests
SUCCEEDED
```
test-suites:
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
        - instances:
            - t3.large
          oss:
            - alinux2023
          regions:
            - us-east-1
          schedulers:
            - slurm
          flags:
            - at_scale
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
