### PR TITLE
[integ-tests] Align test_build_image dimensions in released.yaml with develop.yaml

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -81,21 +81,13 @@ test-suites:
           oss: ["alinux2023"]
     test_createami.py::test_build_image:
       dimensions:
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rhel9 }} ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_3_HOURS_NOPG_rhel9 }} ]
           instances: [ "g4dn.2xlarge" ]
-          oss: ["rhel8", "rhel9"]
+          oss: {{ RHEL_OS_X86 }}
           schedulers: [ "slurm" ]
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_alinux2023 }} ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_10_INSTANCES_3_HOURS_NOPG_ubuntu2404 }} ]
           instances: [ "g4dn.2xlarge" ]
-          oss: ["alinux2023"]
-          schedulers: [ "slurm" ]
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_ubuntu2404 }} ]
-          instances: [ "g4dn.2xlarge" ]
-          oss: [ "ubuntu2404", "ubuntu2204" ]
-          schedulers: [ "slurm" ]
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_rocky9 }} ]
-          instances: [ "g4dn.2xlarge" ]
-          oss: [ "rocky8", "rocky9" ]
+          oss: {{ NO_RHEL_OS_X86 }}
           schedulers: [ "slurm" ]
     test_createami.py::test_build_image_custom_components:
       dimensions:


### PR DESCRIPTION
### Description of changes
Reason:
1. Easier for maintenance
2. Less likely of insufficient capacity because we are consolidating capacity reservation

### Tests
* Test with released.yaml successfully started.

### References
* This PR changes released.yaml, which was missed in https://github.com/aws/aws-parallelcluster/pull/7539

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
