### PR TITLE
Move node bootstrap files from /tmp to /opt/parallelcluster/tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 **ENHANCEMENTS**
 - Improve cluster update resiliency on login nodes by reusing the head-node-driven orchestration already in place on compute nodes,
   removing the dependency on cfn-hup and cfn-init.
+- Move all ParallelCluster-managed bootstrap files off `/tmp` into a dedicated `/opt/parallelcluster/tmp`
+  directory. Therefore, Image builds, cluster creations and updates work on custom AMIs that mount `/tmp` with `noexec`.
 
 **CHANGES**
 - The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`, 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -245,6 +245,12 @@ DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}
 
 DEFAULT_EPHEMERAL_DIR = "/scratch"
 
+# Dedicated ParallelCluster-managed directory used to stage bootstrap files (dna.json, extra.json,
+# wait_condition_handle.txt, bootstrap.sh) instead of /tmp, so bootstrap works when /tmp is mounted
+# with noexec. Defined once here and referenced by cluster_stack.py (cfn-init) and the user_data
+# templates (via the PclusterTmpDir Fn::Sub variable).
+PCLUSTER_TMP_DIR = "/opt/parallelcluster/tmp"
+
 LAMBDA_VPC_ACCESS_MANAGED_POLICY = "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 
 IAM_NAME_PREFIX_LENGTH_LIMIT = 30

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -51,17 +51,17 @@ datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
-  - path: /tmp/dna.json
+  - path: ${PclusterTmpDir}/dna.json
     permissions: '0644'
     owner: root:root
     content: |
       ${DnaJson}
-  - path: /tmp/extra.json
+  - path: ${PclusterTmpDir}/extra.json
     permissions: '0644'
     owner: root:root
     content: |
       ${ExtraJson}
-  - path: /tmp/bootstrap.sh
+  - path: ${PclusterTmpDir}/bootstrap.sh
     permissions: '0744'
     owner: root:root
     content: |
@@ -145,12 +145,12 @@ write_files:
         done
         vendor_cookbook
       fi
-      cd /tmp
+      cd ${PclusterTmpDir}
       mkdir -p /etc/chef/ohai/hints
       touch /etc/chef/ohai/hints/ec2.json
 
       start=$(date +%s)
-      jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )
+      jq -s ".[0] * .[1]" ${PclusterTmpDir}/dna.json ${PclusterTmpDir}/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp ${PclusterTmpDir}/dna.json /etc/chef/dna.json )
       {
         CINC_CMD="cinc-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist"
         FR_CMD="/opt/parallelcluster/scripts/fetch_and_run"
@@ -192,8 +192,8 @@ function error_exit
 }
 
 if [ "${Timeout}" == "NONE" ]; then
-  /tmp/bootstrap.sh
+  ${PclusterTmpDir}/bootstrap.sh
 else
-  timeout ${Timeout} /tmp/bootstrap.sh || error_exit
+  timeout ${Timeout} ${PclusterTmpDir}/bootstrap.sh || error_exit
 fi
 --==BOUNDARY==

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -72,7 +72,7 @@ function error_exit
   sleep 10
   # trim the error message because there is a size limit of 4096 bytes for cfn-signal
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
-  cutoff=$(expr 4096 - $(stat --printf="%s" /tmp/wait_condition_handle.txt))
+  cutoff=$(expr 4096 - $(stat --printf="%s" ${PclusterTmpDir}/wait_condition_handle.txt))
   reason=$(head --bytes=${!cutoff} /var/log/parallelcluster/bootstrap_error_msg 2>/dev/null) || reason="$1"
   $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-signal --exit-code=1 --reason="${!reason}" "${!wait_condition_handle_presigned_url}" --region ${AWS::Region} --url ${CloudFormationUrl}
   exit 1
@@ -91,9 +91,9 @@ export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aw
 # Load ParallelCluster environment variables
 [ -f /etc/parallelcluster/pcluster_cookbook_environment.sh ] && . /etc/parallelcluster/pcluster_cookbook_environment.sh
 
-cd /tmp
+cd ${PclusterTmpDir}
 $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-init -s ${AWS::StackName} -v -c deployFiles -r HeadNodeLaunchTemplate --region ${AWS::Region} --url ${CloudFormationUrl}
-wait_condition_handle_presigned_url=$(cat /tmp/wait_condition_handle.txt)
+wait_condition_handle_presigned_url=$(cat ${PclusterTmpDir}/wait_condition_handle.txt)
 
 custom_cookbook=${CustomChefCookbook}
 export _region=${AWS::Region}

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -48,17 +48,17 @@ datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
-  - path: /tmp/dna.json
+  - path: ${PclusterTmpDir}/dna.json
     permissions: '0644'
     owner: root:root
     content: |
       ${DnaJson}
-  - path: /tmp/extra.json
+  - path: ${PclusterTmpDir}/extra.json
     permissions: '0644'
     owner: root:root
     content: |
       ${ExtraJson}
-  - path: /tmp/bootstrap.sh
+  - path: ${PclusterTmpDir}/bootstrap.sh
     permissions: '0744'
     owner: root:root
     content: |
@@ -136,11 +136,11 @@ write_files:
         done
         vendor_cookbook
       fi
-      cd /tmp
+      cd ${PclusterTmpDir}
       mkdir -p /etc/chef/ohai/hints
       touch /etc/chef/ohai/hints/ec2.json
 
-      jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )
+      jq -s ".[0] * .[1]" ${PclusterTmpDir}/dna.json ${PclusterTmpDir}/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp ${PclusterTmpDir}/dna.json /etc/chef/dna.json )
       {
         CINC_CMD="cinc-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
         pushd /etc/chef &&
@@ -175,9 +175,9 @@ function error_exit
 }
 
 if [ "${Timeout}" == "NONE" ]; then
-  /tmp/bootstrap.sh
+  ${PclusterTmpDir}/bootstrap.sh
 else
-  timeout ${Timeout} /tmp/bootstrap.sh || error_exit
+  timeout ${Timeout} ${PclusterTmpDir}/bootstrap.sh || error_exit
 fi
 
 # Notify the AutoScalingGroup about the successful bootstrap

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -43,6 +43,7 @@ from pcluster.constants import (
     PCLUSTER_CLUSTER_NAME_TAG,
     PCLUSTER_DYNAMODB_PREFIX,
     PCLUSTER_NODE_TYPE_TAG,
+    PCLUSTER_TMP_DIR,
     ULTRASERVER_INSTANCE_PREFIX_LIST,
 )
 from pcluster.launch_template_utils import _LaunchTemplateBuilder
@@ -97,6 +98,7 @@ def get_common_user_data_env(node: Union[HeadNode, SlurmQueue, LoginNodesPool], 
         "ParallelClusterVersion": COOKBOOK_PACKAGES_VERSIONS["parallelcluster"],
         "CookbookVersion": COOKBOOK_PACKAGES_VERSIONS["cookbook"],
         "ChefVersion": COOKBOOK_PACKAGES_VERSIONS["chef"],
+        "PclusterTmpDir": PCLUSTER_TMP_DIR,
     }
 
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -76,6 +76,7 @@ from pcluster.constants import (
     P6E_GB200,
     PCLUSTER_DYNAMODB_PREFIX,
     PCLUSTER_S3_ARTIFACTS_DICT,
+    PCLUSTER_TMP_DIR,
     SLURM_PORTS_RANGE,
 )
 from pcluster.models.s3_bucket import S3Bucket
@@ -1430,29 +1431,20 @@ class ClusterCdkStack:
             },
             "deployConfigFiles": {
                 "files": {
-                    # A nosec comment is appended to the following line in order to disable the B108 check.
-                    # The file is needed by the product
-                    # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
-                    "/tmp/dna.json": {  # nosec B108
+                    f"{PCLUSTER_TMP_DIR}/dna.json": {
                         "content": dna_json,
                         "mode": "000644",
                         "owner": "root",
                         "group": "root",
                         "encoding": "plain",
                     },
-                    # A nosec comment is appended to the following line in order to disable the B108 check.
-                    # The file is needed by the product
-                    # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
-                    "/tmp/extra.json": {  # nosec B108
+                    f"{PCLUSTER_TMP_DIR}/extra.json": {
                         "mode": "000644",
                         "owner": "root",
                         "group": "root",
                         "content": self.config.extra_chef_attributes,
                     },
-                    # A nosec comment is appended to the following line in order to disable the B108 check.
-                    # The file is needed by the product
-                    # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
-                    "/tmp/wait_condition_handle.txt": {  # nosec B108
+                    f"{PCLUSTER_TMP_DIR}/wait_condition_handle.txt": {
                         "mode": "000600",
                         "owner": "root",
                         "group": "root",
@@ -1464,8 +1456,9 @@ class ClusterCdkStack:
                     "touch": {"command": "touch /etc/chef/ohai/hints/ec2.json"},
                     "jq": {
                         "command": (
-                            'jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json '
-                            '|| ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )'
+                            f'jq -s ".[0] * .[1]" {PCLUSTER_TMP_DIR}/dna.json '
+                            f"{PCLUSTER_TMP_DIR}/extra.json > /etc/chef/dna.json "
+                            f'|| ( echo "jq not installed"; cp {PCLUSTER_TMP_DIR}/dna.json /etc/chef/dna.json )'
                         )
                     },
                 },

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1063,7 +1063,11 @@ def test_head_node_dna_json(mocker, test_datadir, config_file_name, expected_hea
     )
 
     generated_head_node_dna_json = json.loads(
-        _get_cfn_init_file_content(template=generated_template, resource="HeadNodeLaunchTemplate", file="/tmp/dna.json")
+        _get_cfn_init_file_content(
+            template=generated_template,
+            resource="HeadNodeLaunchTemplate",
+            file="/opt/parallelcluster/tmp/dna.json",
+        )
     )
     slurm_specific_settings = {
         "ddb_table": "{'Ref': 'DynamoDBTable'}",

--- a/cli/tests/pcluster/templates/test_login_nodes_stack.py
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack.py
@@ -65,9 +65,11 @@ def test_login_nodes_dna_json(
     expected_owner = "root:root"
     expected_permissions = "0644"
 
-    _assert_write_files_directive(login_node_user_data_template, "/tmp/dna.json", expected_owner, expected_permissions)
     _assert_write_files_directive(
-        login_node_user_data_template, "/tmp/extra.json", expected_owner, expected_permissions
+        login_node_user_data_template, "${PclusterTmpDir}/dna.json", expected_owner, expected_permissions
+    )
+    _assert_write_files_directive(
+        login_node_user_data_template, "${PclusterTmpDir}/extra.json", expected_owner, expected_permissions
     )
 
 

--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -222,7 +222,7 @@ def test_unmanaged_shared_storage_fsx(mocker, test_datadir, config_file_name):
         .get("AWS::CloudFormation::Init")
         .get("deployConfigFiles")
         .get("files")
-        .get("/tmp/dna.json")
+        .get("/opt/parallelcluster/tmp/dna.json")
         .get("content")
         .get("Fn::Join")[1][4]
     )


### PR DESCRIPTION
### Description of changes
* Some custom AMIs mount /tmp with noexec, and create-cluster wrote and consumed bootstrap files under /tmp. Move them under /opt/parallelcluster/tmp instead so create-cluster works on such AMIs.


### Tests
* `pcluster build-image` and `pcluster create-cluster` succeeded
* We will add a check in integration tests to use `noexec` on`/tmp` after Nvidia and efs-utils are moved to repo based installation
* The following tests have passed
```
test_hit_no_cluster_dns_mpi[af-south-1-c5.xlarge-rhel8-slurm-None-official] – dns.test_dns25m 44s
test_console_output_with_monitoring_disabled[ap-east-1-c5.xlarge-ubuntu2404-slurm-None-official] – cloudwatch_logging.test_compute_console_output_logging47m 8s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-best-effort] – schedulers.test_slurm43m 22s
test_cloudwatch_logging[ap-east-1-c5.xlarge-rocky9-slurm-None-official] – cloudwatch_logging.test_cloudwatch_logging30m 54s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-greedy-all-or-nothing] – schedulers.test_slurm43m 54s
test_slurm_protected_mode_on_cluster_create[ap-east-1-c5.xlarge-rocky8-slurm-None-official] – schedulers.test_slurm21m 32s
test_custom_action_error[ap-east-1-c5.xlarge-rhel8-slurm-None-official] – cloudwatch_logging.test_compute_console_output_logging28m 9s
test_expedited_requeue[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official] – schedulers.test_slurm30m 2s
test_slurm_config_update[ap-east-1-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm36m 27s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-all-or-nothing] – schedulers.test_slurm43m 22s
test_slurm_memory_based_scheduling[ap-east-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_slurm44m 31s
test_monitoring[ap-northeast-2-c5.xlarge-rocky9-slurm-None-official-True-True-True] – monitoring.test_monitoring57m 8s
test_slurm_custom_partitions[ap-northeast-2-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm29m 59s
test_create_disable_sudo_access_for_default_user[ap-northeast-2-c5.xlarge-rhel8-slurm-None-official] – create.test_create49m 10s
test_slurm_cli_commands[ap-northeast-2-c5.xlarge-ubuntu2404-slurm-None-official-False] – cli_commands.test_cli_commands55m 12s
test_cluster_creation_with_problematic_preinstall_script[ap-south-1-m6g.xlarge-rocky9-slurm-None-official] – create.test_create18m 26s
test_update_instance_list[ap-south-1-c5.xlarge-ubuntu2404-slurm-None-official] – update.test_update1h 18m 46s
test_slurm_accounting[ap-south-1-c5.xlarge-rhel8-slurm-None-official] – schedulers.test_slurm_accounting1h 8m 5s
test_slurm_accounting_external_dbd[ap-south-1-c5.xlarge-rocky8-slurm-None-official] – schedulers.test_slurm_accounting1h 15m 56s
test_ad_integration[ap-southeast-1-c5.xlarge-ubuntu2404-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 44m 29s
test_ad_integration[ap-southeast-1-c5.xlarge-rhel9-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 31m 56s
test_ad_integration[ap-southeast-1-c5.xlarge-alinux2023-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 30m 19s
test_ad_integration[ap-southeast-1-c5.xlarge-rhel9-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration1h 0m 3s
test_ad_integration[ap-southeast-1-c5.xlarge-rocky9-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 31m 28s
test_ad_integration[ap-southeast-1-c5.xlarge-alinux2023-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration59m 1s
test_ad_integration[ap-southeast-1-c5.xlarge-rocky9-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration1h 2m 6s
test_slurm_custom_config_parameters[ap-southeast-3-c5.xlarge-ubuntu2204-slurm-None-official] – schedulers.test_slurm22m 55s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-best-effort-scaling_behaviour_by_capacity1] – scaling.test_scaling46m 32s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-all-or-nothing-scaling_behaviour_by_capacity0] – scaling.test_scaling44m 22s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-greedy-all-or-nothing-scaling_behaviour_by_capacity2] – scaling.test_scaling44m 52s
test_proxy[ap-southeast-5-m6i.xlarge-ubuntu2404-slurm-None-official] – proxy.test_proxy32m 43s
test_cloudwatch_logging[ap-southeast-7-m6g.xlarge-alinux2023-slurm-None-official] – cloudwatch_logging.test_cloudwatch_logging34m 14s
test_efs_compute_az[ca-central-1-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_efs58m 48s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-greedy-all-or-nothing] – schedulers.test_slurm55m 2s
test_efs_same_az[ca-central-1-c5.xlarge-alinux2023-slurm-None-official] – storage.test_efs30m 59s
test_multiple_efs[ca-central-1-m6g.xlarge-rhel9-slurm-None-official] – storage.test_efs47m 46s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-best-effort] – schedulers.test_slurm56m 33s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-all-or-nothing] – schedulers.test_slurm56m 44s
test_update_slurm[eu-central-1-c5.xlarge-rocky8-None-official] – update.test_update59m 33s
test_slurm[eu-central-1-c5.xlarge-alinux2023-slurm-None-official-True] – schedulers.test_slurm1h 10m 25s
test_file_cache[eu-north-1-m6g.xlarge-rocky8-slurm-None-official] – storage.test_fsx_lustre33m 2s
test_fsx_lustre_dra[eu-north-1-m6g.xlarge-rocky9-slurm-None-official] – storage.test_fsx_lustre1h 9m 3s
test_fsx_lustre[eu-north-1-m6g.xlarge-rhel8-slurm-None-official] – storage.test_fsx_lustre39m 43s
test_slurm_rest_api[eu-north-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_slurm_rest_api51m 21s
test_create_imds_secured[eu-south-1-c5.xlarge-rocky9-slurm-None-official-False-users_allow_list1] – create.test_create30m 19s
test_create_imds_secured[eu-south-1-c5.xlarge-rocky9-slurm-None-official-True-users_allow_list0] – create.test_create20m 39s
test_existing_hosted_zone[eu-south-1-c5.xlarge-rocky8-slurm-None-official] – dns.test_dns27m 22s
test_pyxis[eu-west-1-c5.xlarge-alinux2023-slurm-None-official-False] – pyxis.test_pyxis1h 3m 47s
test_slurm_from_login_nodes_in_private_network[eu-west-1-c5.xlarge-rhel9-slurm-None-official] – schedulers.test_slurm54m 54s
test_custom_munge_key[eu-west-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_custom_munge_key45m 4s
test_multiple_fsx[eu-west-2-m6g.xlarge-rhel9-slurm-None-official] – storage.test_fsx_lustre1h 53m 53s
test_multi_az_fsx[eu-west-2-c5.xlarge-rhel8-slurm-None-official] – storage.test_fsx_lustre2h 27m 17s
test_fsx_lustre_dra[eu-west-2-c5.xlarge-rocky8-slurm-None-official] – storage.test_fsx_lustre1h 8m 38s
test_dynamic_file_systems_update[eu-west-2-c5.xlarge-rhel9-slurm-None-official] – update.test_update2h 12m 10s
test_fsx_lustre[eu-west-2-c5.xlarge-rhel9-slurm-None-official] – storage.test_fsx_lustre33m 5s
test_multiple_fsx[eu-west-2-c5.xlarge-alinux2023-slurm-None-official] – storage.test_fsx_lustre1h 47m 42s
test_dynamic_file_systems_update_data_loss[eu-west-2-c5.xlarge-rocky9-slurm-None-official] – update.test_update1h 8m 1s
test_multi_az_create_and_update[eu-west-2-c5.xlarge-rhel8-slurm-None-official] – update.test_update28m 38s
test_cluster_in_private_subnet[il-central-1-c5.xlarge-ubuntu2404-slurm-None-official] – networking.test_cluster_networking51m 11s
test_update_race_conditions[us-east-1-c5.xlarge-rhel9-slurm-None-official] – update.test_update_race_conditions1h 7m 40s
test_scontrol_reboot[us-east-1-c5.xlarge-rhel9-slurm-None-official] – schedulers.test_slurm38m 37s
test_dcv_configuration[us-east-1-g5g.2xlarge-ubuntu2404-slurm-use1-az6-official] – dcv.test_dcv54m 24s
test_update_rollback_failure[us-east-1-c5.xlarge-rhel9-slurm-None-official] – update.test_update_rollback_failure1h 12m 32s
test_head_node_stop[us-east-1-m5d.xlarge-ubuntu2204-slurm-use1-az4-official] – storage.test_ephemeral25m 18s
test_cluster_in_no_internet_subnet[us-east-1-m6g.xlarge-ubuntu2404-slurm-None-official] – networking.test_cluster_networking1h 7m 25s
test_slurm_scaling[us-east-2-c5.xlarge-rocky9-slurm-None-official] – schedulers.test_slurm1h 1m 15s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-40-None-HDD-None-1800-512-LZ4] – storage.test_fsx_lustre45m 50s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-SCRATCH_1-None-NEW-None-None-1200-1024-LZ4] – storage.test_fsx_lustre51m 22s
test_efs_access_point[us-east-2-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_efs41m 26s
test_ebs_multiple[us-east-2-c5.xlarge-alinux2023-slurm-None-official] – storage.test_ebs44m 50s
test_cluster_with_subnet_prioritization[us-east-2-t3.large-rhel8-slurm-None-official] – networking.test_cluster_networking27m 9s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-SCRATCH_2-None-NEW_CHANGED_DELETED-None-None-1200-1024-LZ4] – storage.test_fsx_lustre50m 43s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-50-NEW_CHANGED-None-None-1200-1024-None] – storage.test_fsx_lustre53m 56s
test_scontrol_reboot_ec2_health_checks[us-east-2-t3.medium-rocky9-slurm-None-official] – schedulers.test_slurm36m 0s
test_launch_template_overrides[us-east-2-c5n.18xlarge-alinux2023-slurm-use2-az1-official] – launch_template_overrides.test_launch_template_overrides22m 49s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-12-None-HDD-READ-6000-1024-LZ4] – storage.test_fsx_lustre39m 9s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_2-250-None-SSD-None-1200-2048-LZ4] – storage.test_fsx_lustre31m 39s
test_login_nodes_update[us-east-2-c5.xlarge-rocky8-slurm-None-official] – update.test_update1h 28m 37s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxOpenZfs-Efs] – storage.test_shared_home1h 50m 16s
test_clustermgtd_instance_id_matching[us-west-1-c5.xlarge-rocky9-slurm-None-official] – schedulers.test_slurm23m 40s
test_fsx_lustre_backup[us-west-1-m6g.xlarge-alinux2023-slurm-None-official] – storage.test_fsx_lustre1h 3m 23s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-Ebs-Efs] – storage.test_shared_home1h 15m 32s
test_slurm_overrides[us-west-1-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm17m 49s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxLustre-Efs] – storage.test_shared_home1h 25m 33s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxOntap-Efs] – storage.test_shared_home1h 47m 53s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-Efs-Efs] – storage.test_shared_home1h 14m 3s
test_existing_eip[us-west-1-c5.xlarge-rhel8-slurm-None-official] – networking.test_cluster_networking15m 39s
test_internal_efs[us-west-2-m6g.xlarge-ubuntu2404-slurm-None-official] – storage.test_internal_efs57m 24s
test_default_user_local_home[us-west-2-c5.xlarge-ubuntu2204-slurm-None-official] – users.test_default_user_home36m 40s
test_internal_efs[us-west-2-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_internal_efs
```

### References
* Corresponding CLI changes in userdata https://github.com/aws/aws-parallelcluster/pull/7481

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
