### PR TITLE
[integ-tests-framework] Fix failures from instance type reservation

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1329,6 +1329,10 @@ def resolve_default_instance(request):
     flags = request.getfixturevalue("flags")
     architecture = request.getfixturevalue("architecture")
     alternative_instance_types = []
+    if instance.startswith("p"):
+        # Don't change p-series instance types, because the test is usually intended for a specific p instance type.
+        return
+
     if flags and "any-efa-instances" in flags:
         alternative_instance_types = get_efa_instance_types(region, architecture)
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1308,7 +1308,7 @@ def serial_execution_by_instance(request, instance, region, os_platform):
 
 
 @pytest.fixture(autouse=True)
-def resolve_default_instance(request, architecture):
+def resolve_default_instance(request):
     """Reserve capacity for the test instance, substituting a same-spec alternative on ICE.
 
     Dedups against existing reservations for instances larger than ``.xlarge`` and reserves
@@ -1318,7 +1318,7 @@ def resolve_default_instance(request, architecture):
 
     Skips silently for tests that do not use instance, region, os, or vpc_stack fixtures.
     """
-    required = ("instance", "region", "os", "vpc_stack")
+    required = ("instance", "region", "os", "vpc_stack", "architecture")
     if not all(name in request.fixturenames for name in required):
         return
 
@@ -1327,6 +1327,7 @@ def resolve_default_instance(request, architecture):
     os_name = request.getfixturevalue("os")
     vpc_stack = request.getfixturevalue("vpc_stack")
     flags = request.getfixturevalue("flags")
+    architecture = request.getfixturevalue("architecture")
     alternative_instance_types = []
     if flags and "any-efa-instances" in flags:
         alternative_instance_types = get_efa_instance_types(region, architecture)


### PR DESCRIPTION
### Description of changes
* Make resolve_default_instance compatible with tests without instance fixture
* Skip p series instance types in resolve_default_instance

See commit descriptions for details

### Tests
The following tests have passed or skipped as expected:
```
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
      - instances:
        - p6-b200.48xlarge
        oss:
        - rhel9
        regions:
        - us-east-2
        schedulers:
        - slurm
      - instances:
        - p6-b200.48xlarge
        oss:
        - ubuntu2204
        regions:
        - us-east-2
        schedulers:
        - slurm
      - instances:
        - p6-b200.48xlarge
        oss:
        - rocky8
        regions:
        - us-east-2
        schedulers:
        - slurm
      - instances:
        - p6-b200.48xlarge
        oss:
        - rhel8
        regions:
        - us-east-2
        schedulers:
        - slurm
      - instances:
        - p6-b200.48xlarge
        oss:
        - alinux2023
        regions:
        - us-east-2
        schedulers:
        - slurm
      - instances:
        - p6-b200.48xlarge
        oss:
        - ubuntu2404
        regions:
        - us-east-2
        schedulers:
        - slurm
  networking:
    test_networking.py::test_public_network_topology:
      dimensions:
      - regions:
        - af-south-1
    test_networking.py::test_public_private_network_topology:
      dimensions:
      - regions:
        - af-south-1
  pcluster_api:
    test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
      dimensions:
      - regions:
        - ap-south-1
    test_api_infrastructure.py::test_api_infrastructure_with_full_parameters:
      dimensions:
      - regions:
        - eu-west-1
```
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
