### PR TITLE
Cache getPolicy API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ CHANGELOG
 - Prevent a path traversal when downloading exported cluster and image logs, so a CloudWatch log stream name containing `../`
   segments can no longer cause files to be written outside the export directory.
 - Return a clear error instead of an unexpected fatal exception when the configured AWS profile does not exist.
+- Cache getPolicy API calls to reduce validation time of clusters when using the ParallelCluster API.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ CHANGELOG
 - Prevent a path traversal when downloading exported cluster and image logs, so a CloudWatch log stream name containing `../`
   segments can no longer cause files to be written outside the export directory.
 - Return a clear error instead of an unexpected fatal exception when the configured AWS profile does not exist.
-- Cache getPolicy API calls to reduce validation time of clusters when using the ParallelCluster API.
+- Cache getPolicy API calls to reduce validation time of clusters that have additional IAM policies.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cli/src/pcluster/aws/iam.py
+++ b/cli/src/pcluster/aws/iam.py
@@ -9,7 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.aws.common import AWSExceptionHandler, Boto3Client
+from pcluster.aws.common import AWSExceptionHandler, Boto3Client, Cache
 
 
 class IamClient(Boto3Client):
@@ -18,6 +18,7 @@ class IamClient(Boto3Client):
     def __init__(self):
         super().__init__("iam")
 
+    @Cache.cached
     @AWSExceptionHandler.handle_client_exception
     def get_policy(self, iam_policy):
         """Get policy information."""


### PR DESCRIPTION
### Description of changes
* Cache getPolicy API
* Reduce the validation time for cluster creation and update when using the ParallelCluster API
* Prevents timeout during cluster creation and update caused when validating the cluster config

### Tests
* Created cluster with API that had multiple queues with the same set of 4 additional IAM policies
  * Without cacheing: 4*8 getPolicy calls which cause a timeout
  * With cache: 4 getPolicy calls - no timeout

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
