### PR TITLE
Add LambdaFunctionTimeout parameter to pcluster api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
   removing the dependency on cfn-hup and cfn-init.
 - Move all ParallelCluster-managed bootstrap files off `/tmp` into a dedicated `/opt/parallelcluster/tmp`
   directory. Therefore, Image builds, cluster creations and updates work on custom AMIs that mount `/tmp` with `noexec`.
+- Add `LambdaFunctionTimeout` parameter to ParallelCluster API template which can be used if cluster operations timeout.
 
 **CHANGES**
 - The validator `ClusterNameValidator` now enforces cluster names to be limited to 40 characters when using `ExternalSlurmdbd`, 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -111,6 +111,15 @@ Parameters:
     Default: ''
     MaxLength: 10
 
+  LambdaFunctionTimeout:
+    Description: |
+      Timeout in seconds for the ParallelCluster Lambda function.
+      Increase this value if cluster operations time out during configuration validation.
+    Type: Number
+    Default: 30
+    MinValue: 30
+    MaxValue: 900
+
 Mappings:
   ParallelCluster:
     Constants:
@@ -122,7 +131,7 @@ Mappings:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 30
+    Timeout: !Ref LambdaFunctionTimeout
     Tags:
       'parallelcluster:version': !FindInMap [ParallelCluster, Constants, Version]
 
@@ -295,7 +304,7 @@ Resources:
       TracingConfig:
         Mode: Active
       MemorySize: 2048
-      Timeout: 30
+      Timeout: !Ref LambdaFunctionTimeout
       Role: !If [UseCustomParallelClusterFunctionRole, !Ref ParallelClusterFunctionRole, !GetAtt [ PclusterPolicies, Outputs.ParallelClusterLambdaRoleArn ]]
       Tags:
         - Key: 'parallelcluster:resource'

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -140,19 +140,19 @@ Globals:
       DefaultAuthorizer: AWS_IAM
       ResourcePolicy:
         CustomStatements:
-          Effect: 'Deny'
-          Action: 'execute-api:Invoke'
-          Resource: ['execute-api:/*/*/*']
-          Principal: '*'
-          Condition:
-            StringNotLike:
-              # This allows also creds assumed through sts for the ParallelClusterApiUserRole role
-              aws:PrincipalArn: !If
-                - CreateApiUserRoleCondition
-                - !Sub
-                  - arn:${AWS::Partition}:*::${AWS::AccountId}:*/${IAMRoleAndPolicyPrefix}PCAPIUserRole-${StackIdSuffix}*
-                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-                - '*'
+          - Effect: 'Deny'
+            Action: 'execute-api:Invoke'
+            Resource: ['execute-api:/*/*/*']
+            Principal: '*'
+            Condition:
+              StringNotLike:
+                # This allows also creds assumed through sts for the ParallelClusterApiUserRole role
+                aws:PrincipalArn: !If
+                  - CreateApiUserRoleCondition
+                  - !Sub
+                    - arn:${AWS::Partition}:*::${AWS::AccountId}:*/${IAMRoleAndPolicyPrefix}PCAPIUserRole-${StackIdSuffix}*
+                    - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+                  - '*'
     TracingEnabled: True
     EndpointConfiguration:
       Type: REGIONAL

--- a/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
@@ -90,6 +90,7 @@ def api_with_full_settings(
     params.append({"ParameterKey": "EnableIamAdminAccess", "ParameterValue": "true"})
     params.append({"ParameterKey": "FsxS3Buckets", "ParameterValue": "*"})
     params.append({"ParameterKey": "IAMRoleAndPolicyPrefix", "ParameterValue": "abcdefghij"})
+    params.append({"ParameterKey": "LambdaFunctionTimeout", "ParameterValue": "60"})
     params.append({"ParameterKey": "PermissionsBoundaryPolicy", "ParameterValue": api_permissions_boundary_policy_arn})
     params.append({"ParameterKey": "Region", "ParameterValue": region})
 
@@ -148,18 +149,21 @@ def test_api_infrastructure_with_full_parameters(region, api_with_full_settings)
     parallelcluster_api_url = api_with_full_settings.cfn_outputs["ParallelClusterApiInvokeUrl"]
     parallelcluster_user_role = api_with_full_settings.cfn_outputs["ParallelClusterApiUserRole"]
 
-    _assert_parallelcluster_lambda(lambda_name=parallelcluster_lambda_name, lambda_arn=parallelcluster_lambda_arn)
+    _assert_parallelcluster_lambda(
+        lambda_name=parallelcluster_lambda_name, lambda_arn=parallelcluster_lambda_arn, expected_timeout=60
+    )
     _assert_parallelcluster_api(api_id=parallelcluster_api_id, api_url=parallelcluster_api_url)
     _test_auth(region, parallelcluster_user_role, parallelcluster_api_url)
     _test_api_deletion(api_with_full_settings)
 
 
-def _assert_parallelcluster_lambda(lambda_name, lambda_arn):
+def _assert_parallelcluster_lambda(lambda_name, lambda_arn, expected_timeout=30):
     """Check that the ParallelCluster Lambda is correctly configured
 
     :param client: the Lambda client
     :param lambda_name: the name of the ParallelCluster Lambda
     :param lambda_arn: the ARN of the ParallelCluster Lambda
+    :param expected_timeout: the expected timeout of the Lambda function
     """
     logging.info("Checking Lambda configuration")
 
@@ -167,7 +171,7 @@ def _assert_parallelcluster_lambda(lambda_name, lambda_arn):
     lambda_resource = client.get_function(FunctionName=lambda_name)
     lambda_configuration = lambda_resource["Configuration"]
     assert_that(lambda_configuration["FunctionArn"]).is_equal_to(lambda_arn)
-    assert_that(lambda_configuration["Timeout"]).is_equal_to(30)
+    assert_that(lambda_configuration["Timeout"]).is_equal_to(expected_timeout)
     assert_that(lambda_configuration).contains("Layers")
     assert_that(len(lambda_configuration["Layers"])).is_equal_to(1)
     assert_that(lambda_configuration["Layers"][0]).contains("Arn")


### PR DESCRIPTION
### Description of changes
* Add LambdaFunctionTimeout parameter to pcluster api
* Provides workaround to lambda function timeouts during cluster validation phase

### Tests
* Ran `test_api_infrastructure` and checked timeout was being set to 60


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
