### PR TITLE
docs: Add PCS callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It automatically sets up the required compute resources and a shared filesystem 
 AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and production deployments.
 You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing workflow, on top of AWS ParallelCluster.
 
+> **Looking for managed Slurm?** [AWS Parallel Computing Service (PCS)](https://aws.amazon.com/pcs/) is a managed service that makes it easier to run and scale HPC workloads on AWS using Slurm.
+
 Quick Start
 -----------
 **IMPORTANT**: you will need an **Amazon EC2 Key Pair** to be able to complete the following steps.


### PR DESCRIPTION
### Description of changes

Adds a callout in the README intro pointing readers evaluating ParallelCluster to AWS PCS as the managed Slurm option. ParallelCluster's GitHub README is a high-traffic discovery surface for HPC-on-AWS evaluators; this callout helps the subset who'd be better served by a managed service find it without leaving Amazon's ecosystem.

Placement: between the existing intro paragraph and the `Quick Start` heading, so it's visible to anyone evaluating ParallelCluster but doesn't interrupt the existing onboarding flow.

### Tests

Docs-only change. No automated tests required. Verified rendering in the GitHub Markdown preview — blockquote callout renders correctly with bold lead-in and hyperlinked product name.

### References

* AWS Parallel Computing Service: https://aws.amazon.com/pcs/

### Checklist

- [x] Pointing to the right branch (`develop`)
- [x] Commit message describes what and why
- [x] No code changes — unit/integration tests not applicable
- [x] Documentation impact: this PR *is* the documentation change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.