### PR TITLE
Fix pytest collection errors from trailing comma in parametrize argnames

### DIFF
--- a/cli/tests/pcluster/cli/test_list_cluster_log_streams.py
+++ b/cli/tests/pcluster/cli/test_list_cluster_log_streams.py
@@ -59,7 +59,7 @@ class TestListClusterLogStreamsCommand:
         assert_that(out + err).contains(error_message)
 
     @pytest.mark.parametrize(
-        "args, ",
+        "args",
         [
             {},
             {"filters": ["Name=private-dns-name,Values=ip-10-10-10-10"], "next_token": "123"},

--- a/cli/tests/pcluster/templates/test_capacity_reservation.py
+++ b/cli/tests/pcluster/templates/test_capacity_reservation.py
@@ -24,7 +24,7 @@ from tests.pcluster.utils import get_head_node_policy, get_statement_by_sid
 
 
 @pytest.mark.parametrize(
-    "config_file_name,",
+    "config_file_name",
     ["config.yaml"],
 )
 def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_name):
@@ -60,9 +60,9 @@ def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_n
 
 
 @pytest.mark.parametrize(
-    "config_file_name,",
+    "config_file_name",
     [
-        ("config.yaml"),
+        "config.yaml",
     ],
 )
 def test_capacity_reservation_group_arns_permissions(mocker, test_datadir, config_file_name):


### PR DESCRIPTION
### Description of changes


Root cause: pytest 9.1.0 (released 2026-06-13) shipped #14125 (https://github.com/pytest-dev/pytest/pull/14125) / #719 (https://github.com/pytest-dev/pytest/issues/719), which makes a trailing comma in string argnames ("arg,") behave like the tuple form ("arg",) and unpack each value as a tuple. Our 2021-era tests used "args, " / "config_file_name," with
  ▎ non-tuple values, so values now unpack to the wrong arity ({}→0, "config.yaml"→11 chars) and collection fails. tox doesn't pin pytest, so CI picked up 9.1.0 two days after its release. Fix: drop the trailing comma.



### Tests
* GH actions

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
