### PR TITLE
[integ-tests-framework] Fix tests triggered in other AWS partitions

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -879,6 +879,9 @@ def _run_parallel(args):
         unmarshalled_region = unmarshal_az_override(az)
         unique_regions.add(unmarshalled_region)
 
+    if args.regions:
+        unique_regions = unique_regions & set(args.regions)
+
     for region in unique_regions:
         p = multiprocessing.Process(target=_run_test_in_region, args=(region, args, OUT_DIR, LOGS_DIR))
         jobs.append(p)


### PR DESCRIPTION
### Description of changes
https://github.com/aws/aws-parallelcluster/pull/7538 changed the region list from `args.regions` to retrieving the regions from test definitions (e.g. develop.yaml) to avoid spinning up Python workers in all `args.regions` even if no tests are running in some regions. However, regions in the test definitions could be "too much" too, because it could contain tests in other partitions.

Therefore, this commit adds a intersection between `args.regions` (Jenkins supplies a partition-scoped args.regions list) (when running without Jenkins, args.regions is usually empty) and regions from test definitions (which limits to regions really used by tests).

### Tests
* Ran `develop.yaml` in commercial partition. The tests are running fine

### Reference
This is a bug fix of https://github.com/aws/aws-parallelcluster/pull/7538

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
