### PR TITLE
[Test] Fix gpu_job.sh to discover installed cuda-samples version

### DIFF
--- a/tests/integration-tests/configs/dependency_upgrade.yaml
+++ b/tests/integration-tests/configs/dependency_upgrade.yaml
@@ -1,0 +1,176 @@
+{%- import 'common.jinja2' as common with context -%}
+{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
+{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
+---
+# Config for the dependency-upgrade integration run (check_dependency_updates_pipeline).
+#
+# Purpose: validate that the OS AMIs built with upgraded dependencies still work. Curated
+# subset of develop.yaml covering the features tied to the upgradable deps (see
+# DEP_TEST_FEATURES in check_dependency_updates.py): slurm stack, efa, dcv, pyxis,
+# efs/internal_efs/shared_home, slurm accounting/rest, gpu health checks.
+#
+# OS coverage vs. capacity:
+#   - Plain-region tests (c5.xlarge / m6g.xlarge, no capacity constraint) use
+#     {{ AVAILABLE_AMIS_OSS_X86 }} / {{ AVAILABLE_AMIS_OSS_ARM }} so every OS built this run is
+#     exercised, per architecture.
+#   - Capacity-sensitive tests (GPU/EFA/DCV instances) keep develop.yaml's capacity-reservation
+#     region AND its single OS verbatim: the reservation is per-OS, so these cannot fan out over
+#     all OSes without hitting ICE. Do not replace their region/oss.
+#
+# Excludes special-hardware tests (gb200/p6e/trainium/capacity blocks) that require
+# INSTANCE_TYPES_DATA and dedicated capacity; they do not validate dependency upgrades.
+test-suites:
+  basic:
+    # Capacity-reservation pinned (GPU/DCV instance) - keep region+oss verbatim from develop.yaml.
+    test_essential_features.py::test_essential_features:
+      dimensions:
+        - regions: [{{ US_EAST_1_INSTANCE_TYPE_0_xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_DCV_OS_X86_1__g5g_2xlarge_CAPACITY_RESERVATION_1_INSTANCES_1_HOURS_NOPG_DCV_OS_X86_1 }}]
+          instances: [{{ US_EAST_1_INSTANCE_TYPE_0 }}.xlarge]
+          oss: [{{ DCV_OS_X86_1 }}]
+          schedulers: ["slurm"]
+  dcv:
+    # Capacity-reservation pinned (GPU instances) - keep verbatim.
+    test_dcv.py::test_dcv_configuration:
+      dimensions:
+        # Fan out over all built OSes: two same-AZ reservations split by platform
+        # (RHEL vs Linux/UNIX). 3 g4dn per cluster; sized for worst case 5 non-RHEL + 2 RHEL OSes.
+        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_15_INSTANCES_1_HOURS_NOPG_OTHER__g4dn_2xlarge_CAPACITY_RESERVATION_6_INSTANCES_1_HOURS_NOPG_rhel }}]
+          instances: ["g4dn.2xlarge"]
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+        - regions: [{{ g5g_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_NOPG_DCV_OS_X86_3 }}]
+          instances: ["g5g.2xlarge"]
+          oss: [{{ DCV_OS_X86_3 }}]
+          schedulers: ["slurm"]
+  capacity_reservations:
+    # Verbatim from develop.yaml.
+    test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [{{ OS_X86_3 }}]
+    test_capacity_blocks.py::test_capacity_blocks:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [{{ OS_X86_5 }}]
+          schedulers: ["slurm"]
+  efa:
+    # Fan out the vanilla EFA instances (c5n x86, c6gn ARM) over all built OSes via two
+    # same-AZ reservations split by platform (RHEL vs Linux/UNIX). 3 instances/cluster
+    # (2 compute + 1 head); worst case 5 non-RHEL + 2 RHEL OSes. GPU/HPC-specific EFA
+    # dims (p4d/p6-b200/hpc6id/hpc6a) test instance-specific behavior, not deps, and are dropped.
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_15_INSTANCES_1_HOURS_YESPG_OTHER__c5n_18xlarge_CAPACITY_RESERVATION_6_INSTANCES_1_HOURS_YESPG_rhel }}]
+          instances: ["c5n.18xlarge"]
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+        - regions: [{{ c6gn_16xlarge_CAPACITY_RESERVATION_15_INSTANCES_1_HOURS_YESPG_OTHER__c6gn_16xlarge_CAPACITY_RESERVATION_6_INSTANCES_1_HOURS_YESPG_rhel }}]
+          instances: ["c6gn.16xlarge"]
+          oss: {{ AVAILABLE_AMIS_OSS_ARM }}
+          schedulers: ["slurm"]
+  ultraserver:
+    # Verbatim from develop.yaml. Needs INSTANCE_TYPES_DATA (p6e-gb200.36xlarge).
+    test_gb200.py::test_gb200:
+      dimensions:
+        - regions: [ "use1-az1" ]  # do not move, unless instance type support is moved as well
+          instances: [ "g5g.xlarge" ]
+          oss: [ "alinux2023" ]
+          schedulers: [ "slurm" ]
+        - regions: [ "usw2-az4" ]  # do not move, unless instance type support is moved as well
+          instances: [ "p6e-gb200.36xlarge" ]
+          oss: [ "ubuntu2204", "ubuntu2404", "rocky9", "alinux2023", "rhel9" ]
+          schedulers: [ "slurm" ]
+  health_checks:
+    # Capacity-reservation pinned (GPU instance) - keep verbatim.
+    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
+      dimensions:
+        - regions: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0_CAPACITY_RESERVATION_3_INSTANCES_1_HOURS_NOPG_OS_X86_5 }}]
+          instances: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0 }}]
+          oss: [{{ OS_X86_5 }}]
+          schedulers: ["slurm"]
+  pyxis:
+    test_pyxis.py::test_pyxis:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+  schedulers:
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_scaling:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_custom_munge_key.py::test_custom_munge_key:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_slurm_accounting.py::test_slurm_accounting:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_slurm_accounting.py::test_slurm_accounting_external_dbd:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_slurm_rest_api.py::test_slurm_rest_api:
+      dimensions:
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+  storage:
+    test_efs.py::test_efs_access_point:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    # EFS tests can be done in any region.
+    test_efs.py::test_efs_compute_az:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_efs.py::test_efs_same_az:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: [ "slurm" ]
+    # The checks performed in test_efs_same_az is similar to test_multiple_efs.
+    # We should consider this when assigning dimensions to each test.
+    test_efs.py::test_multiple_efs:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: [ "slurm" ]
+    test_shared_home.py::test_shared_home:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]
+    test_internal_efs.py::test_internal_efs:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT }}
+          oss: {{ AVAILABLE_AMIS_OSS_X86 }}
+          schedulers: ["slurm"]

--- a/tests/integration-tests/tests/common/data/gpu_job.sh
+++ b/tests/integration-tests/tests/common/data/gpu_job.sh
@@ -3,7 +3,7 @@
 #SBATCH --output=cuda-gpu-validate-%j.out
 
 # Build and run a single CUDA sample (passed as a script argument) from the
-# pre-installed /usr/local/cuda-samples-13.0 tree. CUDA samples 13.x are
+# pre-installed /usr/local/cuda-samples-* tree. CUDA samples 13.x are
 # CMake-only and /usr/local/... isn't writable, so the script copies the
 # sample into a temp dir before building.
 
@@ -27,9 +27,20 @@ nvidia-smi -L
 nvidia-smi
 nvcc --version
 
-SAMPLES_SRC=/usr/local/cuda-samples-13.0
-if [[ ! -d "$SAMPLES_SRC/Samples/$SAMPLE_REL" ]]; then
-    echo "ERROR: sample not found: $SAMPLES_SRC/Samples/$SAMPLE_REL" >&2
+# Pick whichever cuda-samples-<ver> tree is installed (version not hardcoded).
+SAMPLES_SRC=$(ls -d /usr/local/cuda-samples-* 2>/dev/null | sort -V | tail -1)
+if [[ -z "$SAMPLES_SRC" ]]; then
+    echo "ERROR: no /usr/local/cuda-samples-* tree found" >&2
+    exit 2
+fi
+
+# 13.3+ moved C++ samples under cpp/; older trees keep them under Samples/.
+if [[ -d "$SAMPLES_SRC/cpp/$SAMPLE_REL" ]]; then
+    SAMPLE_ROOT="$SAMPLES_SRC/cpp"
+elif [[ -d "$SAMPLES_SRC/Samples/$SAMPLE_REL" ]]; then
+    SAMPLE_ROOT="$SAMPLES_SRC/Samples"
+else
+    echo "ERROR: sample not found under $SAMPLES_SRC (cpp/ or Samples/): $SAMPLE_REL" >&2
     exit 2
 fi
 
@@ -39,9 +50,9 @@ trap 'rm -rf "$WORKDIR"' EXIT
 # Shared scaffolding required by every sample (Common/, top-level cmake/)
 cp -r "$SAMPLES_SRC"/{Common,cmake,CMakeLists.txt} "$WORKDIR"/
 
-DST="$WORKDIR/Samples/$SAMPLE_REL"
+DST="$WORKDIR/samples/$SAMPLE_REL"
 mkdir -p "$(dirname "$DST")"
-cp -r "$SAMPLES_SRC/Samples/$SAMPLE_REL" "$DST"
+cp -r "$SAMPLE_ROOT/$SAMPLE_REL" "$DST"
 
 echo "===== Building $SAMPLE_REL ====="
 cmake -S "$DST" -B "$DST/build"


### PR DESCRIPTION
### Description of changes
* Detect the Cuda samples version installed in the AMI instead of hardcoding to a particular version; without this the dependency upgrades where we upgrade CUDA version fails with 
```
  Built on Tue_Jun_09_02:43:40_PM_PDT_2026                                                                                                           
  Cuda compilation tools, release 13.3, V13.3.73                                                                                                     
  Build cuda_13.3.r13.3/compiler.38244171_0                                                                                                          
  ERROR: sample not found: /usr/local/cuda-samples-13.0/Samples/1_Utilities/deviceQuery 
```

* Add dependency_upgrades.yaml for testing

### Test
* Submit a Job with test script

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
