### PR TITLE
[Test] In test_dcv_configuration, tolerate the intermittent crash on `ibus-extension-gtk3`, which is not related to DCV or NVIDIA.

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -50,6 +50,9 @@ TOLERATED_CRASH_PATTERNS = [
     re.compile(r"gnome-software.*scroll_to \(libadwaita", re.DOTALL),
     # tracker-miner-fs-3, tracker-extract, and tracker-store crash on Ubuntu/RHEL — GNOME file indexer, unrelated to DCV
     re.compile(r"tracker-(miner|extract|store)", re.DOTALL),
+    # ibus-extension-gtk3 aborts in the GNOME session — GNOME input-method component, unrelated to DCV.
+    # Observed on ubuntu2404/arm64 (g5g).
+    re.compile(r"ibus-extension-gtk3", re.DOTALL),
 ]
 
 


### PR DESCRIPTION
### Description of changes
[Test] In test_dcv_configuration, tolerate the intermittent crash on `ibus-extension-gtk3`, which is not related to DCV or NVIDIA.


### Tests
SUCCESS

```
test-suites:
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
      - instances:
        - g5g.2xlarge
        oss:
        - ubuntu2404
        regions:
        - us-east-1
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
