### PR TITLE
[IAM] Relax login nodes tag condition in public policies to prevent cluster creation/update failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ CHANGELOG
 - Fix login nodes not mounting `/opt/parallelcluster/shared` when EFS is used as the internal shared storage type.
 - Fix an issue where compute nodes are incorrectly replaced when launching a large number of nodes due to eventual consistency.
 - Fix an issue where starting the compute fleet may not reliably recover the cluster from protected mode.
+- Fix cluster creation and update failures on clusters with login nodes, caused by the IAM policy
+  requiring the `parallelcluster:cluster-name` tag to be the only tag instead of just being present.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cloudformation/custom_resource/cluster-1-click.yaml
+++ b/cloudformation/custom_resource/cluster-1-click.yaml
@@ -82,6 +82,18 @@ Resources:
             Networking:
               SubnetIds:
               - !GetAtt [ PclusterVpc, Outputs.PrivateSubnetId ]
+        LoginNodes:
+          Pools:
+            - Name: login
+              InstanceType: t3.small
+              Count: 1
+              Networking:
+                SubnetIds:
+                  - !GetAtt [ PclusterVpc, Outputs.PublicSubnetId ]
+              Iam:
+                AdditionalIamPolicies:
+                  - Policy: !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+              GracetimePeriod: 3
 
 Outputs:
   HeadNodeIp:

--- a/cloudformation/custom_resource/cluster-1-click.yaml
+++ b/cloudformation/custom_resource/cluster-1-click.yaml
@@ -78,14 +78,14 @@ Resources:
           - Name: queue0
             ComputeResources:
             - Name: queue0-cr0
-              InstanceType: t3.micro
+              InstanceType: t3.medium
             Networking:
               SubnetIds:
               - !GetAtt [ PclusterVpc, Outputs.PrivateSubnetId ]
         LoginNodes:
           Pools:
             - Name: login
-              InstanceType: t3.small
+              InstanceType: t3.medium
               Count: 1
               Networking:
                 SubnetIds:

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -599,7 +599,6 @@ Resources:
               - autoscaling:DescribeScalingActivities
               - autoscaling:PutLifecycleHook
               - autoscaling:UpdateAutoScalingGroup
-              - elasticloadbalancing:CreateListener
               - elasticloadbalancing:CreateTargetGroup
               - elasticloadbalancing:DescribeTags
               - elasticloadbalancing:DeleteListener
@@ -616,6 +615,14 @@ Resources:
                 aws:TagKeys: [ "parallelcluster:cluster-name" ]
             Effect: Allow
             Sid: LoginNodesFunctionalities
+          - Action:
+              - elasticloadbalancing:CreateListener
+            Resource: '*'
+            Condition:
+              "Null":
+                "aws:RequestTag/parallelcluster:cluster-name": "false"
+            Effect: Allow
+            Sid: LoginNodesFunctionalitiesCondition2
           - Action:
               - autoscaling:CreateAutoScalingGroup
               - autoscaling:DeleteTags


### PR DESCRIPTION
### Description of changes

#### Context
ParallelCluster relies on an IAM policy that has become too restrictive following a recent AWS service-side change to the CloudFormation ELBv2 Listener resource. When a cluster hits this issue Clusters that include login nodes fail to create or update when deployed through the ParallelCluster API or the CloudFormation Custom Resource.

### Changes
* Fix cluster creation and update failures on clusters with login nodes,  caused by the IAM policy requiring the `parallelcluster:cluster-name` tag to be the only tag instead of just being present.
* Add a login-nodes pool to the sample cluster deployed by the 1-click custom-resource template. This increases feature coverage so the 1-click path also provisions login nodes.

### Notes
This change is necessary and sufficient to resolve the impact described in https://github.com/aws/aws-parallelcluster/issues/7491. We'll consider a broader relaxation later for better future-proofing.

### Tests
* Manually validate deploying a cluster with login nodes through custom resource.
* SUCCESS
```
test-suites:
  pcluster_api:
    test_api.py::test_login_nodes:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
  custom_resource:
    # Create a cluster via the pcluster CFN custom resource
    test_cluster_custom_resource.py::test_cluster_create:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
