### PR TITLE
[CICD] Bump CodeQL actions to version v3 (from version v2) as version v2 has been deprecated.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
### Description of changes
Bump CodeQL actions to version v3 (from version v2) as version v2 has been deprecated.

### Tests
PR checks


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
