### PR TITLE
[integ-tests] Remove test_trainium from develop.yaml

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -807,13 +807,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_0 }}]
           schedulers: ["slurm"]
-  trainium:
-    test_trainium.py::test_trainium:
-      dimensions:
-        - regions: [{{ trn1_32xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_UBUNTU2404 }}]
-          schedulers: ["slurm"]
-          oss: ["ubuntu2404"]
-          instances: ["trn1.32xlarge"]
   update:
     test_update.py::test_update_slurm:
       dimensions:


### PR DESCRIPTION
### Description of changes
* test_trainium doesn't exist in released.yaml. So only one removal is needed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
