### PR TITLE
[integ-test] Find official Rocky8 AMI with include deprecated

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -53,7 +53,12 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     # FIXME: when fixed upstream, unpin the timestamp introduced because the `kernel-devel` package was missing for
     # the kernel released in 20231127 RHEL 8.8 AMI
     "rhel8": {"name": "RHEL-8.10*", "owners": RHEL_OWNERS},
-    "rocky8": {"name": "Rocky-8-EC2-Base-8.10*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky8": {
+        "name": "Rocky-8-EC2-Base-8.10*",
+        "owners": ["792107900819"],
+        "includeDeprecated": True,  # Latest official Rocky8 AMI is deprecated:
+        # https://forums.rockylinux.org/t/rocky-8-10-amis-missing-from-aws-eu-west-1-region/20558
+    },  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.7*_HVM*", "owners": RHEL_OWNERS},
@@ -89,7 +94,12 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     },
     # Simple redhat8 to be able to build in remarkable test
     "rhel8": {"name": "RHEL-8.8*_HVM-*", "owners": RHEL_OWNERS},
-    "rocky8": {"name": "Rocky-8-EC2-Base-8.10*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky8": {
+        "name": "Rocky-8-EC2-Base-8.10*",
+        "owners": ["792107900819"],
+        "includeDeprecated": True,  # Latest official Rocky8 AMI is deprecated:
+        # https://forums.rockylinux.org/t/rocky-8-10-amis-missing-from-aws-eu-west-1-region/20558
+    },  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.*_HVM*", "owners": RHEL_OWNERS},


### PR DESCRIPTION
### Description of changes
Latest official Rocky8 AMI is deprecated: https://forums.rockylinux.org/t/rocky-8-10-amis-missing-from-aws-eu-west-1-region/20558

### Tests
* test_build_image[us-west-2-g4dn.2xlarge-rocky8] passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
