### PR TITLE
[Dependencies] Align Cinc version used in user data, to the one used in build-image: 19.3.14.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -158,7 +158,7 @@ MAX_EXISTING_STORAGE_COUNT = {"efs": 20, "fsx": 20, "raid": 0}
 COOKBOOK_PACKAGES_VERSIONS = {
     "parallelcluster": "3.16.0",
     "cookbook": "aws-parallelcluster-cookbook-3.16.0",
-    "chef": "18.4.12",
+    "chef": "19.3.14",
     "ami": "dev",
 }
 


### PR DESCRIPTION
### Description of changes
Align Cinc version used in user data, to the one used in build-image: 19.3.14.

### Tests
ONGOING

```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
