### PR TITLE
Fix cherry-pick workflow by ignoring merge commits

### DIFF
--- a/.github/workflows/cherry-pick-to-branch.yml
+++ b/.github/workflows/cherry-pick-to-branch.yml
@@ -30,7 +30,7 @@ jobs:
           # workflow_dispatch has no PR event payload, so fetch everything we need
           # about the PR from the API.
           PR_JSON=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
-            --json baseRefName,title,author,commits)
+            --json baseRefName,title,author)
 
           SOURCE_BRANCH=$(echo "${PR_JSON}" | jq -r '.baseRefName')
           PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title')
@@ -44,8 +44,17 @@ jobs:
             fi
           done
 
-          # Get all commit SHAs from the PR
-          COMMITS=$(echo "${PR_JSON}" | jq -r '.commits[].oid' | tr '\n' ' ')
+          # A PR can contain merges from its base branch. Those commits should not be cherry-picked.
+          # The types of commit are distinguished by the number of parents:
+          # 1 paranet = non-merge commits, 2 parents = merge commit
+          COMMITS=$(gh api --paginate \
+            "repos/${REPO}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            --jq '.[] | select((.parents | length) < 2) | .sha' | tr '\n' ' ')
+
+          if [ -z "${COMMITS// }" ]; then
+            echo "::error::PR #${PR_NUMBER} contains no non-merge commits to cherry-pick"
+            exit 1
+          fi
 
           echo "commits=${COMMITS}" >> "$GITHUB_OUTPUT"
           echo "source_branch=${SOURCE_BRANCH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description of changes
Ignore merge commits when collecting commits to cherry-pick.

For example, PR #7531 contained one change commit and one merge from develop. The workflow now cherry-picks only the change commit.

### Tests
* Tests will be done after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
