### PR TITLE
[Test]Use all private subnets for build_image compute queue in createami

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/pcluster.config.yaml
@@ -15,7 +15,9 @@ Scheduling:
     - Name: queue1
       Networking:
         SubnetIds:
+          {% for private_subnet_id in private_subnet_ids %}
           - {{ private_subnet_id }}
+          {% endfor %}
       ComputeResources:
         - Name: compute-resource1
           Instances:


### PR DESCRIPTION
Pin-to-single-AZ caused recurring InsufficientInstanceCapacity (ICE) failures.
And use flexible instance type



### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
