### PR TITLE
Increase test_custom_image instance to 2xlarge and disable lustre client

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -776,7 +776,7 @@ test-suites:
     test_api.py::test_custom_image:
       dimensions:
         - regions: ["sa-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          instances: ["c5.2xlarge"]
           oss: [{{ OS_X86_4 }}]
     test_api.py::test_login_nodes:
       dimensions:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
@@ -5,3 +5,7 @@ Build:
   ParentImage: {{ parent_image }}
   UpdateOsPackages:
     Enabled: true
+  Installation:
+    LustreClient:
+      # Disable Lustre installation because these newer operating systems release new kernels more often. Lustre usually does not support the latest kernels
+      Enabled: False


### PR DESCRIPTION
### Description of changes
* Increase test_custom_image instance to 2xlarge and disable lustre client
* Fix failing integration test due to OOM from EFA installation

### Tests
* Ran test_custom_image on Rocky9, and ubuntu2404

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
