### PR TITLE
[Test] In test_patching_cluster execute the lustre refresh on Ubuntu the same way we do on RHEL/Rocky, to prevent failures on kernel bump.

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -445,7 +445,9 @@ def clusters_factory(request, region):
     """
     factory = ClustersFactory(delete_logs_on_success=request.config.getoption("delete_logs_on_success"))
 
-    def _cluster_factory(cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, **kwargs):
+    def _cluster_factory(
+        cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, bastion=None, **kwargs
+    ):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster_name = (
             request.config.getoption("cluster")
@@ -467,7 +469,7 @@ def clusters_factory(request, region):
         if not request.config.getoption("cluster"):
             cluster.creation_response = factory.create_cluster(cluster, request, **kwargs)
         # Run pcluster-diag after every successful cluster creation
-        _run_pcluster_diag(request, cluster)
+        _run_pcluster_diag(request, cluster, bastion=bastion)
         return cluster
 
     yield _cluster_factory
@@ -615,11 +617,15 @@ def _get_outdir_path(request, output_subdir, extension):
     )
 
 
-def _run_pcluster_diag(request, cluster):
-    """Run pcluster-diag on the cluster and save the report to the test output directory."""
+def _run_pcluster_diag(request, cluster, bastion=None):
+    """Run pcluster-diag on the cluster and save the report to the test output directory.
+
+    :param bastion: optional "user@host" SSH bastion used to reach head nodes that are not directly
+        reachable, e.g. clusters deployed in a private subnet behind a proxy.
+    """
     if not cluster.create_complete:
         return
-    rce = RemoteCommandExecutor(cluster)
+    rce = RemoteCommandExecutor(cluster, bastion=bastion)
     diag_result = rce.run_remote_command("sudo pcluster-diag run --yes", timeout=120)
     logging.info("pcluster-diag output for cluster %s:\n%s", cluster.name, diag_result.stdout)
     user = get_username_for_os(cluster.os)

--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -44,7 +44,7 @@ fix_rpmdb() {
 # If the upgrade no-ops (same version, different .ko) reinstall to swap the module, 
 # then fail if none resolves for the new kernel.
 # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
-refresh_lustre_client() {
+refresh_lustre_client_rhel() {
     [[ -f /etc/yum.repos.d/aws-fsx.repo ]] || return 0
     local new_kernel
     new_kernel=$(rpm -q kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort -V | tail -n1)
@@ -54,6 +54,24 @@ refresh_lustre_client() {
     sudo dnf upgrade -y kmod-lustre-client lustre-client
     modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 \
         || sudo dnf reinstall -y kmod-lustre-client lustre-client || true
+    modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 \
+        || { echo "ERROR: no FSx Lustre client available for kernel ${new_kernel}" >&2; exit 1; }
+}
+
+# On Ubuntu the FSx Lustre client kernel module ships as a per-kernel package
+# (lustre-client-modules-<uname-r>), so a patching kernel bump leaves no matching
+# module for the new kernel about to boot.
+# Before the reboot, install the target kernel's module package, mirroring the
+# cookbook's Ubuntu lustre setup.
+# See https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
+refresh_lustre_client_debian() {
+    [[ -f /etc/apt/sources.list.d/fsxlustreclientrepo.list ]] || return 0
+    local new_kernel
+    new_kernel=$(find /lib/modules -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -V | tail -n1)
+    modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 && return 0
+    sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        "lustre-client-modules-${new_kernel}" lustre-client-modules-aws || true
     modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 \
         || { echo "ERROR: no FSx Lustre client available for kernel ${new_kernel}" >&2; exit 1; }
 }
@@ -111,10 +129,15 @@ else
     exit 1
 fi
 
-# The pinned-repo kmod mismatch is a RHEL/Rocky-only problem; AL2023 and Ubuntu get their
-# Lustre client from non-pinned channels, so only run the fix-up there.
-if [[ "$(. /etc/os-release && echo "${ID}")" =~ ^(rhel|rocky)$ ]]; then
-    refresh_lustre_client
-fi
+# A patching kernel bump can leave the FSx Lustre client without a module matching
+# the kernel about to boot, which breaks FSx mounts after the reboot. Refresh the
+# client per-OS: RHEL/Rocky re-point the minor-pinned repo, Ubuntu installs the
+# per-kernel module package. AL2/AL2023 pull Lustre from non-pinned channels that
+# already track the kernel, so they need no fix-up.
+case "$(. /etc/os-release && echo "${ID}")" in
+    rhel | rocky) refresh_lustre_client_rhel ;;
+    ubuntu) refresh_lustre_client_debian ;;
+    *) : ;;
+esac
 
 echo "===== System ${FLAVOUR} patching completed on $(hostname) ====="

--- a/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
+++ b/tests/integration-tests/tests/patching/test_patching/test_patching_cluster/patch_node.sh
@@ -67,7 +67,8 @@ refresh_lustre_client_rhel() {
 refresh_lustre_client_debian() {
     [[ -f /etc/apt/sources.list.d/fsxlustreclientrepo.list ]] || return 0
     local new_kernel
-    new_kernel=$(find /lib/modules -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -V | tail -n1)
+    new_kernel=$(dpkg-query -W -f='${Package}\n' 'linux-image-*-aws' 2>/dev/null \
+        | sed 's/^linux-image-//' | grep -E '^[0-9]' | sort -V | tail -n1)
     modinfo -k "${new_kernel}" lustre >/dev/null 2>&1 && return 0
     sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -127,9 +127,11 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, clusters_factory, sc
     assert_that(proxy_public_ip).is_not_none().described_as("Proxy public IP should not be None")
 
     cluster_config = pcluster_config_reader(proxy_address=proxy_address, subnet_with_proxy=subnet_with_proxy)
-    cluster = clusters_factory(cluster_config)
 
+    # The head node sits in a private subnet reachable only through the proxy instance, which acts as an
+    # SSH bastion. Pass it to the factory so the post-creation pcluster-diag can reach the head node too.
     bastion = f"ubuntu@{proxy_public_ip}"
+    cluster = clusters_factory(cluster_config, bastion=bastion)
 
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion)
     slurm_commands = SlurmCommands(remote_command_executor)


### PR DESCRIPTION
### Description of changes
[Test] In test_patching_cluster execute the lustre refresh on Ubuntu the same way we do on RHEL/Rocky, to prevent failures on kernel bump.

### Tests
The test fails as expected now because the refresh finds not available Lustre client for the new kernel version

```
test-suites:
  patching:
    test_patching.py::test_patching_cluster:
      dimensions:
        - regions: [{{ g4dn_8xlarge_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.8xlarge"]
          oss: ["ubuntu2204","ubuntu2404"]
          flags: ["patching:minimal"]
          schedulers: ["slurm"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
