### PR TITLE
[integ-tests] Unmask tmp.mount when creating AMI with persistent `noexec` on `/tmp`

### DIFF
--- a/cloudformation/patching/ami-patching.yaml
+++ b/cloudformation/patching/ami-patching.yaml
@@ -259,6 +259,9 @@ Resources:
                   commands:
                     - |
                       set -euxo pipefail
+                      # Rocky 8 cloud images mask tmp.mount. Unmask it so the
+                      # fstab-generated mount unit can participate in the boot transaction.
+                      systemctl unmask tmp.mount
                       awk '
                       function add_option(options_list, option, item_count, i, items) {
                           item_count = split(options_list, items, ",")


### PR DESCRIPTION
### Description of changes
tmp.mount is masked on rocky 8 vanilla AMI. This triggers [a known issue](https://access.redhat.com/solutions/2074783). The solution follows the known issue

### Tests
* test_build_image passed on all OSes

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
