### PR TITLE
[integ-test] Use EFA 1.49.0 to build image on Rocky 9.8

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -62,7 +62,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
     "rhel9": {"name": "RHEL-9.7*_HVM*", "owners": RHEL_OWNERS},
-    "rocky9": {"name": "Rocky-9-EC2-Base-9.7*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
+    "rocky9": {"name": "Rocky-9-EC2-Base-9.*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
 # Remarkable AMIs are latest deep learning base AMI and FPGA developer AMI without pcluster infrastructure

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -166,10 +166,12 @@ def test_build_image(
     if os in ["alinux2", "alinux2023"]:
         update_os_packages = True
 
-    if os in ["rhel9", "rocky9"]:
+    if os in ["rhel9"]:
         update_os_packages = False
 
-    enable_dcv = True
+    use_newer_efa = False
+    if os in ["rocky9"]:
+        use_newer_efa = True
 
     image_config = pcluster_config_reader(
         config_file="image.config.yaml",
@@ -179,7 +181,7 @@ def test_build_image(
         enable_nvidia=str(enable_nvidia and get_gpu_count(instance) > 0).lower(),
         update_os_packages=str(update_os_packages).lower(),
         enable_lustre_client=str(enable_lustre_client).lower(),
-        enable_dcv=str(enable_dcv).lower(),
+        use_newer_efa=str(use_newer_efa).lower(),
     )
 
     image = images_factory(image_id, image_config, region)

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -36,8 +36,8 @@ DeploymentSettings:
         - {{ default_vpc_security_group_id }}
 DevSettings:
     TerminateInstanceOnFailure: True
-{% if enable_dcv == "false" %}
+{% if use_newer_efa == "true" %}
     Cookbook:
         ExtraChefAttributes: |
-            {"cluster": {"dcv": {"install_enabled": false}}}
+            {"cluster": {"efa": {"version": "1.49.0", "sha256": "cf2e9281a2328a243c76f911a490faed43ca0fecfe4733c25e34b2e92a32c309"}}}
 {% endif %}


### PR DESCRIPTION
### Description of changes
1. Adds a DevSetting to use EFA 1.49.0 when building image with Rocky 9
2. Removes the old DevSetting on `enable_dcv`, because it is no longer used anymore
3. RHEL9 build is unchanged so that we are monitoring the build health on both RHEL 9.7, and Rocky 9.8 with DevSettings

### Tests
* build-image on all OSes have passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
