### PR TITLE
[Test] In `test_patching_cluster`, apply required step to refresh lustre after kernel bump + prevent false positive on kernel module assertion

### DIFF
--- a/tests/integration-tests/tests/patching/test_patching.py
+++ b/tests/integration-tests/tests/patching/test_patching.py
@@ -22,7 +22,6 @@ from tests.common.osu_common import PRIVATE_OSES
 from tests.common.utils import (
     COMPUTE_NODE,
     GPU_JOB_SCRIPT,
-    HEAD_NODE,
     LOGIN_NODE,
     NODE_TYPES,
     reboot_head_node,
@@ -173,12 +172,9 @@ def test_patching_cluster(
     _run_gpu_workload(cluster, scheduler_commands_factory, use_login_node=False)
     _run_gpu_workload(cluster, scheduler_commands_factory, use_login_node=True)
 
-    # Snapshot and log the kernel modules loaded after patching, then assert (softly,
-    # so every node type is reported even if one fails) that every module loaded
-    # before patching is still loaded on the head, compute and login nodes.
-    kernel_modules_after = _collect_loaded_kernel_modules(
-        cluster, scheduler_commands_factory, trigger_head_node_mount=True
-    )
+    # Trigger lazily-loaded modules so that we can compare pre v/s post reboot kernel modules.
+    _trigger_lazy_kernel_modules(cluster, scheduler_commands_factory)
+    kernel_modules_after = _collect_loaded_kernel_modules(cluster, scheduler_commands_factory)
     logging.info("Kernel modules loaded after patching: %s", kernel_modules_after)
     with soft_assertions():
         for node_type in NODE_TYPES:
@@ -248,23 +244,26 @@ def _run_gpu_workload(cluster, scheduler_commands_factory, use_login_node):
     logging.info("GPU validation job %s submitted from the %s succeeded", job_id, source)
 
 
-def _collect_loaded_kernel_modules(cluster, scheduler_commands_factory, trigger_head_node_mount=False):
-    """Snapshot the loaded kernel modules per node type.
+def _trigger_lazy_kernel_modules(cluster, scheduler_commands_factory):
+    """Ensure on-demand kernel modules are loaded before the post-reboot snapshot.
 
-    After patching, the head node is rebooted in place, so we need to perform a read
-    operation on the FSx storage to trigger the loading of the Lustre kernel modules
-    before sampling. This is gated by trigger_head_node_mount, since it is only needed
-    for the post-reboot snapshot: before patching the mount has already been triggered,
-    and compute and login nodes perform the mount as part of their bootstrap and so
-    trigger it implicitly.
+    Some modules load lazily and are absent right after the reboot until something
+    exercises them, which would make the post-reboot snapshot miss them and fail the
+    before/after comparison.
     """
+    for node_type in NODE_TYPES:
+        executor = _node_executor(cluster, scheduler_commands_factory, node_type)
+        # Read the FSx for Lustre mountpoint to trigger the loading of lustre kernel module.
+        executor.run_remote_command(f"ls {FSX_LUSTRE_MOUNT_DIR}")
+        # Load the kernel TLS module directly
+        executor.run_remote_command("sudo modprobe tls")
+
+
+def _collect_loaded_kernel_modules(cluster, scheduler_commands_factory):
+    """Snapshot the loaded kernel modules per node type."""
     modules = {}
     for node_type in NODE_TYPES:
         executor = _node_executor(cluster, scheduler_commands_factory, node_type)
-        if node_type == HEAD_NODE and trigger_head_node_mount:
-            # Access the FSx for Lustre mountpoint to trigger its on-demand automount,
-            # so its client kernel modules get loaded before sampling.
-            executor.run_remote_command(f"ls {FSX_LUSTRE_MOUNT_DIR}")
         modules[node_type] = _loaded_kernel_modules(executor)
     return modules
 

--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -37,6 +37,27 @@ fix_rpmdb() {
     sudo rpm --rebuilddb
 }
 
+# On RHEL/Rocky the AMI's aws-fsx repo is pinned to the minor release it was built on, so a
+# patching kernel bump leaves no matching lustre kmod and FSx mounts fail after reboot..
+# Before the reboot, and targeting the kernel about to boot, re-point the repo
+# at the new minor and upgrade the client to that minor's newest build. 
+# If the upgrade no-ops (same version, different .ko) reinstall to swap the module, 
+# then fail if none resolves for the new kernel.
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
+refresh_lustre_client() {
+    [[ -f /etc/yum.repos.d/aws-fsx.repo ]] || return 0
+    local new_kernel
+    new_kernel=$(rpm -q kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort -V | tail -n1)
+    modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 && return 0
+    sudo sed -i -E "s#(/el/)[0-9]+(\.[0-9]+)?#\1$(. /etc/os-release && echo "${VERSION_ID}")#" /etc/yum.repos.d/aws-fsx.repo
+    sudo dnf clean metadata
+    sudo dnf upgrade -y kmod-lustre-client lustre-client
+    modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 \
+        || sudo dnf reinstall -y kmod-lustre-client lustre-client || true
+    modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 \
+        || { echo "ERROR: no FSx Lustre client available for kernel ${new_kernel}" >&2; exit 1; }
+}
+
 echo "===== Starting system ${FLAVOUR} patching on $(hostname) ====="
 # Report the running kernel before patching. The kernel after the reboot is
 # reported separately once the node has rebooted (the reboot is mandatory to
@@ -88,6 +109,12 @@ elif command -v apt-get >/dev/null 2>&1; then
 else
     echo "ERROR: no supported package manager found (dnf/yum/apt-get)" >&2
     exit 1
+fi
+
+# The pinned-repo kmod mismatch is a RHEL/Rocky-only problem; AL2023 and Ubuntu get their
+# Lustre client from non-pinned channels, so only run the fix-up there.
+if [[ "$(. /etc/os-release && echo "${ID}")" =~ ^(rhel|rocky)$ ]]; then
+    refresh_lustre_client
 fi
 
 echo "===== System ${FLAVOUR} patching completed on $(hostname) ====="


### PR DESCRIPTION
### Description of changes
In `test_patching_cluster`, apply required step to refresh lustre after kernel bump.
Also, prevent a false positive on kernel module assertion by triggering the loading of lazy loaded kernel module `tls`.

### Tests
* Manually verified that the commands are enough to refresh lustre kernel module after a breaking kernel bump (validated with bump from RHEL9.7 to RHEL9.8)
* Verified w/ FSx Lustre team that those steps are the expected ones to execute on kernel bump and there is no automated way" to trigger the rebuild of the lustre kernel modules against the new kernel (no dksm solution or similar).
* SUCCESS test with pcluster 3.15.0 so that the patching will trigegr the kernel bump.
```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["rhel9"]
          schedulers: ["slurm"]
          flags: ["patching:full"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
