### PR TITLE
[Test] Fix pcluster-diag report path for DefaultUserHome=Local

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -89,7 +89,6 @@ from utils import (
     get_metadata,
     get_network_interfaces_count,
     get_similar_instance_types,
-    get_username_for_os,
     get_vpc_snakecase_value,
     random_alphanumeric,
     to_pascal_case,
@@ -628,9 +627,8 @@ def _run_pcluster_diag(request, cluster, bastion=None):
     rce = RemoteCommandExecutor(cluster, bastion=bastion)
     diag_result = rce.run_remote_command("sudo pcluster-diag run --yes", timeout=120)
     logging.info("pcluster-diag output for cluster %s:\n%s", cluster.name, diag_result.stdout)
-    user = get_username_for_os(cluster.os)
     remote_report_path = rce.run_remote_command(
-        f"ls -t /home/{user}/pcluster-diag-output/pcluster-diag-report-*.json | head -1",
+        'ls -t "$HOME"/pcluster-diag-output/pcluster-diag-report-*.json | head -1',
         timeout=10,
     ).stdout.strip()
     if remote_report_path:


### PR DESCRIPTION
### Description of changes
`_run_pcluster_diag` hard-coded the report glob as `/home/<user>/pcluster-diag-output`, but with `DeploymentSettings/DefaultUserHome=Local` the cookbook runs `'usermod -d /local/home/<user>'`, so the report is written under `/local/home/<user>`.
 This made test_default_user_local_home fail (the ls error string was treated as a remote path by get_remote_files -> FileNotFoundError). Use "$HOME", which the --login shell resolves from `/etc/passwd`, so it is correct for both Shared and Local homes.


Without this the failure is `'/home/ec2-user/pcluster-diag-output/pcluster-diag-report-*.json': No such "
 'file or directory'`


### Tests
```
test-suites:
  storage:
    test_shared_home.py::test_shared_home:
      dimensions:
        - regions: [ "us-west-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ LUSTRE_OS_X86_0 }}]
          schedulers: [ "slurm" ]
  users:
    test_default_user_home.py::test_default_user_local_home:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel8
        regions:
        - us-west-2
        schedulers:
        - slurm
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
