### PR TITLE
[integ-tests] Add post_cluster_setup to run a function after cluster creation

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -446,7 +446,12 @@ def clusters_factory(request, region):
     factory = ClustersFactory(delete_logs_on_success=request.config.getoption("delete_logs_on_success"))
 
     def _cluster_factory(
-        cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, bastion=None, **kwargs
+        cluster_config,
+        upper_case_cluster_name=False,
+        custom_cli_credentials=None,
+        bastion=None,
+        post_cluster_setup=None,
+        **kwargs,
     ):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster_name = (
@@ -468,6 +473,8 @@ def clusters_factory(request, region):
         )
         if not request.config.getoption("cluster"):
             cluster.creation_response = factory.create_cluster(cluster, request, **kwargs)
+        if cluster.create_complete and post_cluster_setup:
+            post_cluster_setup(cluster)
         # Run pcluster-diag after every successful cluster creation
         _run_pcluster_diag(request, cluster, bastion=bastion)
         return cluster

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -606,24 +606,26 @@ def test_ad_integration(  # noqa: C901
     vpc = directory_stack_outputs.get("VpcId")
     config_params.update(get_vpc_public_subnet(vpc))
 
-    cluster_config = pcluster_config_reader(**config_params)
-    cluster = clusters_factory(cluster_config)
-
     certificate_secret_arn = directory_stack_outputs.get("DomainCertificateSecretArn")
     certificate = boto3.client("secretsmanager").get_secret_value(SecretId=certificate_secret_arn)["SecretString"]
     with open(test_datadir / "certificate.crt", "w") as f:
         f.write(certificate)
 
+    def setup_directory_certificate(cluster):
+        remote_command_executor = RemoteCommandExecutor(cluster)
+        remote_command_executor.run_remote_command(
+            f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i systemctl restart sssd",
+            additional_files=[test_datadir / "certificate.crt"],
+        )
+        if directory_certificate_verification:
+            logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
+            time.sleep(600)
+            # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
+            #  We should look for other methods to let the SSSD agent use the new certificate more quickly
+
+    cluster_config = pcluster_config_reader(**config_params)
+    cluster = clusters_factory(cluster_config, post_cluster_setup=setup_directory_certificate)
     remote_command_executor = RemoteCommandExecutor(cluster)
-    remote_command_executor.run_remote_command(
-        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i systemctl restart sssd",
-        additional_files=[test_datadir / "certificate.crt"],
-    )
-    if directory_certificate_verification:
-        logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
-        time.sleep(600)
-        # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
-        #  We should look for other methods to let the SSSD agent use the new certificate more quickly
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     assert_that(NUM_USERS_TO_TEST).is_less_than_or_equal_to(NUM_USERS_TO_CREATE)
@@ -731,25 +733,25 @@ def test_ad_integration_on_login_nodes(
         directory_certificate_verification,
     )
     config_params.update(get_vpc_public_subnet(directory_stack_outputs.get("VpcId")))
-    cluster_config = pcluster_config_reader(**config_params)
-    cluster = clusters_factory(cluster_config)
-
     certificate_secret_arn = directory_stack_outputs.get("DomainCertificateSecretArn")
     certificate = boto3.client("secretsmanager").get_secret_value(SecretId=certificate_secret_arn)["SecretString"]
     with open(test_datadir / "certificate.crt", "w") as f:
         f.write(certificate)
 
-    # Publish compute node count metric every minute via cron job
-    remote_command_executor = RemoteCommandExecutor(cluster)
-    remote_command_executor.run_remote_command(
-        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i service sssd restart",
-        additional_files=[test_datadir / "certificate.crt"],
-    )
-    if directory_certificate_verification:
-        logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
-        time.sleep(600)
-        # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
-        #  We should look for other methods to let the SSSD agent use the new certificate more quickly
+    def setup_directory_certificate(cluster):
+        remote_command_executor = RemoteCommandExecutor(cluster)
+        remote_command_executor.run_remote_command(
+            f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i service sssd restart",
+            additional_files=[test_datadir / "certificate.crt"],
+        )
+        if directory_certificate_verification:
+            logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
+            time.sleep(600)
+            # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
+            #  We should look for other methods to let the SSSD agent use the new certificate more quickly
+
+    cluster_config = pcluster_config_reader(**config_params)
+    cluster = clusters_factory(cluster_config, post_cluster_setup=setup_directory_certificate)
 
     login_node_command_executor = RemoteCommandExecutor(cluster, use_login_node=True)
     scheduler_commands = scheduler_commands_factory(login_node_command_executor)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -18,6 +18,7 @@ import random
 import string
 import time
 import zipfile
+from functools import partial
 from pathlib import Path
 
 import boto3
@@ -100,6 +101,24 @@ def get_ad_config_param_vals(
         "ldap_tls_req_cert": "never" if directory_certificate_verification is False else "hard",
         "private_subnet_id": directory_stack_outputs.get("PrivateSubnetIds").split(",")[0],
     }
+
+
+def setup_directory_certificate(
+    cluster,
+    ldap_tls_ca_cert,
+    certificate_path,
+    directory_certificate_verification,
+):
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    remote_command_executor.run_remote_command(
+        f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i systemctl restart sssd",
+        additional_files=[certificate_path],
+    )
+    if directory_certificate_verification:
+        logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
+        time.sleep(600)
+        # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
+        #  We should look for other methods to let the SSSD agent use the new certificate more quickly
 
 
 def _add_file_to_zip(zip_file, path, arcname):
@@ -611,20 +630,16 @@ def test_ad_integration(  # noqa: C901
     with open(test_datadir / "certificate.crt", "w") as f:
         f.write(certificate)
 
-    def setup_directory_certificate(cluster):
-        remote_command_executor = RemoteCommandExecutor(cluster)
-        remote_command_executor.run_remote_command(
-            f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i systemctl restart sssd",
-            additional_files=[test_datadir / "certificate.crt"],
-        )
-        if directory_certificate_verification:
-            logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
-            time.sleep(600)
-            # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
-            #  We should look for other methods to let the SSSD agent use the new certificate more quickly
-
     cluster_config = pcluster_config_reader(**config_params)
-    cluster = clusters_factory(cluster_config, post_cluster_setup=setup_directory_certificate)
+    cluster = clusters_factory(
+        cluster_config,
+        post_cluster_setup=partial(
+            setup_directory_certificate,
+            ldap_tls_ca_cert=ldap_tls_ca_cert,
+            certificate_path=test_datadir / "certificate.crt",
+            directory_certificate_verification=directory_certificate_verification,
+        ),
+    )
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
@@ -738,20 +753,16 @@ def test_ad_integration_on_login_nodes(
     with open(test_datadir / "certificate.crt", "w") as f:
         f.write(certificate)
 
-    def setup_directory_certificate(cluster):
-        remote_command_executor = RemoteCommandExecutor(cluster)
-        remote_command_executor.run_remote_command(
-            f"sudo cp certificate.crt {ldap_tls_ca_cert} && sudo -i service sssd restart",
-            additional_files=[test_datadir / "certificate.crt"],
-        )
-        if directory_certificate_verification:
-            logging.info("Sleeping 10 minutes to wait for the SSSD agent use the certificate.")
-            time.sleep(600)
-            # TODO: we have to sleep for 10 minutes to wait for the SSSD agent use the newly placed certificate.
-            #  We should look for other methods to let the SSSD agent use the new certificate more quickly
-
     cluster_config = pcluster_config_reader(**config_params)
-    cluster = clusters_factory(cluster_config, post_cluster_setup=setup_directory_certificate)
+    cluster = clusters_factory(
+        cluster_config,
+        post_cluster_setup=partial(
+            setup_directory_certificate,
+            ldap_tls_ca_cert=ldap_tls_ca_cert,
+            certificate_path=test_datadir / "certificate.crt",
+            directory_certificate_verification=directory_certificate_verification,
+        ),
+    )
 
     login_node_command_executor = RemoteCommandExecutor(cluster, use_login_node=True)
     scheduler_commands = scheduler_commands_factory(login_node_command_executor)


### PR DESCRIPTION
### Description of changes
* This is useful for test_ad_integration with certificate verification enabled where we need to place the directory certificate and restart SSSD before running pcluster-diag

### Tests
* test_ad_integration has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
