### PR TITLE
[integ-tests][health-checks] Run GPU health checks on Capacity Block for p-family instances

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -321,6 +321,10 @@ test-suites:
           instances: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0 }}]
           oss: [{{ OS_X86_5 }}]
           schedulers: ["slurm"]
+        - regions: [ "aps1-az2" ]  # do not move, unless capacity reservation is moved as well
+          instances: [ "p6-b200.48xlarge" ]
+          oss: ["rhel8", "rhel9"]
+          schedulers: [ "slurm" ]
   iam:
     test_iam.py::test_iam_policies:
       dimensions:

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from typing import Union
 
@@ -6,8 +7,21 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.common.assertions import assert_head_node_is_running
+from tests.common.utils import get_capacity_reservation_id
 
 HEALTH_CHECK_LOG_FILE = "/var/log/parallelcluster/slurm_health_check.log"
+
+# Instance families that are only available through Capacity Blocks.
+CAPACITY_BLOCK_INSTANCE_PREFIXES = ("p5", "p6")
+
+# Number of Capacity Block nodes the test asks for, the same count the efa and ultraserver/test_gb200
+# tests request for their p-family capacity-block queues.
+CAPACITY_BLOCK_MAX_QUEUE_SIZE = 2
+
+# The GPU health check is executed by the prolog and the DCGMI diagnostic is slow on the intricate GPU
+# topology of the p families; the health check manager itself allows it up to 600s. Wait generously for
+# the job so a slow-but-healthy check is not mistaken for a failure.
+GPU_HEALTH_CHECK_JOB_TIMEOUT_MINUTES = 30
 
 
 @dataclass
@@ -19,18 +33,38 @@ class NodeHealthStatus:
     latest_job: Union[int, None]
 
 
-@pytest.mark.usefixtures("instance", "scheduler")
+@pytest.mark.usefixtures("scheduler", "serial_execution_by_instance")
 def test_cluster_with_gpu_health_checks(
     region,
     os,
+    instance,
     architecture,
     pcluster_config_reader,
     s3_bucket_factory,
     clusters_factory,
     test_datadir,
     scheduler_commands_factory,
+    request,
 ):
-    """Test cluster with GPU Checks."""
+    """Test cluster with GPU Checks.
+
+    For instances that are only available through Capacity Blocks (p5/p6 families) the test runs a
+    reduced variant: a single queue with a single compute resource backed by a Capacity Block, and the
+    only assertion is that the GPU health check ran and succeeded on every node. Any other instance
+    type runs the full matrix of GPU/non-GPU compute resources with health checks enabled/disabled.
+    """
+    if instance.startswith(CAPACITY_BLOCK_INSTANCE_PREFIXES):
+        _test_gpu_health_checks_on_capacity_block(
+            region=region,
+            os=os,
+            instance=instance,
+            architecture=architecture,
+            pcluster_config_reader=pcluster_config_reader,
+            clusters_factory=clusters_factory,
+            scheduler_commands_factory=scheduler_commands_factory,
+            request=request,
+        )
+        return
 
     expected_nodes_health_statuses = {
         "queue-1": {
@@ -78,12 +112,9 @@ def test_cluster_with_gpu_health_checks(
             ),
         },
     }
-    if architecture == "x86_64":
-        non_gpu_instance = "c5.xlarge"
-    else:
-        non_gpu_instance = "m6g.xlarge"
-
-    cluster_config = pcluster_config_reader(non_gpu_instance=non_gpu_instance)
+    cluster_config = pcluster_config_reader(
+        non_gpu_instance=_non_gpu_instance(architecture), capacity_reservation_id=None
+    )
     cluster = clusters_factory(cluster_config)
     assert_head_node_is_running(region, cluster)
     remote_command_executor = RemoteCommandExecutor(cluster)
@@ -138,6 +169,88 @@ def test_cluster_with_gpu_health_checks(
     )
 
 
+def _test_gpu_health_checks_on_capacity_block(
+    region,
+    os,
+    instance,
+    architecture,
+    pcluster_config_reader,
+    clusters_factory,
+    scheduler_commands_factory,
+    request,
+):
+    """Assert the GPU health check runs and succeeds on the nodes of a Capacity Block.
+
+    Searches for an active Capacity Block for the given instance type and runs a single queue with a
+    single compute resource on it. A job is then submitted to all nodes and the health check log of
+    every node is checked for a successful GPU health check with no failures.
+    """
+    queue = "queue-1"
+    compute_resource = "compute-resource-1"
+    max_queue_size = CAPACITY_BLOCK_MAX_QUEUE_SIZE
+
+    capacity_reservations = get_capacity_reservation_id(request, instance, region, max_queue_size, os)
+    if not capacity_reservations:
+        message = f"Skipping the test as no Capacity Block for {instance} and os {os} was found in {region}"
+        logging.warning(message)
+        pytest.skip(message)
+    capacity_reservation_id = capacity_reservations[0].get("CapacityReservationId")
+    logging.info(
+        "Using Capacity Block %s for %s node(s) of instance %s", capacity_reservation_id, max_queue_size, instance
+    )
+
+    cluster_config = pcluster_config_reader(
+        non_gpu_instance=_non_gpu_instance(architecture),
+        capacity_reservation_id=capacity_reservation_id,
+        max_queue_size=max_queue_size,
+    )
+    suppress_validators = ["type:UltraserverCapacityBlockSizeValidator"]
+    # p6e-gb200 is not officially supported on rhel8/rocky8/rhel9, which this test does not care about:
+    # it only exercises the GPU health check.
+    if os.startswith(("rhel", "rocky")):
+        suppress_validators.append("type:InstanceTypeOSCompatibleValidator")
+    cluster = clusters_factory(cluster_config, suppress_validators=suppress_validators)
+    assert_head_node_is_running(region, cluster)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = scheduler_commands_factory(remote_command_executor)
+
+    # Submit a job to every node of the Capacity Block so that the prolog, and therefore the GPU health
+    # check, runs on all of them. The payload is deliberately trivial: what is being tested is the prolog,
+    # which Slurm runs to completion before the job's tasks start. On p-family GPU topologies the DCGMI
+    # diagnostic can take several minutes, so allow well beyond the 12 minute default when waiting.
+    job_id = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "srun sleep 1",
+            "partition": queue,
+            "nodes": max_queue_size,
+            "slots": max_queue_size,
+        }
+    )
+    slurm_commands.wait_job_completed(job_id, timeout=GPU_HEALTH_CHECK_JOB_TIMEOUT_MINUTES)
+    slurm_commands.assert_job_succeeded(job_id)
+
+    for compute_node_ip in cluster.get_compute_nodes_private_ip(queue, compute_resource, ["running"], max_queue_size):
+        logging.info("Checking the GPU health check succeeded on compute node %s", compute_node_ip)
+        health_check_log = _assert_file_content_in_compute_node(
+            HEALTH_CHECK_LOG_FILE,
+            compute_node_ip,
+            cluster,
+            # Both the health check script and its manager log as "... - LEVEL - JobID <id> - <message>",
+            # so anchor on the job id followed by a non-digit to avoid matching a job id with this one as
+            # a prefix (e.g. JobID 1234 when looking for JobID 123).
+            [
+                rf".*JobID {job_id}\D.*Running GPU Health Check with DCGMI.*",
+                rf".*JobID {job_id}\D.*The GPU Health Check succeeded.*",
+                rf".*JobID {job_id}\D.*HealthCheckManager finished with exit code '0'.*",
+            ],
+            log_content=True,
+        )
+        # Failures are logged at ERROR level, which precedes the job id field in every format written to
+        # this file, so no ERROR line for this job may appear. The prolog wrapper script labels the field
+        # "Job <id>" while the health check script and its manager use "JobID <id>", hence the optional ID.
+        _assert_patterns_in_content(health_check_log, [rf".*ERROR.*Job(?:ID)? {job_id}\D.*"], should_exist=False)
+
+
 def _test_failing_gpu_health_checks(
     slurm_commands,
     cluster,
@@ -186,14 +299,31 @@ def _test_failing_gpu_health_checks(
     assert_that(rollback_script_output).contains("Health check configuration restored")
 
 
-def _assert_file_content_in_compute_node(file_path, compute_node_ip, cluster, patterns, should_exist=True):
+def _non_gpu_instance(architecture):
+    return "c5.xlarge" if architecture == "x86_64" else "m6g.xlarge"
+
+
+def _assert_file_content_in_compute_node(
+    file_path, compute_node_ip, cluster, patterns, should_exist=True, log_content=False
+):
+    """Assert the patterns against the content of a remote file and return that content.
+
+    Set log_content to print the whole file, which facilitates troubleshooting since the assertions
+    only report which pattern did not match.
+    """
     compute_node_remote_command_executor = RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip)
     results_from_compute_node = compute_node_remote_command_executor.run_remote_command(
         command=f"cat {file_path}"
     ).stdout
+    if log_content:
+        logging.info("Content of %s on compute node %s:\n%s", file_path, compute_node_ip, results_from_compute_node)
+    _assert_patterns_in_content(results_from_compute_node, patterns, should_exist=should_exist)
+    return results_from_compute_node
 
+
+def _assert_patterns_in_content(content, patterns, should_exist=True):
     for pattern in patterns:
         if should_exist:
-            assert_that(results_from_compute_node).matches(pattern)
+            assert_that(content).matches(pattern)
         else:
-            assert_that(results_from_compute_node).does_not_match(pattern)
+            assert_that(content).does_not_match(pattern)

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
@@ -10,6 +10,50 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: slurm
+{% if capacity_reservation_id %}
+  # Capacity Block variant, used for p-family instances. The GPU health check runs from the prolog and
+  # on the intricate GPU topology of the p families a DCGMI diagnostic can run for several minutes (the
+  # health check manager allows it up to health_check_timeout, 600s by default). Prolog time counts
+  # towards BatchStartTimeout, so the cookbook defaults (BatchStartTimeout=180, MessageTimeout=60) would
+  # make slurmctld declare the batch job missing and requeue it while the check is still running, i.e.
+  # the "Prolog hung" / "Batch Job missing" failures described in
+  # https://github.com/aws/aws-parallelcluster/wiki/(3.6.0-%E2%80%90-latest)-Long-GPU-health-checks---Prolog-cause-%E2%80%9CProlog-hung%E2%80%9D-or-%E2%80%9CBatch-Job-missing%E2%80%9D-errors
+  # PrologFlags=Alloc,NoHold additionally moves the prolog to resource allocation time so it does not
+  # block task launch across every allocated node.
+  SlurmSettings:
+    CustomSlurmSettings:
+      - PrologFlags: "Alloc,NoHold"
+      # The wiki recommends more than 240s for complex GPU topologies.
+      - MessageTimeout: 300
+      # Comfortably above the 600s health check timeout, so a slow-but-healthy check is not requeued.
+      - BatchStartTimeout: 900
+  SlurmQueues:
+  - Name: queue-1
+    CapacityType: CAPACITY_BLOCK
+    CapacityReservationTarget:
+      CapacityReservationId: {{ capacity_reservation_id }}
+    ComputeResources:
+    - Name: compute-resource-1
+      # A single instance type (not a flexible Instances list) and static nodes spanning the whole
+      # Capacity Block, which is what CAPACITY_BLOCK requires.
+      InstanceType: {{ instance }}
+      MinCount: {{ max_queue_size }}
+      MaxCount: {{ max_queue_size }}
+      # Matches how the p-family capacity-block queues are configured in the efa and ultraserver/test_gb200
+      # tests, so the cluster shape here is the same one those instances are expected to run with.
+      DisableSimultaneousMultithreading: true
+      Efa:
+        Enabled: true
+      HealthChecks:
+        Gpu:
+          Enabled: true
+    Networking:
+      # Capacity Blocks come with their own capacity guarantees, so no placement group is requested.
+      PlacementGroup:
+        Enabled: false
+      SubnetIds:
+        - {{ private_subnet_id }}
+{% else %}
   SlurmQueues:
   - Name: queue-1
     HealthChecks:
@@ -71,3 +115,4 @@ Scheduling:
         {% for private_subnet_id in private_subnet_ids %}
         - {{ private_subnet_id }}
         {% endfor %}
+{% endif %}


### PR DESCRIPTION
### Description of changes

test_cluster_with_gpu_health_checks now takes a simplified path when the instance dimension is a p5/p6 family instance, which is only obtainable through an EC2 Capacity Block. It looks up an active Capacity Block for the instance type, sizes a single queue and compute resource to the block, runs one job and asserts the GPU health check ran and succeeded on every node. The non-GPU instances and the remaining compute resources are not exercised on this path, and no Capacity Block found means the test is skipped.

Following https://github.com/aws/aws-parallelcluster/wiki/(3.6.0-%E2%80%90-latest)-Long-GPU-health-checks---Prolog-cause-%E2%80%9CProlog-hung%E2%80%9D-or-%E2%80%9CBatch-Job-missing%E2%80%9D-errors for testing with p family instances

Behaviour for every other instance type is unchanged.


### Tests
* Ongoing for p6-b200 with capacity blocks

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
