### PR TITLE
[integ-tests] Verify NFS v3 client mount has lockd pinned to port 4045

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 - The CLI now requires the additional permission `tag:GetResources`.
 - Add support for Python 3.13 in pcluster CLI
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.
+- Change the default NFS lock manager port from 32768 to 4045. 32768 is in the Linux ephemeral port range (32768–60999), causing sporadic mount failures because of port collision. This only affects nodes that mount an external NFSv3 server; all ParallelCluster managed storage is mounted over NFSv4 and is unaffected. Customers who mount external NFSv3 servers and restrict NFS ports in a firewall must allow TCP/UDP 4045 instead of 32768.
 
 **BUG FIXES**
 - Fix sporadic S3 bucket (with name parallelcluster-*-v1-do-not-delete) creation failure when multiple create-cluster commands are running simultaneously in the same region.

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -584,6 +584,57 @@ def check_fstab_file(remote_command_executor, expected_entry):
     assert_that(result.stdout).matches(expected_entry)
 
 
+def assert_client_lockd_uses_port(remote_command_executor, ontap_volume_id, expected_port=4045):
+    """
+    Verify the client-side NFS lock manager (lockd/NLM) uses the pinned, non-ephemeral port.
+
+    ParallelCluster mounts everything it manages over NFSv4, so lockd is only exercised when a
+    customer mounts an external NFSv3 server. We reproduce that here by explicitly mounting an
+    FSx ONTAP volume with `vers=3` (ParallelCluster itself would mount ONTAP as v4 by default).
+
+    We then assert lockd bound the pinned port 4045 rather than the historical port 32768.
+    """
+    logging.info("Checking client-side lockd binds port %s on an NFSv3 mount", expected_port)
+    mount_dir = "/mnt/nfsv3_lockd_check"
+    fsx_client = boto3.client("fsx")
+    volume = fsx_client.describe_volumes(VolumeIds=[ontap_volume_id]).get("Volumes")[0]
+    junction_path = volume["OntapConfiguration"]["JunctionPath"]
+    svm_id = volume["OntapConfiguration"]["StorageVirtualMachineId"]
+    dns_name = fsx_client.describe_storage_virtual_machines(StorageVirtualMachineIds=[svm_id])[
+        "StorageVirtualMachines"
+    ][0]["Endpoints"]["Nfs"]["DNSName"]
+
+    remote_command_executor.run_remote_command(f"sudo mkdir -p {mount_dir}")
+    # Retry the v3 mount a few times to make the test robust.
+    remote_command_executor.run_remote_command(
+        f"for i in $(seq 1 6); do sudo mount -t nfs -o vers=3 {dns_name}:{junction_path} {mount_dir} "
+        f"&& break || {{ echo 'mount attempt '$i' failed, retrying'; sleep 10; }}; done"
+    )
+    try:
+        # Confirm the mount is actually NFSv3.
+        mounts = remote_command_executor.run_remote_command(f"mount | grep ' {mount_dir} '").stdout
+        assert_that(mounts).matches(r"vers=3|nfsvers=3")
+
+        # A POSIX (fcntl) lock over NFSv3 triggers NLM, bringing lockd up so it binds its port.
+        remote_command_executor.run_remote_command(
+            f"sudo timeout 30 python3 -c \"import fcntl; f=open('{mount_dir}/.lockd_probe','w'); "
+            'fcntl.lockf(f, fcntl.LOCK_EX); fcntl.lockf(f, fcntl.LOCK_UN)" || true'
+        )
+
+        # nlockmgr must be registered on the pinned port, and never on 32768.
+        rpcinfo = remote_command_executor.run_remote_command("rpcinfo -p localhost").stdout
+        assert_that(rpcinfo).matches(rf"\b{expected_port}\s+nlockmgr")
+        assert_that(rpcinfo).does_not_match(r"\b32768\s+nlockmgr")
+
+        # lockd should be listening on the pinned port and nothing should be on 32768.
+        listening = remote_command_executor.run_remote_command(
+            f"sudo ss -tuln | grep -E ':{expected_port}(\\s|$)' || true"
+        ).stdout
+        assert_that(listening).is_not_empty()
+    finally:
+        remote_command_executor.run_remote_command(f"sudo umount {mount_dir} || true")
+
+
 def assert_fsx_open_zfs_correctly_mounted(remote_command_executor, mount_dir, volume_id):
     logging.info("Testing fsx OpenZFS is correctly mounted on the head node")
     result = remote_command_executor.run_remote_command("df -h -t nfs4")
@@ -793,7 +844,7 @@ def get_mount_name(fsx_fs_id, region):
 
 def create_fsx_ontap(fsx_factory, num, vpc=None, subnet=None):
     return fsx_factory(
-        ports=[111, 635, 2049, 4046],
+        ports=[111, 635, 2049, 4045, 4046],
         ip_protocols=["tcp", "udp"],
         num=num,
         vpc=vpc,

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -27,6 +27,7 @@ from troposphere.fsx import LustreConfiguration
 from utils import is_fsx_lustre_deployment_type_supported
 
 from tests.storage.storage_common import (
+    assert_client_lockd_uses_port,
     assert_fsx_lustre_correctly_mounted,
     check_dra,
     check_fsx,
@@ -368,6 +369,9 @@ def test_multiple_fsx(
         fsx_lustre_mount_dirs + fsx_open_zfs_mount_dirs + fsx_ontap_mount_dirs,
         bucket_name,
     )
+
+    if fsx_on_tap_volume_ids:
+        assert_client_lockd_uses_port(RemoteCommandExecutor(cluster), fsx_on_tap_volume_ids[0])
 
 
 @pytest.mark.usefixtures("instance")


### PR DESCRIPTION
### Description of changes
Among our integration tests, only FSx Ontap supports v3 mount. Therefore, the check is added to the end of test_multiple_fsx. The check mounts FSx Ontap again with v3, and checks lockd register port 4045 in rpcbind.

This commit also allows 4045 port in the security group of the FSx Ontap, because v3 mount also requires lockd port on the server, which is defined as 4045 in Ontap too

### Tests
The following tests have passed:
```
test-suites:
  storage:
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rhel8", "rocky8", "rocky9", "rhel9"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_multiple_fsx:
      dimensions:
        - regions: ["eu-west-2"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rhel8", "rocky8", "rocky9", "rhel9"]
          schedulers: ["slurm"]
```

### References
* Cookbook default port change https://github.com/aws/aws-parallelcluster-cookbook/pull/3217

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
