### PR TITLE
[Test] Fix export-image-logs race by validating it only when the build stack is retained

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -197,8 +197,15 @@ def test_build_image(
         _test_build_imds_settings(image, "required", region)
 
         _test_build_image_success(image, request.config.getoption("output_dir"))
-        _test_export_logs(s3_bucket_factory, image, region)
-        _test_export_logs(s3_bucket_factory, image, region, True)
+
+        # Only validate export-image-logs if the build did NOT complete successfully. On a successful
+        # build the build-image stack self-deletes, which races the export command and causes
+        # intermittent "stack does not exist" failures; a successful build also does not need its logs
+        # exported. If the build failed the stack is retained, so the export reliably has its stack.
+        if image.image_status != "BUILD_COMPLETE":
+            _test_export_logs(s3_bucket_factory, image, region)
+            _test_export_logs(s3_bucket_factory, image, region, True)
+
         _test_image_tag_and_volume(image)
         _test_list_image_log_streams(image)
         _test_get_image_log_events(image)
@@ -635,6 +642,7 @@ def test_build_image_wrong_pcluster_version(
     architecture,
     pcluster_ami_without_standard_naming,
     images_factory,
+    s3_bucket_factory,
     request,
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
@@ -656,6 +664,13 @@ def test_build_image_wrong_pcluster_version(
     image = images_factory(image_id, image_config, region)
 
     _test_build_image_failed(image, request.config.getoption("output_dir"))
+
+    # This build deterministically fails, so the build-image stack is retained (it does not
+    # self-delete). That makes it a reliable place to validate export-image-logs end to end, for
+    # both a custom bucket and the default pcluster bucket.
+    _test_export_logs(s3_bucket_factory, image, region)
+    _test_export_logs(s3_bucket_factory, image, region, True)
+
     log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
     log_data = " ".join(log["message"] for log in image.get_log_events(log_stream_name, limit=100)["events"])
     assert_that(log_data).matches(rf"AMI was created.+{wrong_version}.+is.+used.+{current_version}")

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -28,7 +28,7 @@ from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import minutes, seconds
 from troposphere import Template, iam
-from utils import generate_stack_name, get_arn_partition, get_gpu_count
+from utils import generate_stack_name, get_arn_partition, get_gpu_count, run_command
 
 from tests.common.assertions import (
     _assert_build_image_stack_deleted,
@@ -202,9 +202,15 @@ def test_build_image(
         # build the build-image stack self-deletes, which races the export command and causes
         # intermittent "stack does not exist" failures; a successful build also does not need its logs
         # exported. If the build failed the stack is retained, so the export reliably has its stack.
+        #
+        # On a successful build we still want evidence that the build logs reached CloudWatch, so we tail
+        # the image build log group instead: `aws logs tail` reads the log group directly and has none of
+        # export's dependencies (no S3 bucket, no build-image stack), so it cannot hit the deletion race.
         if image.image_status != "BUILD_COMPLETE":
             _test_export_logs(s3_bucket_factory, image, region)
             _test_export_logs(s3_bucket_factory, image, region, True)
+        else:
+            _test_tail_image_logs(image, region)
 
         _test_image_tag_and_volume(image)
         _test_list_image_log_streams(image)
@@ -386,6 +392,27 @@ def _set_s3_bucket_policy(bucket_name, partition, region):
         ],
     }
     boto3.client("s3").put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
+
+
+def _test_tail_image_logs(image, region):
+    """Assert the image build logs reached CloudWatch by tailing the image build log group.
+
+    Used on a successful build, where export-image-logs is skipped (the build-image stack self-deletes
+    and races the export). ``aws logs tail`` reads the log group directly -- no S3 bucket and no
+    dependency on the build-image stack -- so it gives race-free evidence that logs are being pushed.
+    The image build log group is ``/aws/imagebuilder/ParallelClusterImage-<image_id>``.
+    """
+    logging.info("Testing that image build logs reached CloudWatch via aws logs tail")
+    log_group_name = f"/aws/imagebuilder/ParallelClusterImage-{image.image_id}"
+    # `aws logs tail` defaults to only the last 10 minutes; an image build takes much longer, so widen
+    # the window with --since so an empty result means "no logs" rather than "no logs in the last 10 min".
+    result = run_command(
+        ["aws", "logs", "tail", log_group_name, "--since", "1h", "--region", region],
+        raise_on_error=True,
+    )
+    assert_that(result.stdout.strip()).described_as(
+        f"no log events found in {log_group_name}; build logs were not pushed to CloudWatch"
+    ).is_not_empty()
 
 
 def _test_export_logs(s3_bucket_factory, image, region, use_pcluster_bucket=False):


### PR DESCRIPTION
### Description of changes
On a successful build the image stack self-deletes, racing export-image-logs ("stack does not exist"). Skip the export check on success and run it on the deterministic-failure test (stack retained) plus guarded on failure in test_build_image.
In this way we mimics Cx behavior.


### Tests
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: {{ RHEL_OS_X86 }}
          schedulers: ["slurm"]
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_6_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: {{ NO_RHEL_OS_X86 }}
          schedulers: ["slurm"]
    test_createami.py::test_build_image_wrong_pcluster_version:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
