### PR TITLE
[Test] In CFN template to deploy proxy environment, anchor ProxyVerificationWaitCondition to Proxy to prevent stack creation failure due to timeout.

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -574,6 +574,8 @@ Resources:
 
   ProxyVerificationWaitCondition:
     Type: AWS::CloudFormation::WaitCondition
+    DependsOn:
+      - Proxy
     Properties:
       Count: 1
       Handle: !Ref ProxyVerificationWaitConditionHandle


### PR DESCRIPTION
### Description of changes
In CFN template to deploy proxy environment, anchor ProxyVerificationWaitCondition to Proxy to prevent stack creation failure due to timeout.

### Tests
The fix allows to unblock the test

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - ubuntu2404
        regions:
        - us-east-1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
