### PR TITLE
[Test] Let test_Ad_integration validate the case where the Ad contains 1000 users

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -461,8 +461,35 @@ Resources:
               aws ds describe-domain-controllers --directory-id "${DirectoryId}" --region "${AWS::Region}"
               
               ADMIN_PW="${AdminPassword}"
-              
-              USERNAMES="ReadOnlyUser,${UserNames}"
+
+              # UserNames is a comma-separated list of literal names and/or generators
+              # "prefix:<P>;num:<N>;active:<M>": create N users <P>0..<P>(N-1), of which the first M
+              # are active (only active users get a password, see PostLambda). "active" is required.
+              USER_SPEC="${UserNames}"
+              EXPANDED_USERS=$(USER_SPEC="$USER_SPEC" python3 <<'PYEOF'
+              import os
+              import re
+              GENERATOR_RE = re.compile(r"^prefix:(?P<prefix>[^;]+);num:(?P<num>\d+);active:(?P<active>\d+)$")
+              def expand_user_names(spec_string):
+                  # All users to create (every generator yields N users; "active" is ignored here).
+                  names = []
+                  for spec in spec_string.split(","):
+                      spec = spec.strip()
+                      if not spec:
+                          continue
+                      if spec.startswith("prefix:"):
+                          m = GENERATOR_RE.match(spec)
+                          if not m:
+                              raise ValueError("Invalid user spec (expected 'prefix:<P>;num:<N>;active:<M>'): " + spec)
+                          for i in range(int(m.group("num"))):
+                              names.append("{}{}".format(m.group("prefix"), i))
+                      else:
+                          names.append(spec)
+                  return names
+              print(",".join(expand_user_names(os.environ["USER_SPEC"])))
+              PYEOF
+              )
+              USERNAMES="ReadOnlyUser,$EXPANDED_USERS"
               echo "Registering Users: $USERNAMES ..."
               for username in $(echo $USERNAMES | sed "s/,/ /g")
               do
@@ -572,14 +599,35 @@ Resources:
           import logging
           import random
           import string
+          import re
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)
           ds = boto3.client("ds")
           ec2 = boto3.client("ec2")
+          GENERATOR_RE = re.compile(r"^prefix:(?P<prefix>[^;]+);num:(?P<num>\d+);active:(?P<active>\d+)$")
 
           def create_physical_resource_id():
               alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
               return ''.join(random.choice(alnum) for _ in range(16))
+
+          def active_user_names(spec_string):
+              # Only the active users (first M of each generator); these get a password.
+              names = []
+              for spec in spec_string.split(","):
+                  spec = spec.strip()
+                  if not spec:
+                      continue
+                  if spec.startswith("prefix:"):
+                      m = GENERATOR_RE.match(spec)
+                      if not m:
+                          raise ValueError("Invalid user spec (expected 'prefix:<P>;num:<N>;active:<M>'): " + spec)
+                      num = int(m.group("num"))
+                      active = int(m.group("active"))
+                      for i in range(min(active, num)):
+                          names.append("{}{}".format(m.group("prefix"), i))
+                  else:
+                      names.append(spec)
+              return names
 
           def redact_keys(event: dict, redactions: set):
               ret = {}
@@ -610,8 +658,7 @@ Resources:
                   response_data['Message'] = 'Resource creation successful!'
                   physical_resource_id = create_physical_resource_id()
                   ds.reset_user_password(DirectoryId=directory_id, UserName='ReadOnlyUser', NewPassword=read_only_password)
-                  for name in user_names.split(","):
-                    name = name.strip()
+                  for name in active_user_names(user_names):
                     ds.reset_user_password(DirectoryId=directory_id, UserName=name, NewPassword=user_password)
                   ds.reset_user_password(DirectoryId=directory_id, UserName=admin, NewPassword=admin_password)
                   ec2.stop_instances(InstanceIds=[instance_id])

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -163,7 +163,7 @@ class CfnStacksFactory:
         if id in self.__created_stacks:
             raise ValueError("Stack {0} already exists in region {1}".format(name, region))
 
-        logging.info("Creating stack {0} in region {1}".format(name, region))
+        logging.info("Creating stack {0} in region {1} with parameters: {2}".format(name, region, stack.parameters))
         is_template_url = stack.template.startswith("https://")
         with aws_credential_provider(region, self.__credentials):
             try:

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -8,9 +8,11 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import logging
 import random
 from collections import OrderedDict
+from typing import List
 
 import boto3
 from assertpy import assert_that
@@ -26,6 +28,8 @@ from utils import (
     retrieve_tags,
     to_pascal_from_kebab_case,
 )
+
+SENSITIVE_PARAMETER_NAME_SUBSTRINGS = ("password", "secret")
 
 
 class CfnStack:
@@ -47,6 +51,21 @@ class CfnStack:
         self.__cfn_outputs = retrieve_cfn_outputs(self.name, self.region)
         self.__cfn_resources = retrieve_cfn_resources(self.name, self.region)
         self.tags = retrieve_tags(self.name, self.region)
+
+    @property
+    def obfuscated_parameters(self) -> List[dict]:
+        """
+        Return a copy of the stack parameters with sensitive values obfuscated.
+
+        A parameter is considered sensitive when its ParameterKey contains "password" or "secret"
+        (case insensitive). This is used to avoid logging secret values.
+        """
+        obfuscated = copy.deepcopy(self.parameters)
+        for parameter in obfuscated:
+            key = parameter.get("ParameterKey", "")
+            if any(substring in key.lower() for substring in SENSITIVE_PARAMETER_NAME_SUBSTRINGS):
+                parameter["ParameterValue"] = "****"
+        return obfuscated
 
     @property
     def cfn_outputs(self):
@@ -163,7 +182,9 @@ class CfnStacksFactory:
         if id in self.__created_stacks:
             raise ValueError("Stack {0} already exists in region {1}".format(name, region))
 
-        logging.info("Creating stack {0} in region {1} with parameters: {2}".format(name, region, stack.parameters))
+        logging.info(
+            "Creating stack {0} in region {1} with parameters: {2}".format(name, region, stack.obfuscated_parameters)
+        )
         is_template_url = stack.template.startswith("https://")
         with aws_credential_provider(region, self.__credentials):
             try:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -35,8 +35,9 @@ from xdist import get_xdist_worker_id
 from tests.ad_integration.cluster_user import ClusterUser
 from tests.common.utils import run_system_analyzer
 
-NUM_USERS_TO_CREATE = 5
+NUM_USERS_TO_CREATE = 1000
 NUM_USERS_TO_TEST = 3
+USER_NAME_PREFIX = "PclusterUser"
 
 
 def get_infra_stack_outputs(stack_name):
@@ -159,9 +160,10 @@ def _get_stack_parameters(directory_type, vpc_stack, keypair):
     private_subnets = vpc_stack.get_all_private_subnets().copy()
     private_subnets.remove(private_subnet)
 
-    users = ""
-    for i in range(NUM_USERS_TO_CREATE):
-        users += f"PclusterUser{i},"
+    # Compact generator (stays under CFN's 4096-char param limit): create NUM_USERS_TO_CREATE users
+    # but only activate the first NUM_USERS_TO_TEST (the ones the test logs in with) to keep the
+    # password-reset step under the custom-resource Lambda timeout.
+    users = f"prefix:{USER_NAME_PREFIX};num:{NUM_USERS_TO_CREATE};active:{NUM_USERS_TO_TEST}"
 
     stack_parameters = [
         {
@@ -176,7 +178,7 @@ def _get_stack_parameters(directory_type, vpc_stack, keypair):
             "ParameterKey": "ReadOnlyPassword",
             "ParameterValue": "".join(random.choices(string.ascii_letters + string.digits, k=60)),
         },
-        {"ParameterKey": "UserNames", "ParameterValue": users[:-1]},
+        {"ParameterKey": "UserNames", "ParameterValue": users},
         {
             "ParameterKey": "UserPassword",
             "ParameterValue": "".join(random.choices(string.ascii_letters + string.digits, k=60)),


### PR DESCRIPTION
### Description of changes
Let test_ad_integration validate the case where the AD contains 1000 users 1000 users (rather than just 3).
This is to ensure that we are able to integrate with a big AD.

To this aim, we reinterpreted the existing UserNames parameter of  ad-integration.yam so it can generate users, without changing the stack's parameter interface (no new parameters, same Type: String).

Each comma-separated token in UserNames is now one of:

* A literal username (existing behavior), or
A generator of the form prefix:<PREFIX>;num:<N>;active:<M>, which creates N users <PREFIX>0 .. <PREFIX>(N-1) and marks the first M as "active". All N users are created, but only the M active ones have their password configured.

This is backward compatible because tokens without the new prefixes are treated as literal usernames, so existing comma-separated lists and the parameter default (user000) behave unchanged.

Also, add logging of CFN stack parameters with obfiuscated sensitive params, used for any cfn stack creation to facilitate troubleshooting.

### Tests
SUCCESS

```
test-suites:
  ad_integration:
    test_ad_integration.py::test_ad_integration:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ {{ LUSTRE_OS_X86_0 }}, {{ LUSTRE_OS_X86_2 }}, {{ LUSTRE_OS_X86_4 }}, {{ LUSTRE_OS_X86_6 }}]
          schedulers: ["slurm"]
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
