### PR TITLE
[Test] Stop running test_efa on p4d, and cover gdrcopy on p6-b200

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -285,10 +285,6 @@ test-suites:
           instances: ["c5n.18xlarge"]
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
-        - regions: [{{ p4d_24xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_OS_X86_2 }}]
-          instances: ["p4d.24xlarge"]
-          oss: [{{ OS_X86_2 }}]  # The capacity reservation cannot use RHEL operating system
-          schedulers: ["slurm"]
         - regions: [ "use2-az2" ]  # do not move, unless capacity reservation is moved as well
           instances: [ "p6-b200.48xlarge" ]
           oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9", "rhel8", "rhel9"]

--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -107,10 +107,6 @@ test-suites:
           instances: ["c5n.9xlarge"]
           oss: {{ NEW_OS }}
           schedulers: ["slurm"]
-        - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
-          instances: ["p4d.24xlarge"]
-          oss: {{ NEW_OS }}
-          schedulers: ["slurm"]
         - regions: ["us-east-1"]
           instances: ["c6gn.16xlarge"]
           oss: {{ NEW_OS }}

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -154,8 +154,8 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: [{{ p4d_24xlarge_CAPACITY_RESERVATION_2_INSTANCES_2_HOURS_YESPG_alinux2023 }}]
-          instances: ["p4d.24xlarge"]
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_OS_X86_0 }}]
+          instances: [ "c5n.18xlarge" ]
           oss: ["alinux2023"]
           schedulers: ["slurm"]
   iam:

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -154,7 +154,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_OS_X86_0 }}]
+        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_alinux2023 }}]
           instances: [ "c5n.18xlarge" ]
           oss: ["alinux2023"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -52,6 +52,9 @@ FABTESTS_BASIC_TESTS = ["rdm_tagged_bw", "rdm_tagged_pingpong"]
 
 FABTESTS_GDRCOPY_TESTS = ["runt"]
 
+# Instance types the gdrcopy tests (GPUDirect RDMA) are run on.
+FABTESTS_GDRCOPY_INSTANCES = ["p4d.24xlarge", "p6-b200.48xlarge"]
+
 
 def _try_reserve_head_node_instance(region, az_id, architecture, os):
     """Try to create a 1-hour capacity reservation for a head node instance in the given AZ.
@@ -238,7 +241,8 @@ def _execute_fabtests(remote_command_executor, test_datadir, instance):
     )
 
     logging.info("Running Fabtests")
-    test_cases = FABTESTS_BASIC_TESTS + FABTESTS_GDRCOPY_TESTS if instance == "p4d.24xlarge" else FABTESTS_BASIC_TESTS
+    gdr_supported = instance in FABTESTS_GDRCOPY_INSTANCES
+    test_cases = FABTESTS_BASIC_TESTS + FABTESTS_GDRCOPY_TESTS if gdr_supported else FABTESTS_BASIC_TESTS
 
     if "g6" in instance:
         test_cases = test_cases + ["not cuda"]
@@ -253,7 +257,7 @@ def _execute_fabtests(remote_command_executor, test_datadir, instance):
             "efa-enabled-st-efa-enabled-i1-1",
             "efa-enabled-st-efa-enabled-i1-2",
             ",".join(test_cases),
-            "enable-gdr" if instance == "p4d.24xlarge" else "skip-gdr",
+            "enable-gdr" if gdr_supported else "skip-gdr",
         ],
         timeout=60,
         pty=False,


### PR DESCRIPTION
### Description of changes
p4d capacity has become unobtainable in practice. On-demand running `test_efa` on p6-b200 covers the same ground. Drop the p4d dimension from `develop.yaml` and `new_os.yaml`.

The fabtests gdrcopy cases and `FI_EFA_USE_DEVICE_RDMA` were keyed off p4d alone, so p6-b200 was skipping the GPUDirect RDMA path entirely. Run them on both, p4d included, so the path still works when p4d is run by hand.

`released.yaml` is handled by cherry-picking `d6e0d6ea03f9dacc526cf0c39afd8b2d262e2c5c` from `integ-tests-3.15.1`, which had already switched that dimension to c5n.18xlarge for the same reason.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
