### PR TITLE
[Test] In 1-click template used to deploy storage, make the parameters `FsxLustreImportPath` and `FsxLustreExportPath` optional.

### DIFF
--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -123,6 +123,8 @@ Conditions:
     - !Equals [!Ref CreateEfs, 'true']
     - !Not [!Equals [!Ref SubnetThree, '']]
   CreateFsxLustre: !Equals [!Ref CreateFsxLustre, 'true']
+  HasFsxLustreImportPath: !Not [!Equals [!Ref FsxLustreImportPath, '']]
+  HasFsxLustreExportPath: !Not [!Equals [!Ref FsxLustreExportPath, '']]
   CreateFsxOntap: !Equals [!Ref CreateFsxOntap, 'true']
   CreateFsxOpenZfs: !Equals [!Ref CreateFsxOpenZfs, 'true']
   CreateFileCache: !Equals [!Ref CreateFileCache, 'true']
@@ -206,8 +208,8 @@ Resources:
       FileSystemTypeVersion: '2.15'
       LustreConfiguration:
         DeploymentType: PERSISTENT_1
-        ExportPath: !Ref FsxLustreExportPath
-        ImportPath: !Ref FsxLustreImportPath
+        ExportPath: !If [HasFsxLustreExportPath, !Ref FsxLustreExportPath, !Ref 'AWS::NoValue']
+        ImportPath: !If [HasFsxLustreImportPath, !Ref FsxLustreImportPath, !Ref 'AWS::NoValue']
         PerUnitStorageThroughput: 50
       SecurityGroupIds:
         - !Ref FsxLustreSecurityGroup


### PR DESCRIPTION
### Description of changes
In 1-click template used to deploy storage, make the parameters `FsxLustreImportPath` and `FsxLustreExportPath` optional.

Those params are always populated by our end12ned tests, but when used to do manual experiments, it's annoying to always specify import/export paths when unnecessary.

### Tests
Successfully deployed FSx Lustre omitting the two parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
