### PR TITLE
[Test] Resolve how the test framework reaches the cluster head node to execute pcluster-diag.

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -102,6 +102,18 @@ class CfnVpcStack(CfnStack):
         if "CAPABILITY_NAMED_IAM" not in self.capabilities:
             self.capabilities.append("CAPABILITY_NAMED_IAM")
 
+    @property
+    def bastion(self):
+        """Return the SSH bastion for this VPC as "user@ip", or None if the VPC has no bastion.
+
+        The network template emits the BastionUser/BastionIP outputs only for VPCs that deploy a
+        bastion instance (e.g. to reach head nodes in private or no-internet subnets).
+        """
+        outputs = self.cfn_outputs
+        user = outputs.get("BastionUser")
+        ip = outputs.get("BastionIP")
+        return f"{user}@{ip}" if user and ip else None
+
     def set_az_override(self, az_override):
         """Sets the az_id to override the default AZ used to pick the subnets."""
         self.az_override = az_override

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -478,6 +478,14 @@ class Cluster:
         return instance.get("PublicIpAddress") if instance.get("PublicIpAddress") else instance.get("PrivateIpAddress")
 
     @property
+    def head_node_public_ip(self):
+        """Return the public ip of the cluster head node, or None if it does not have one."""
+        ec2 = boto3.client("ec2", region_name=self.region)
+        reservations = ec2.describe_instances(InstanceIds=[self.head_node_instance_id]).get("Reservations")
+        instance = reservations[0].get("Instances")[0]
+        return instance.get("PublicIpAddress")
+
+    @property
     def head_node_instance_id(self):
         """Return the given cluster's head node's instance ID."""
         return self.cfn_resources.get("HeadNode")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -25,6 +25,7 @@ from itertools import product
 from shutil import copyfile
 from traceback import format_tb
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 import boto3
 import cfn_tools
@@ -86,6 +87,7 @@ from utils import (
     get_architecture_supported_by_instance_type,
     get_arn_partition,
     get_instance_info,
+    get_instance_public_ip_by_private_ip,
     get_metadata,
     get_network_interfaces_count,
     get_similar_instance_types,
@@ -622,7 +624,8 @@ def _run_pcluster_diag(request, cluster):
     """Run pcluster-diag on the cluster and save the report to the test output directory."""
     if not cluster.create_complete:
         return
-    rce = RemoteCommandExecutor(cluster)
+    bastion = _get_bastion(request, cluster)
+    rce = RemoteCommandExecutor(cluster, bastion=bastion)
     diag_result = rce.run_remote_command("sudo pcluster-diag run --yes", timeout=120)
     logging.info("pcluster-diag output for cluster %s:\n%s", cluster.name, diag_result.stdout)
     remote_report_path = rce.run_remote_command(
@@ -633,6 +636,40 @@ def _run_pcluster_diag(request, cluster):
         report_dst = _get_outdir_path(request, "pcluster_diag_reports", "json")
         rce.get_remote_files(remote_report_path, report_dst)
         logging.info("pcluster-diag report saved to %s", report_dst)
+
+
+def _get_bastion(request, cluster):
+    """Return the SSH endpoint pcluster-diag must use to reach the cluster head node.
+
+    Returns None when the head node is directly reachable (it has a public IP), otherwise the
+    "user@ip" SSH bastion to tunnel through.
+    """
+    # 1. Head node directly reachable from the test runner.
+    if cluster.head_node_public_ip:
+        return None
+
+    # 2. Head node behind an HTTP proxy declared in the cluster config.
+    proxy_address = cluster.config.get("HeadNode", {}).get("Networking", {}).get("Proxy", {}).get("HttpProxyAddress")
+    proxy_private_ip = urlparse(proxy_address).hostname if proxy_address else None
+    if proxy_private_ip:
+        proxy_public_ip = get_instance_public_ip_by_private_ip(proxy_private_ip, cluster.region)
+        if proxy_public_ip:
+            # The proxy instance runs Ubuntu, so pcluster-diag tunnels through it as the "ubuntu" user.
+            return f"ubuntu@{proxy_public_ip}"
+
+    # 3. Head node in a private/no-internet subnet reachable through the VPC-stack bastion. Try the
+    #    endpoints VPC (used by no-internet tests) before the base VPC.
+    for fixture_name in ("vpc_stack_with_endpoints", "vpc_stack"):
+        if fixture_name in request.fixturenames:
+            bastion = getattr(request.getfixturevalue(fixture_name), "bastion", None)
+            if bastion:
+                return bastion
+
+    # 4. No reachable path to the head node.
+    raise RuntimeError(
+        f"Cannot run pcluster-diag on cluster {cluster.name}: the head node has no public IP, the cluster "
+        "config declares no HTTP proxy, and the test exposes no VPC-stack bastion to reach it."
+    )
 
 
 @pytest.fixture()

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -445,12 +445,7 @@ def clusters_factory(request, region):
     factory = ClustersFactory(delete_logs_on_success=request.config.getoption("delete_logs_on_success"))
 
     def _cluster_factory(
-        cluster_config,
-        upper_case_cluster_name=False,
-        custom_cli_credentials=None,
-        bastion=None,
-        post_cluster_setup=None,
-        **kwargs,
+        cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, post_cluster_setup=None, **kwargs
     ):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster_name = (
@@ -475,7 +470,7 @@ def clusters_factory(request, region):
         if cluster.create_complete and post_cluster_setup:
             post_cluster_setup(cluster)
         # Run pcluster-diag after every successful cluster creation
-        _run_pcluster_diag(request, cluster, bastion=bastion)
+        _run_pcluster_diag(request, cluster)
         return cluster
 
     yield _cluster_factory
@@ -623,15 +618,11 @@ def _get_outdir_path(request, output_subdir, extension):
     )
 
 
-def _run_pcluster_diag(request, cluster, bastion=None):
-    """Run pcluster-diag on the cluster and save the report to the test output directory.
-
-    :param bastion: optional "user@host" SSH bastion used to reach head nodes that are not directly
-        reachable, e.g. clusters deployed in a private subnet behind a proxy.
-    """
+def _run_pcluster_diag(request, cluster):
+    """Run pcluster-diag on the cluster and save the report to the test output directory."""
     if not cluster.create_complete:
         return
-    rce = RemoteCommandExecutor(cluster, bastion=bastion)
+    rce = RemoteCommandExecutor(cluster)
     diag_result = rce.run_remote_command("sudo pcluster-diag run --yes", timeout=120)
     logging.info("pcluster-diag output for cluster %s:\n%s", cluster.name, diag_result.stdout)
     remote_report_path = rce.run_remote_command(

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -127,11 +127,9 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, clusters_factory, sc
     assert_that(proxy_public_ip).is_not_none().described_as("Proxy public IP should not be None")
 
     cluster_config = pcluster_config_reader(proxy_address=proxy_address, subnet_with_proxy=subnet_with_proxy)
+    cluster = clusters_factory(cluster_config)
 
-    # The head node sits in a private subnet reachable only through the proxy instance, which acts as an
-    # SSH bastion. Pass it to the factory so the post-creation pcluster-diag can reach the head node too.
     bastion = f"ubuntu@{proxy_public_ip}"
-    cluster = clusters_factory(cluster_config, bastion=bastion)
 
     remote_command_executor = RemoteCommandExecutor(cluster=cluster, bastion=bastion)
     slurm_commands = SlurmCommands(remote_command_executor)

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -579,6 +579,21 @@ def get_username_for_os(os):
     return usernames.get(os)
 
 
+def get_instance_public_ip_by_private_ip(private_ip, region):
+    """Return the public IP of the running instance that has the given private IP.
+
+    Assumes a single instance matches the given private IP.
+    """
+    ec2 = boto3.client("ec2", region_name=region)
+    reservations = ec2.describe_instances(
+        Filters=[
+            {"Name": "private-ip-address", "Values": [private_ip]},
+            {"Name": "instance-state-name", "Values": ["running"]},
+        ]
+    ).get("Reservations")
+    return reservations[0].get("Instances")[0].get("PublicIpAddress")
+
+
 def add_keys_to_known_hosts(hostname, host_keys_file):
     """Add ssh key for a host to a known_hosts file, retrying if the host is not yet reachable."""
 


### PR DESCRIPTION
### Description of changes
Resolve how the test framework reaches the cluster head node to execute pcluster-diag.
       
It will connect directly when the head node has a public IP, else tunnel through the proxy declared
in the cluster config, else through the VPC-stack bastion, else fail with a clear reason.

### Tests
Succeeded, but test_cluster_in_no_internet_subnet, which failed for an unrelated reason. This is ok anyways because the goal of this PR was to unblock the execution of the tests

```
test-suites:
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
      - instances:
        - m6g.xlarge
        oss:
        - ubuntu2404
        regions:
        - us-east-1
        schedulers:
        - slurm
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel9
        regions:
        - il-central-1
        schedulers:
        - slurm
  proxy:
    test_proxy.py::test_proxy:
      dimensions:
      - instances:
        - m6i.xlarge
        oss:
        - rhel9
        regions:
        - ap-southeast-5
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
