### PR TITLE
[CfnResource] Add login nodes to 1-click sample cluster.

### DIFF
--- a/cloudformation/custom_resource/cluster-1-click.yaml
+++ b/cloudformation/custom_resource/cluster-1-click.yaml
@@ -82,6 +82,18 @@ Resources:
             Networking:
               SubnetIds:
               - !GetAtt [ PclusterVpc, Outputs.PrivateSubnetId ]
+        LoginNodes:
+          Pools:
+            - Name: login
+              InstanceType: t3.medium
+              Count: 1
+              Networking:
+                SubnetIds:
+                  - !GetAtt [ PclusterVpc, Outputs.PublicSubnetId ]
+              Iam:
+                AdditionalIamPolicies:
+                  - Policy: !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+              GracetimePeriod: 3
 
 Outputs:
   HeadNodeIp:


### PR DESCRIPTION
### Description of changes
Add login nodes to 1-click sample cluster.

Add a login-nodes pool to the sample cluster deployed by the 1-click custom-resource template. This increases feature coverage so the 1-click path also provisions login nodes.

### Tests
Test fails, as expected, due to known. issue https://github.com/aws/aws-parallelcluster/issues/7491

```
test-suites:
  custom_resource:
    test_cluster_custom_resource.py::test_cluster_1_click:
      dimensions:
        - regions: ["us-east-1"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
