### PR TITLE
[Test] Allowlist amazon-efs-utils.aws.com in proxy used by test `test_build_image_no_internet`

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -381,8 +381,8 @@ Resources:
 
               # Domain allowlist for isolated network:
               # OS package repos: Ubuntu, Rocky, Amazon Linux
-              # AWS services: awscli, EFA installer, S3 (global + virtual-hosted)
-              # Build dependencies: Rust crates (efs-utils), snap store (Firefox/DCV on Ubuntu)
+              # AWS services: awscli, EFA installer, efs-utils package repo + GPG key (CloudFront), S3 (global + virtual-hosted)
+              # Build dependencies: Rust crates, snap store (Firefox/DCV on Ubuntu)
               # RHEL repos: Red Hat Update Infrastructure (RHUI)
               # EPEL GPG key: CloudFront distribution
               # DCV GPG key: CloudFront distribution (NICE DCV)
@@ -414,6 +414,7 @@ Resources:
             \.s3\.amazonaws\.com
             ^s3\.amazonaws\.com
             ^efa-installer\.amazonaws\.com
+            ^amazon-efs-utils\.aws\.com
             ^index\.crates\.io
             ^static\.crates\.io
             ^api\.snapcraft\.io


### PR DESCRIPTION
### Description of changes
Allowlist amazon-efs-utils.aws.com in proxy used by test `test_build_image_no_internet` to allow the download of the efs-utils software and GPG key.

### Tests
This change unblocks the test

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - rocky8
        regions:
        - us-east-1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
