### PR TITLE
Prevent path traversal when downloading exported logs

### DIFF
--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -230,6 +230,17 @@ class CloudWatchLogsExporter:
             decompressed_path = decompressed_path.replace(
                 r"{unwanted_path_segment}{sep}".format(unwanted_path_segment=prefix, sep=os.path.sep), ""
             )
+            # Defend against path traversal: an S3 object key (derived from a CloudWatch log stream name) may
+            # contain '..' path segments that would escape destdir and overwrite arbitrary local files. Verify
+            # the resolved destination is still contained within destdir before writing anything to disk.
+            if not self._is_path_contained(decompressed_path, destdir):
+                LOGGER.warning(
+                    "Skipping S3 object with key=%s: resolved path %s escapes the export directory %s",
+                    archive_object.key,
+                    decompressed_path,
+                    destdir,
+                )
+                continue
             compressed_path = f"{decompressed_path}.gz"
 
             LOGGER.debug("Downloading object with key=%s to %s", archive_object.key, compressed_path)
@@ -243,6 +254,17 @@ class CloudWatchLogsExporter:
             with gzip.open(compressed_path) as gfile, open(decompressed_path, "wb") as outfile:
                 outfile.write(gfile.read())
             os.remove(compressed_path)
+
+    @staticmethod
+    def _is_path_contained(path, parent_dir):
+        """Return True if path, once resolved, is located inside parent_dir (defends against '..' traversal)."""
+        resolved_parent = os.path.realpath(parent_dir)
+        resolved_path = os.path.realpath(path)
+        # commonpath raises ValueError when the paths are on different drives (Windows); treat that as not contained.
+        try:
+            return os.path.commonpath([resolved_parent, resolved_path]) == resolved_parent
+        except ValueError:
+            return False
 
 
 def get_all_stack_events(stack_name: str):

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -326,3 +326,20 @@ class TestCloudWatchLogsExporter:
         else:
             task_id = cw_logs_exporter._export_logs_to_s3("log_group_name", "bucket")
             wait_for_completion_mock.assert_called_with(task_id)
+
+    @pytest.mark.parametrize(
+        "path_relative_to_parent, expected",
+        [
+            ("child", True),
+            (os.path.join("nested", "child"), True),
+            (".", True),
+            ("foo..bar", True),  # embedded dots are a legitimate single component, not a traversal
+            (os.path.join("..", "escape"), False),
+            (os.path.join("a", "..", "..", "escape"), False),
+            (os.path.join("..", "..", "..", "etc", "cron.d", "evil"), False),
+        ],
+    )
+    def test_is_path_contained(self, tmp_path, path_relative_to_parent, expected):
+        parent_dir = str(tmp_path)
+        candidate = os.path.join(parent_dir, path_relative_to_parent)
+        assert_that(CloudWatchLogsExporter._is_path_contained(candidate, parent_dir)).is_equal_to(expected)


### PR DESCRIPTION
### Description of changes
CloudWatchLogsExporter._download_s3_objects_with_prefix() reconstructed local output paths from S3 object keys using string-based prefix stripping, without verifying the result stayed under the export directory. An S3 object key derived from a CloudWatch log stream name containing '../' segments could escape the destination directory and overwrite arbitrary files in the context.

Resolve the destination path and confirm it is contained within destdir (os.path.realpath + os.path.commonpath) before downloading or writing. Objects whose resolved path escapes the export directory are skipped with a warning.

### Tests
* New unit test is passing

### References
* Supersedes https://github.com/aws/aws-parallelcluster/pull/7416

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
