### PR TITLE
Fix flaky failures during creating CFN stack from proxy.yaml

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -467,6 +467,10 @@ Resources:
             echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
             echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections
             apt-get $APT_RETRY install -y iptables-persistent
+
+            curl -X PUT -H "Content-Type:" \
+              --data-binary '{"Status":"SUCCESS","Reason":"Proxy ready","UniqueId":"Proxy","Data":"OK"}' \
+              "${ProxyReadyWaitConditionHandle}"
       Tags:
         - Key: Name
           Value: !Sub [ "Proxy-${StackIdSuffix}", {StackIdSuffix: !Select [1, !Split ['/', !Ref 'AWS::StackId']]}]
@@ -479,6 +483,19 @@ Resources:
       SourceDestCheck: false
       SubnetId: !Ref PublicSubnet
 
+  # Signaled upon the finish Proxy UserData. ProxyClient depends on this so it launches only after the
+  # proxy can actually carry network traffic.
+  ProxyReadyWaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+
+  ProxyReadyWaitCondition:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: Proxy
+    Properties:
+      Count: 1
+      Handle: !Ref ProxyReadyWaitConditionHandle
+      Timeout: 600
+
   # PROXY VERIFICATION CLIENT
   # In cluster mode: tests explicit proxy (http_proxy env var) by downloading from GitHub.
   # In build-image mode: tests transparent proxy (iptables REDIRECT) by curling allowlisted domains.
@@ -486,6 +503,7 @@ Resources:
     Type: AWS::EC2::Instance
     DependsOn:
       - Proxy
+      - ProxyReadyWaitCondition
     Properties:
       IamInstanceProfile: !Ref ProxyClientNodeInstanceProfile
       ImageId: resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id


### PR DESCRIPTION
### Description of changes
The proxy.yaml CFN stack creation sporadically failed with "WaitCondition timed out. Received 0 conditions when expecting 1" on ProxyVerificationWaitCondition.

Root cause is a startup race. `ProxyClient` runs in the private subnet and reaches the internet only through the Proxy instance, whose transparent-proxy plumbing is set up by its UserData. `ProxyClient` is created after `Proxy`, which CloudFormation satisfies as soon as the `Proxy` instance is running, not when its UserData finishes.

When the `Proxy`'s own "apt-get update" is slow (e.g. a slow security.ubuntu.com mirror), `ProxyClient` would fail connecting to network.

Console logs confirmed the race: in a failing run the Proxy did not add the iptables REDIRECT rules until 04:51:31, while the ProxyClient's apt window ran 04:50:09-04:50:42 and failed ~49s too early. On runs where the mirror is fast, the Proxy finishes first and verification passes.

Fix: add ProxyReadyWaitConditionHandle/ProxyReadyWaitCondition. The Proxy signals this handle as the final step of its UserData. This removes the race regardless of how long the Proxy's apt takes.

### Tests
* test_proxy has been passed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
