### PR TITLE
Normalize CUDA version to major.minor in build-image test

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -124,7 +124,8 @@ phases:
             - |
               set -v
               PATTERN=$(jq '.default.cluster.nvidia.cuda.version' {{ CookbookDefaultFile }})
-              VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
+              # Normalize cuda.version to major.minor (e.g. 13.0.2 -> 13.0) to match nvcc and the /usr/local/cuda-<ver> install dir.
+              VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs | cut -d. -f1,2)
               echo ${VERSION}
 
       - name: CudaSamplesDir


### PR DESCRIPTION
### Description of changes

The CudaVersion test step read cluster.nvidia.cuda.version verbatim, which can be a 3-part value (e.g. 13.0.2) when set via ExtraChefAttributes. The CUDA toolkit installs to /usr/local/cuda-<major.minor> and nvcc reports only major.minor, so the test built a non-existent /usr/local/cuda-13.0.2/bin path (nvcc: command not found) and the 'release 13.0' vs '13.0.2' compare failed.

Normalize to major.minor with 'cut -d. -f1,2' at the single source feeding all downstream CUDA path and version-compare logic. Mirrors the normalize-in-the- consumer approach from aws-parallelcluster-cookbook PR #3204; a cookbook-side node.default writeback does not work because ExtraChefAttributes outranks it in Chef attribute precedence.

This PR is to be merged once we merge https://github.com/aws/aws-parallelcluster-cookbook/pull/3204

Without this PR below is failure
```

echo "Testing CUDA installation with nvcc"
+ echo 'Testing CUDA installation with nvcc'
cuda_ver="13.0.2"
+ cuda_ver=13.0.2
export PATH=/usr/local/cuda-${cuda_ver}/bin:${PATH}
+ export PATH=/usr/local/cuda-13.0.2/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+ PATH=/usr/local/cuda-13.0.2/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
export LD_LIBRARY_PATH=/usr/local/cuda-${cuda_ver}/lib64:${LD_LIBRARY_PATH}
+ export LD_LIBRARY_PATH=/usr/local/cuda-13.0.2/lib64:
+ LD_LIBRARY_PATH=/usr/local/cuda-13.0.2/lib64:
cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
++ nvcc -V
++ grep -E -o 'release [0-9]+.[0-9]+'
/tmp/AWSTOE3630884017/script-1863281942.sh: line 36: nvcc: command not found
+ cuda_output=
[[ "${cuda_output}" != "release ${cuda_ver}" ]] && echo "ERROR Installed version ${cuda_output} but expected ${cuda_ver}" && exit 1
+ [[ '' != \r\e\l\e\a\s\e\ \1\3\.\0\.\2 ]]
+ echo 'ERROR Installed version  but expected 13.0.2'
+ exit 1
2026-06-15 18:16:23.461000	CmdExecution: ExitCode 1
```


### Tests
* Build Image 
```
2026-06-16 22:12:10.222000	Stdout: [38;5;41m  âœ”  tag:install_expected_versions_of_nvidia_cuda_installed: cuda version is expected to be 13.3[0m
2026-06-16 22:12:10.222000	Stdout: [38;5;41m     âœ”  cuda version is expected to be 13.3 is expected to eq "release 13.3"[0m
```
and 
```

echo "Testing CUDA installation with nvcc"
+ echo 'Testing CUDA installation with nvcc'
cuda_ver="13.3"
+ cuda_ver=13.3
export PATH=/usr/local/cuda-${cuda_ver}/bin:${PATH}
+ export PATH=/usr/local/cuda-13.3/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+ PATH=/usr/local/cuda-13.3/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
export LD_LIBRARY_PATH=/usr/local/cuda-${cuda_ver}/lib64:${LD_LIBRARY_PATH}
+ export LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:
+ LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:
cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
++ nvcc -V
++ grep -E -o 'release [0-9]+.[0-9]+'
+ cuda_output='release 13.3'
[[ "${cuda_output}" != "release ${cuda_ver}" ]] && echo "ERROR Installed version ${cuda_output} but expected ${cuda_ver}" && exit 1
+ [[ release 13.3 != \r\e\l\e\a\s\e\ \1\3\.\3 ]]
echo "Correctly installed CUDA ${cuda_output}"
+ echo 'Correctly installed CUDA release 13.3'
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
