### PR TITLE
Pin neuron-bench (aws-neuronx-tools) to 2.30 in trainium test

### DIFF
--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
@@ -6,7 +6,9 @@
 
 cat <<'EOF' >submission-script.sh
 #!/bin/bash
-set -xe
+# pipefail: without it, a neuron-bench crash is masked by tee's exit 0, so the
+# Slurm job reports COMPLETED with an empty output-ccl.txt instead of failing.
+set -xeo pipefail
 
 # FIXME remove this repo once packages are public available
 TEMPORARY_ARTIFACTS_BUCKET_PATH=s3://aws-parallelcluster-beta/neuron/

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
@@ -20,8 +20,10 @@ EOF
   apt-get install aws-neuronx-collectives=2.* -y
   info "Install Neuron Runtime"
   apt-get install aws-neuronx-runtime-lib=2.* -y
+  # neuron-bench in aws-neuronx-tools 2.31 segfaults in finalizeRuntimeTracing after the run;
+  # 2.30 is the last good line. Remove the pin once the upstream crash is fixed.
   info "Install Neuron Tools"
-  apt-get install aws-neuronx-tools=2.* -y
+  apt-get install aws-neuronx-tools=2.30.* -y
   info "Add neuron in PATH"
   export PATH=/opt/aws/neuron/bin:$PATH
   info "Install Python venv"
@@ -48,8 +50,10 @@ EOF
   yum install aws-neuronx-collectives-2.* -y
   info "Install Neuron Runtime"
   yum install aws-neuronx-runtime-lib-2.* -y
+  # neuron-bench in aws-neuronx-tools 2.31 segfaults in finalizeRuntimeTracing after the run;
+  # 2.30 is the last good line. Remove the pin once the upstream crash is fixed.
   info " Install Neuron Tools"
-  yum install aws-neuronx-tools-2.* -y
+  yum install aws-neuronx-tools-2.30.* -y
   info "Add neuron in PATH"
   export PATH=/opt/aws/neuron/bin:$PATH
   info "Create Python venv"


### PR DESCRIPTION
### Description of changes
**Note**: Revert this PR when the bug is fixed by aws-neuronx-tools.

test_trainium's CCL check started failing because output-ccl.txt came back empty while the Slurm job still reported COMPLETED.

Root cause: neuron-bench in aws-neuronx-tools 2.31.13.0 (Neuron SDK 2.31.0, released 2026-07-07) segfaults in finalizeRuntimeTracing right after "Benchmark finished", before the CCL summary is printed. The test script installs Neuron with a floating "=2.*", so CI silently moved onto 2.31 as soon as it shipped.

Verified with a single-node, ~12s repro (no Slurm/EFA needed): with only the tools version changed and everything else held constant, 2.31.13.0 segfaults (exit 134) while 2.30.10.0 (Neuron SDK 2.30.0, 2026-05-21) runs clean and prints CCL(1/50/99/100). This rules out the runtime-lib / collectives versions, cross-node CC, EFA, Slurm, and the kernel.

Changes:
- neuron-installation.sh: pin aws-neuronx-tools to 2.30.*
- neuron-ccl.sh: add `set -o pipefail` so a neuron-bench crash fails the job instead of producing an empty output-ccl.txt with a COMPLETED state, and so the framework dumps slurm-*.out on failure.

### Tests
* Full integration test re-run on trn1.32xlarge with the fix (aws-neuronx-tools 2.30.10) -> PASS.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
