### PR TITLE
[Test] Fix test_patching_cluster on Ubuntu by `DEBIAN_FRONTEND=noninteractive` and improve logging to facilitate troubleshooting

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -12,6 +12,7 @@
 import functools
 import json
 import logging
+import re
 import subprocess
 import time
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1760,6 +1760,53 @@ def ami_copy(region):
             logging.error("Delete copied AMI snapshot failed due to %s", e)
 
 
+def _log_ami_patching_build_output(region, stack_name):  # noqa: C901
+    """Fetch and log the EC2 Image Builder execution logs for the patched-AMI build.
+
+    Image Builder streams the output of every recipe step (including the patch
+    script stdout from the ApplyPatches ExecuteBash step) to the CloudWatch log
+    group /aws/imagebuilder/pcluster-ami-patching-recipe-<stack_name>. Surfacing it
+    here mirrors how the head node patching output is logged by the test, so the AMI
+    patching output is available in the test logs too. Any failure to retrieve the
+    logs is swallowed so it never fails the test.
+    """
+    log_group_name = f"/aws/imagebuilder/pcluster-ami-patching-recipe-{stack_name}"
+    logs_client = boto3.client("logs", region_name=region)
+    try:
+        streams = []
+        next_token = None
+        while True:
+            kwargs = {"logGroupName": log_group_name, "orderBy": "LogStreamName"}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = logs_client.describe_log_streams(**kwargs)
+            streams.extend(response.get("logStreams", []))
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+        if not streams:
+            logging.info("No AMI patching Image Builder log streams found in log group %s", log_group_name)
+            return
+        for stream in streams:
+            stream_name = stream["logStreamName"]
+            messages = []
+            prev_token = None
+            event_token = None
+            while True:
+                event_kwargs = {"logGroupName": log_group_name, "logStreamName": stream_name, "startFromHead": True}
+                if event_token:
+                    event_kwargs["nextToken"] = event_token
+                event_response = logs_client.get_log_events(**event_kwargs)
+                messages.extend(event["message"] for event in event_response.get("events", []))
+                event_token = event_response.get("nextForwardToken")
+                if event_token == prev_token:
+                    break
+                prev_token = event_token
+            logging.info("AMI patching Image Builder log (stream %s):\n%s", stream_name, "\n".join(messages))
+    except Exception as e:  # noqa: BLE001
+        logging.warning("Could not retrieve AMI patching Image Builder logs from log group %s: %s", log_group_name, e)
+
+
 @pytest.fixture()
 def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_factory, s3_bucket_factory):
     """
@@ -1825,6 +1872,7 @@ def patched_ami_factory(region, vpc_stack, test_datadir, request, cfn_stacks_fac
         ami_id = stack.cfn_outputs["AmiId"]
         built.append((ami_id, stack_name))
         logging.info("Patched AMI %s is available", ami_id)
+        _log_ami_patching_build_output(region, stack_name)
         return ami_id
 
     yield _build

--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -58,16 +58,20 @@ elif command -v yum >/dev/null 2>&1; then
     fi
 elif command -v apt-get >/dev/null 2>&1; then
     echo "Detected apt package manager"
-    export DEBIAN_FRONTEND=noninteractive
-    sudo apt-get update -y
+    # Make apt non-interactive so no prompt blocks the upgrade (under a PTY with no
+    # operator, any prompt would hang until the caller's timeout kills the command).
+    # DEBIAN_FRONTEND is passed *through* sudo, which resets the environment by default,
+    # so an exported var alone would not reach the root apt-get process.
+    _envars=(DEBIAN_FRONTEND=noninteractive)
+    sudo "${_envars[@]}" apt-get update -y
     if [[ "${FLAVOUR}" == "minimal" ]]; then
         # unattended-upgrades applies only the security pocket by default and will
         # upgrade linux-image-* (kernel) packages when needed.
-        sudo apt-get install -y unattended-upgrades
-        sudo unattended-upgrade -v
+        sudo "${_envars[@]}" apt-get install -y unattended-upgrades
+        sudo "${_envars[@]}" unattended-upgrade -v
     else
         # Apply all available package updates, including kernel packages.
-        sudo apt-get upgrade -y
+        sudo "${_envars[@]}" apt-get upgrade -y
     fi
 else
     echo "ERROR: no supported package manager found (dnf/yum/apt-get)" >&2


### PR DESCRIPTION
### Description of changes
Fix test_patching_cluster on Ubuntu by `DEBIAN_FRONTEND=noninteractive` and improve logging to facilitate troubleshooting

Also patching a minor bug on cluster stack deletion caused by missing import.

### Tests
SUCCEEDED on Ubuntu. On RHEL9 it fails for known issue on lustre module broken by kernel bump.

```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["ubuntu2404"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["rhel9"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
