### PR TITLE
[Test] Fix intermittent failure in test_create_ami

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -197,15 +197,17 @@ def test_build_image(
     )
 
     with soft_assertions():
-        _test_build_image_success(image, request.config.getoption("output_dir"))
+        _wait_for_build_instance(image, region)
         _test_build_instances_tags(image, image.config["Build"]["Tags"], region)
         _test_build_imds_settings(image, "required", region)
+
+        _test_build_image_success(image, request.config.getoption("output_dir"))
+        _test_export_logs(s3_bucket_factory, image, region)
+        _test_export_logs(s3_bucket_factory, image, region, True)
         _test_image_tag_and_volume(image)
         _test_list_image_log_streams(image)
         _test_get_image_log_events(image)
         _test_list_images(image)
-        _test_export_logs(s3_bucket_factory, image, region)
-        _test_export_logs(s3_bucket_factory, image, region, True)
 
     _test_cluster_creation(
         image.ec2_image_id, pcluster_config_reader, region, clusters_factory, scheduler_commands_factory
@@ -556,6 +558,28 @@ def test_build_image_custom_components(
     _test_build_image_success(image, request.config.getoption("output_dir"))
 
 
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(10))
+def _wait_for_build_instance(image, region):
+    """Wait until the ImageBuilder build instance is launched.
+
+    The build instance exists only while the image is being built; it is terminated and the build-image
+    stack self-deletes once the image reaches BUILD_COMPLETE. Waiting for it here lets the tag and IMDS
+    checks run against a live instance instead of racing the teardown or passing vacuously.
+    """
+    instance_name = f"Build instance for ParallelClusterImage-{image.image_id}"
+    reservations = (
+        boto3.client("ec2", region_name=region)
+        .describe_instances(
+            Filters=[
+                {"Name": "tag:Name", "Values": [instance_name]},
+                {"Name": "instance-state-name", "Values": ["running"]},
+            ]
+        )
+        .get("Reservations")
+    )
+    return [instance for reservation in reservations for instance in reservation.get("Instances", [])]
+
+
 def _test_build_imds_settings(image, status, region):
     logging.info(f"Checking that the ImageBuilder instances have IMDSv2 {status}")
 
@@ -596,8 +620,10 @@ def _test_build_image_success(image, output_dir):
     pcluster_describe_image_result = image.describe()
     logging.info(pcluster_describe_image_result)
 
+    # Poll every 5 minutes so BUILD_COMPLETE is detected close to when it happens. The build-image stack
+    # self-deletes on build success, so detecting completion sooner reduces the export-image-logs race window.
     while image.image_status.endswith("_IN_PROGRESS"):  # e.g. BUILD_IN_PROGRESS, DELETE_IN_PROGRESS
-        time.sleep(600)
+        time.sleep(300)
         pcluster_describe_image_result = image.describe()
         logging.info(pcluster_describe_image_result)
     if image.image_status != "BUILD_COMPLETE":

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -148,16 +148,11 @@ def test_build_image(
         base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
         enable_nvidia = False  # Deep learning AMIs have Nvidia pre-installed
     elif "rhel" in os or "ubuntu" in os or os == "rocky8":
-        # Test AMIs from first stage build. Because RHEL/Rocky and Ubuntu have specific requirement of kernel versions.
-        try:
-            base_ami = retrieve_latest_ami(region, os, ami_type="first_stage", architecture=architecture)
-        except IndexError:  # If first stage AMI is not available, use official AMI.
-            # Therefore, the test tries to succeed at best effort.
-            logging.info("First stage AMI not available, using official AMI instead.")
-            base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
-            update_os_packages = True
-            if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
-                enable_lustre_client = False
+        # Use official AMIs. First stage AMIs must not be used as parent image in this test.
+        base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
+        update_os_packages = True
+        if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
+            enable_lustre_client = False
     else:
         # Test vanilla AMIs.
         base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)


### PR DESCRIPTION
### Description of changes
Fix intermittent failure in test_create_ami by:
 1. execute the export of logs right after build success. This is to reduce the risk of exporting logs when the image stack is already deleted.
 2. reduce the interval between image stack checks from 10min to 5min. Again, this is to reduce the risk of exporting logs when the image stack is already deleted.
 3. execute the build image checks as soon as the build image goes running. This is to move the logs exporting earlier.
 4. Always use the public vanilla AMIs as parent image rather than private first stage AMIs.


### Tests
SUCCESS

```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - alinux2
        - rhel9
        regions:
        - us-east-2
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
