### PR TITLE
[Test] In test_patching_cluster add possibility to specify the patching flavour to be either minimal (minimal security-only updates, the default) or full (full Os package update).

### DIFF
--- a/cloudformation/patching/ami-patching.yaml
+++ b/cloudformation/patching/ami-patching.yaml
@@ -18,6 +18,15 @@ Parameters:
   PatchScriptS3Uri:
     Description: S3 URI (s3://bucket/key) of the patching script to run on the build instance.
     Type: String
+  PatchFlavour:
+    Description: >-
+      Patching flavour passed to the patch script. 'minimal' applies only security
+      errata (smallest set); 'full' applies all available package updates.
+    Type: String
+    Default: minimal
+    AllowedValues:
+      - minimal
+      - full
 
 Resources:
 
@@ -203,7 +212,7 @@ Resources:
                     - aws s3 cp ${PatchScriptS3Uri} /usr/local/sbin/patch_node.sh
                     - sudo chown root:root /usr/local/sbin/patch_node.sh
                     - sudo chmod 0744 /usr/local/sbin/patch_node.sh
-                    - sudo /usr/local/sbin/patch_node.sh
+                    - sudo /usr/local/sbin/patch_node.sh ${PatchFlavour}
               - name: Reboot
                 action: Reboot
               - name: PostRebootChecks

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -180,9 +180,11 @@ test-suites:
           instances: ["g4dn.8xlarge"]
           oss: {{ RHEL_OS_X86 }}
           schedulers: ["slurm"]
+          flags: ["patching:minimal"]
         - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
           instances: ["g4dn.8xlarge"]
           oss: {{ NO_RHEL_OS_X86 }}
+          flags: ["patching:minimal"]
           schedulers: ["slurm"]
   custom_resource:
     test_cluster_custom_resource.py::test_cluster_create:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -122,10 +122,12 @@ test-suites:
   #         instances: ["g4dn.8xlarge"]
   #         oss: {{ RHEL_OS_X86 }}
   #         schedulers: ["slurm"]
+  #         flags: ["patching:minimal"]
   #       - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
   #         instances: ["g4dn.8xlarge"]
   #         oss: {{ NO_RHEL_OS_X86 }}
   #         schedulers: ["slurm"]
+  #         flags: ["patching:minimal"]
   custom_resource:
     test_cluster_custom_resource.py::test_cluster_1_click:
       dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1751,7 +1751,9 @@ def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_fac
     parallelcluster:source-ami and parallelcluster:ami-patching-stack. The stack's
     AmiId output is returned.
 
-    The returned callable takes the base AMI id and the builder instance type.
+    The returned callable takes the base AMI id, the builder instance type and an
+    optional patching flavour ('minimal' for security-only errata, 'full' for all
+    available package updates; defaults to 'minimal').
     On teardown the stack is deleted, which deregisters the produced AMI and its
     snapshots (deleting an Image Builder image does not remove the produced AMI).
     """
@@ -1762,7 +1764,7 @@ def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_fac
     reuse_stack_name = request.config.getoption("patch_ami_stack")
     built = []  # list of (ami_id, stack_name) for stacks created (and to be deleted) by this fixture
 
-    def _build(base_ami, builder_instance):
+    def _build(base_ami, builder_instance, flavour="minimal"):
         # Reuse an already-deployed patch-infra stack when requested: just read its
         # AmiId output and skip creation/deletion.
         if reuse_stack_name:
@@ -1770,7 +1772,12 @@ def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_fac
             stack = CfnStack(name=reuse_stack_name, region=region, template=template_body)
             return stack.cfn_outputs["AmiId"]
 
-        logging.info("Starting patching of AMI %s using a %s builder instance", base_ami, builder_instance)
+        logging.info(
+            'Starting patching of AMI %s using a %s builder instance with patching flavour "%s"',
+            base_ami,
+            builder_instance,
+            flavour,
+        )
         bucket_name = s3_bucket_factory()
         boto3.resource("s3", region_name=region).Bucket(bucket_name).upload_file(
             str(test_datadir / "patch_node.sh"), "scripts/patch_node.sh"
@@ -1786,6 +1793,7 @@ def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_fac
                 {"ParameterKey": "SubnetId", "ParameterValue": vpc_stack.get_public_subnet()},
                 {"ParameterKey": "VpcId", "ParameterValue": vpc_stack.cfn_outputs["VpcId"]},
                 {"ParameterKey": "PatchScriptS3Uri", "ParameterValue": f"s3://{bucket_name}/scripts/patch_node.sh"},
+                {"ParameterKey": "PatchFlavour", "ParameterValue": flavour},
             ],
             capabilities=["CAPABILITY_IAM"],
         )

--- a/tests/integration-tests/tests/patching/test_patching.py
+++ b/tests/integration-tests/tests/patching/test_patching.py
@@ -30,10 +30,17 @@ from tests.common.utils import (
     wait_node_reachable,
 )
 
-# Time budget (seconds) for the OS security patching to complete on the head node.
+# Time budget (seconds) for the patching to complete on the head node.
 PATCHING_TIMEOUT = 1800
 
-# Snhared storage mount dir
+# Patching flavour passed to patch_node.sh: "minimal" applies only security patches,
+# "full" applies all available OS package updates. It is selected via the test's
+# "flags" dimension: a flag "patching:<flavour>" overrides the default below.
+PATCHING_FLAG_PREFIX = "patching:"
+DEFAULT_PATCHING_FLAVOUR = "minimal"
+
+# Shared storage mount dir, injected into the cluster config as fsx_lustre_mount_dir
+# so it is defined in a single place.
 FSX_LUSTRE_MOUNT_DIR = "/shared-fsxlustre"
 
 
@@ -48,10 +55,16 @@ def test_patching_cluster(
     test_datadir,
     scheduler_commands_factory,
     patched_ami_factory,
+    flags,
     request,
 ):
     """
     Validate that users can self-patch their clusters.
+
+    The patching flavour is selected via the "flags" dimension. Supported flags:
+      - "patching:minimal": apply only security patches (smallest set).
+      - "patching:full": apply all available OS package updates (comprehensive).
+    When no patching flag is set, the flavour defaults to minimal.
 
     Flow:
       1.  Create a cluster.
@@ -87,8 +100,9 @@ def test_patching_cluster(
 
     # Bake the patched AMI while the cluster is still being created. The builder
     # instance uses the same GPU instance type as the cluster nodes.
-    patched_ami = patched_ami_factory(base_ami, instance)
-    logging.info("Patched AMI is %s", patched_ami)
+    patching_flavour = _patching_flavour(flags)
+    patched_ami = patched_ami_factory(base_ami, instance, flavour=patching_flavour)
+    logging.info("Patched AMI is %s (patching flavour: %s)", patched_ami, patching_flavour)
 
     # Wait for the cluster creation to complete before using it.
     logging.info("Waiting for cluster %s to reach CREATE_COMPLETE", cluster.name)
@@ -135,11 +149,14 @@ def test_patching_cluster(
     _wait_instances_using_ami(ec2, cluster, "Compute", patched_ami)
     _wait_instances_using_ami(ec2, cluster, "LoginNode", patched_ami)
 
-    # Patch the head node in place and reboot it.
+    # Patch the head node in place and reboot it, using the same flavour as the patched AMI.
     remote_command_executor = RemoteCommandExecutor(cluster)
-    logging.info("Patching the head node")
+    logging.info("Patching the head node with the patching flavour %s", patching_flavour)
     patch_result = remote_command_executor.run_remote_script(
-        str(test_datadir / "patch_node.sh"), run_as_root=True, timeout=PATCHING_TIMEOUT
+        str(test_datadir / "patch_node.sh"),
+        args=[patching_flavour],
+        run_as_root=True,
+        timeout=PATCHING_TIMEOUT,
     )
     logging.info("Head node patching script output:\n%s", patch_result.stdout)
     reboot_head_node(cluster)
@@ -194,6 +211,18 @@ def _wait_instances_using_ami(ec2, cluster, node_type, expected_ami):
             expected_ami,
         )
     return using_patched_ami
+
+
+def _patching_flavour(flags=()):
+    """Return the patching flavour (minimal|full) selected via the flags dimension.
+
+    Look for a flag "patching:<flavour>" and return <flavour>, falling back to the
+    default flavour when no such flag is present.
+    """
+    for flag in flags:
+        if flag.startswith(PATCHING_FLAG_PREFIX):
+            return flag.removeprefix(PATCHING_FLAG_PREFIX)
+    return DEFAULT_PATCHING_FLAVOUR
 
 
 def _run_gpu_workload(cluster, scheduler_commands_factory, use_login_node):

--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -2,15 +2,32 @@
 #
 # Patching script.
 #
-# Applies all available *security* patches to the system using the native
-# package manager. Kernel packages are intentionally NOT excluded: if a
-# security fix requires a newer kernel, the bump is accepted. A reboot after
-# this script runs is required to activate a new kernel.
+# Applies OS package updates using the native package manager, in one of two
+# flavours (mandatory first argument):
+#
+#   minimal: apply only the available *security* patches (smallest set).
+#   full:    apply all available package updates (comprehensive upgrade).
+#
+# Kernel packages are intentionally NOT excluded in either flavour: if an update
+# requires a newer kernel, the bump is accepted. A reboot after this script runs
+# is required to activate a new kernel.
+#
+# Usage: patch_node.sh <minimal|full>
 #
 # Supports dnf (AL2023/RHEL9/Rocky9), yum (AL2/RHEL8) and apt (Ubuntu).
 set -euo pipefail
 
-echo "===== Starting system security patching on $(hostname) ====="
+if [[ $# -lt 1 ]]; then
+    echo "ERROR: missing mandatory patching flavour argument (minimal|full)" >&2
+    exit 1
+fi
+FLAVOUR="$1"
+if [[ "${FLAVOUR}" != "minimal" && "${FLAVOUR}" != "full" ]]; then
+    echo "ERROR: invalid patching flavour '${FLAVOUR}', expected 'minimal' or 'full'" >&2
+    exit 1
+fi
+
+echo "===== Starting system ${FLAVOUR} patching on $(hostname) ====="
 # Report the running kernel before patching. The kernel after the reboot is
 # reported separately once the node has rebooted (the reboot is mandatory to
 # activate any new kernel).
@@ -20,26 +37,41 @@ if command -v dnf >/dev/null 2>&1; then
     echo "Detected dnf package manager"
     sudo dnf clean all
     sudo dnf makecache --refresh || true
-    # Apply only security errata. Kernel packages are allowed to be upgraded.
-    sudo dnf upgrade --security -y
+    if [[ "${FLAVOUR}" == "minimal" ]]; then
+        # Apply only security errata. Kernel packages are allowed to be upgraded.
+        sudo dnf upgrade --security -y
+    else
+        # Apply all available package updates.
+        sudo dnf upgrade -y
+    fi
 elif command -v yum >/dev/null 2>&1; then
     echo "Detected yum package manager"
     sudo yum clean all
     sudo yum makecache || true
-    # update-minimal --security applies the smallest set of security errata.
-    # Kernel bumps are allowed (no --exclude=kernel*).
-    sudo yum update-minimal --security -y
+    if [[ "${FLAVOUR}" == "minimal" ]]; then
+        # update-minimal --security applies the smallest set of security errata.
+        # Kernel bumps are allowed (no --exclude=kernel*).
+        sudo yum update-minimal --security -y
+    else
+        # Apply all available package updates.
+        sudo yum update -y
+    fi
 elif command -v apt-get >/dev/null 2>&1; then
     echo "Detected apt package manager"
     export DEBIAN_FRONTEND=noninteractive
     sudo apt-get update -y
-    # unattended-upgrades applies only the security pocket by default and will
-    # upgrade linux-image-* (kernel) packages when needed.
-    sudo apt-get install -y unattended-upgrades
-    sudo unattended-upgrade -v
+    if [[ "${FLAVOUR}" == "minimal" ]]; then
+        # unattended-upgrades applies only the security pocket by default and will
+        # upgrade linux-image-* (kernel) packages when needed.
+        sudo apt-get install -y unattended-upgrades
+        sudo unattended-upgrade -v
+    else
+        # Apply all available package updates, including kernel packages.
+        sudo apt-get upgrade -y
+    fi
 else
     echo "ERROR: no supported package manager found (dnf/yum/apt-get)" >&2
     exit 1
 fi
 
-echo "===== System security patching completed on $(hostname) ====="
+echo "===== System ${FLAVOUR} patching completed on $(hostname) ====="


### PR DESCRIPTION
### Description of changes
In test_patching_cluster add possibility to specify the patching flavour to be either:
* minimal: minimal security-only updates, the default
* full: full Os package update

### Tests
SUCCESS:

```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_rocky8 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["rocky8"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["ubuntu2404"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
