### PR TITLE
[Test] Reduce the risk of ICE for test test_build_image_no_internet  by using t3.medium for proxy instance and allowing to set the AZ for the proxy infra and build-image

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -31,6 +31,13 @@ Parameters:
       - "true"
       - "false"
 
+  PrivateSubnetAvailabilityZone:
+    Description: >-
+      AZ name (e.g. us-east-1c) for the private subnet. 
+      When empty, the private subnet falls back to the Region's "b" AZ.
+    Type: String
+    Default: ""
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -39,6 +46,7 @@ Metadata:
         Parameters:
           - VpcCidr
           - SSHCidr
+          - PrivateSubnetAvailabilityZone
       - Label:
           default: Permissions
         Parameters:
@@ -57,6 +65,7 @@ Conditions:
   IsClusterProxy: !Not [!Condition IsBuildImageProxy]
   # China regions (aws-cn partition) use cn.com.amazonaws prefix for VPC Interface endpoint service names
   IsChinaRegion: !Equals [!Ref "AWS::Partition", "aws-cn"]
+  HasPrivateSubnetAvailabilityZone: !Not [!Equals [!Ref PrivateSubnetAvailabilityZone, ""]]
 
 Resources:
 
@@ -118,7 +127,7 @@ Resources:
   PrivateSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZone: !Sub ${AWS::Region}b
+      AvailabilityZone: !If [HasPrivateSubnetAvailabilityZone, !Ref PrivateSubnetAvailabilityZone, !Sub "${AWS::Region}b"]
       CidrBlock: !Select [ 1, !Cidr [ !GetAtt Vpc.CidrBlock, 2, 8 ]]
       MapPublicIpOnLaunch: false
       VpcId: !Ref Vpc

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -22,7 +22,7 @@ from tests.common.schedulers_common import SlurmCommands
 
 
 @pytest.fixture(scope="class")
-def proxy_stack_factory(region, request, cfn_stacks_factory, instance):
+def proxy_stack_factory(region, request, cfn_stacks_factory):
     """
     Set up and tear down a CloudFormation stack to deploy a proxy environment.
 
@@ -62,7 +62,7 @@ def proxy_stack_factory(region, request, cfn_stacks_factory, instance):
                         "ParameterKey": "EnableBuildImageProxy",
                         "ParameterValue": "true" if enable_build_image_proxy else "false",
                     },
-                    {"ParameterKey": "InstanceType", "ParameterValue": instance},
+                    {"ParameterKey": "InstanceType", "ParameterValue": "t3.medium"},
                 ]
                 capabilities = ["CAPABILITY_IAM"]
                 tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -15,6 +15,7 @@ import boto3
 import pytest
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
+from conftest_networking import get_az_id_to_az_name_map
 from remote_command_executor import RemoteCommandExecutor
 from utils import generate_stack_name
 
@@ -22,7 +23,7 @@ from tests.common.schedulers_common import SlurmCommands
 
 
 @pytest.fixture(scope="class")
-def proxy_stack_factory(region, request, cfn_stacks_factory):
+def proxy_stack_factory(region, request, cfn_stacks_factory, az_id):
     """
     Set up and tear down a CloudFormation stack to deploy a proxy environment.
 
@@ -51,6 +52,11 @@ def proxy_stack_factory(region, request, cfn_stacks_factory):
                 )
             else:
                 stack_name = generate_stack_name("integ-tests-proxy", request.config.getoption("stackname_suffix"))
+                private_subnet_az = (
+                    get_az_id_to_az_name_map(region, request.config.getoption("credential")).get(az_id, "")
+                    if az_id
+                    else ""
+                )
                 stack_parameters = [
                     {"ParameterKey": "Keypair", "ParameterValue": request.config.getoption("key_name")},
                     {"ParameterKey": "VpcCidr", "ParameterValue": "10.0.0.0/16"},
@@ -63,6 +69,7 @@ def proxy_stack_factory(region, request, cfn_stacks_factory):
                         "ParameterValue": "true" if enable_build_image_proxy else "false",
                     },
                     {"ParameterKey": "InstanceType", "ParameterValue": "t3.medium"},
+                    {"ParameterKey": "PrivateSubnetAvailabilityZone", "ParameterValue": private_subnet_az},
                 ]
                 capabilities = ["CAPABILITY_IAM"]
                 tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]


### PR DESCRIPTION
### Description of changes
[Test] Reduce the risk of ICE for test test_build_image_no_internet  by using t3.medium for proxy instance and allowing to set the AZ for the proxy infra and build-image.

Notice that it is the private subnet of the proxy that drives the subnet used by the buiuld. That is the reaosn why we must be able to set the AZ used by the proxy.

### Tests
With this changes the test is now able to finalize the deployment of the proxy instance and build instance without ICEs and I was able to control the AZ to launch the instance in.

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - alinux2023
        regions:
        - use1-az1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
