### PR TITLE
[integ-tests-framework] Only spin up Python workers in regions with tests

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -871,10 +871,7 @@ def _make_logging_dirs(base_dir):
 
 def _run_parallel(args):
     jobs = []
-    if args.regions:
-        enabled_regions = args.regions
-    else:
-        enabled_regions = get_all_regions(args.tests_config)
+    enabled_regions = get_all_regions(args.tests_config)
 
     # unmarshal az and collect unique regions
     unique_regions = set()


### PR DESCRIPTION
### Description of changes
This reduces the number of workers when running integration tests in only a few regions, therefore reduces CPU consumption and test framework initializing time.

`args.regions` is a historical parameter before we started using `develop.yaml`. When running in Jenkins, `args.regions` still passes in the whole list of regions. Therefore, prior to this commit, test framework was spinning up Python workers in all regions on Jenkins.

### Tests
* Tests are passing with less initialization time

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
