### PR TITLE
[Test] Prevent intermittent failure in test_patching_cluster by executing pkg manager cache commands with -y option to prevent interactive mode.

### DIFF
--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -47,7 +47,7 @@ if command -v dnf >/dev/null 2>&1; then
     echo "Detected dnf package manager"
     fix_rpmdb
     sudo dnf clean all
-    sudo dnf makecache --refresh || true
+    sudo dnf makecache --refresh -y  || true
     if [[ "${FLAVOUR}" == "minimal" ]]; then
         # Apply only security errata. Kernel packages are allowed to be upgraded.
         sudo dnf upgrade --security -y
@@ -59,7 +59,7 @@ elif command -v yum >/dev/null 2>&1; then
     echo "Detected yum package manager"
     fix_rpmdb
     sudo yum clean all
-    sudo yum makecache || true
+    sudo yum makecache -y || true
     if [[ "${FLAVOUR}" == "minimal" ]]; then
         # update-minimal --security applies the smallest set of security errata.
         # Kernel bumps are allowed (no --exclude=kernel*).


### PR DESCRIPTION
### Description of changes
[Test] Prevent intermittent failure in test_patching_cluster by executing pkg manager cache commands with -y option to prevent interactive mode.

### Tests
SUCCESS

```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
      - instances:
        - g4dn.8xlarge
        oss:
        - rocky9
        - alinux2023
        regions:
        - eu-west-2
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
