### PR TITLE
[Test][Patching] Recover rpmdb if needed to prevent failures.

### DIFF
--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -27,6 +27,16 @@ if [[ "${FLAVOUR}" != "minimal" && "${FLAVOUR}" != "full" ]]; then
     exit 1
 fi
 
+# Recover the rpmdb in case a previously killed process left it corrupted (stale
+# Berkeley DB locks on EL8/AL2 cause "rpmdb open failed" on every rpm/dnf/yum call).
+# Gated on a probe query: if the rpmdb is usable, recovery is skipped entirely.
+fix_rpmdb() {
+    sudo rpm -q rpm >/dev/null 2>&1 && return 0
+    echo "rpmdb is broken, rebuilding it"
+    sudo rm -f /var/lib/rpm/__db.*
+    sudo rpm --rebuilddb
+}
+
 echo "===== Starting system ${FLAVOUR} patching on $(hostname) ====="
 # Report the running kernel before patching. The kernel after the reboot is
 # reported separately once the node has rebooted (the reboot is mandatory to
@@ -35,6 +45,7 @@ echo "Kernel before patching: $(uname -r)"
 
 if command -v dnf >/dev/null 2>&1; then
     echo "Detected dnf package manager"
+    fix_rpmdb
     sudo dnf clean all
     sudo dnf makecache --refresh || true
     if [[ "${FLAVOUR}" == "minimal" ]]; then
@@ -46,6 +57,7 @@ if command -v dnf >/dev/null 2>&1; then
     fi
 elif command -v yum >/dev/null 2>&1; then
     echo "Detected yum package manager"
+    fix_rpmdb
     sudo yum clean all
     sudo yum makecache || true
     if [[ "${FLAVOUR}" == "minimal" ]]; then


### PR DESCRIPTION
### Description of changes
Recover rpmdb if needed to prevent transient failures in test patching

### Tests
SUCCESS

```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["rocky8"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
