### PR TITLE
[integ-tests] Improve test_proxy to avoid insufficient capacity error

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -6,6 +6,11 @@ Parameters:
     Description: EC2 Keypair to access management instance.
     Type: AWS::EC2::KeyPair::KeyName
 
+  InstanceType:
+    Description: Instance type of the proxy and client instances.
+    Type: String
+    Default: t3.medium
+
   VpcCidr:
     Description: CIDR for the VPC
     Type: String
@@ -318,7 +323,7 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref ProxyInstanceProfile
       ImageId: resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id
-      InstanceType: t3.medium
+      InstanceType: !Ref InstanceType
       KeyName: !Ref Keypair
       NetworkInterfaces:
         - DeviceIndex: 0
@@ -483,7 +488,7 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref ProxyClientNodeInstanceProfile
       ImageId: resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id
-      InstanceType: t3.medium
+      InstanceType: !Ref InstanceType
       KeyName: !Ref Keypair
       SecurityGroupIds:
         - !If [IsClusterProxy, !Ref ProxyClientSecurityGroup, !GetAtt Vpc.DefaultSecurityGroup]

--- a/tests/integration-tests/tests/common/capacity_helpers.py
+++ b/tests/integration-tests/tests/common/capacity_helpers.py
@@ -16,7 +16,7 @@ import boto3
 from utils import get_similar_instance_types
 
 # Default instance types that are subject to capacity fallback.
-DEFAULT_INSTANCE_TYPES = {"c5.xlarge", "m6g.xlarge"}
+DEFAULT_INSTANCE_TYPES = {"c5.xlarge", "m6g.xlarge", "m6i.xlarge"}
 
 
 def resolve_instance_with_capacity(region, az_id, instance_type, os, minutes=50, count=2):

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -22,7 +22,7 @@ from tests.common.schedulers_common import SlurmCommands
 
 
 @pytest.fixture(scope="class")
-def proxy_stack_factory(region, request, cfn_stacks_factory):
+def proxy_stack_factory(region, request, cfn_stacks_factory, instance):
     """
     Set up and tear down a CloudFormation stack to deploy a proxy environment.
 
@@ -62,6 +62,7 @@ def proxy_stack_factory(region, request, cfn_stacks_factory):
                         "ParameterKey": "EnableBuildImageProxy",
                         "ParameterValue": "true" if enable_build_image_proxy else "false",
                     },
+                    {"ParameterKey": "InstanceType", "ParameterValue": instance},
                 ]
                 capabilities = ["CAPABILITY_IAM"]
                 tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]

--- a/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
+++ b/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
@@ -19,7 +19,7 @@ Scheduling:
       ComputeResources:
         - Name: compute1
           Instances:
-            - InstanceType: t3.medium
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 5
       Networking:


### PR DESCRIPTION
### Description of changes
1. Avoid use hard coded t3.medium. Use `instance` specified in the test definition file. Therefore, the test framework can make capacity reservation accordingly
2. Add m6i.xlarge to the instance type list, which the test framework automatically makes capacity reservation. test_proxy uses m6i.xlarge because it runs in ap-southeast-5, where c5 is not available

### Tests
* test_proxy has been passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
