### PR TITLE
[Test] Stabilize test_proxy

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -31,10 +31,10 @@ Parameters:
       - "true"
       - "false"
 
-  PrivateSubnetAvailabilityZone:
+  AvailabilityZone:
     Description: >-
-      AZ name (e.g. us-east-1c) for the private subnet. 
-      When empty, the private subnet falls back to the Region's "b" AZ.
+      AZ name (e.g. us-east-1c) for both the public and private subnets.
+      When empty, both subnets fall back to the Region's "a" AZ.
     Type: String
     Default: ""
 
@@ -46,7 +46,7 @@ Metadata:
         Parameters:
           - VpcCidr
           - SSHCidr
-          - PrivateSubnetAvailabilityZone
+          - AvailabilityZone
       - Label:
           default: Permissions
         Parameters:
@@ -65,7 +65,7 @@ Conditions:
   IsClusterProxy: !Not [!Condition IsBuildImageProxy]
   # China regions (aws-cn partition) use cn.com.amazonaws prefix for VPC Interface endpoint service names
   IsChinaRegion: !Equals [!Ref "AWS::Partition", "aws-cn"]
-  HasPrivateSubnetAvailabilityZone: !Not [!Equals [!Ref PrivateSubnetAvailabilityZone, ""]]
+  HasAvailabilityZone: !Not [!Equals [!Ref AvailabilityZone, ""]]
 
 Resources:
 
@@ -95,7 +95,7 @@ Resources:
   PublicSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZone: !Sub ${AWS::Region}a
+      AvailabilityZone: !If [HasAvailabilityZone, !Ref AvailabilityZone, !Sub "${AWS::Region}a"]
       CidrBlock: !Select [ 0, !Cidr [ !GetAtt Vpc.CidrBlock, 2, 8 ]]
       MapPublicIpOnLaunch: true
       VpcId: !Ref Vpc
@@ -127,7 +127,7 @@ Resources:
   PrivateSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZone: !If [HasPrivateSubnetAvailabilityZone, !Ref PrivateSubnetAvailabilityZone, !Sub "${AWS::Region}b"]
+      AvailabilityZone: !If [HasAvailabilityZone, !Ref AvailabilityZone, !Sub "${AWS::Region}a"]
       CidrBlock: !Select [ 1, !Cidr [ !GetAtt Vpc.CidrBlock, 2, 8 ]]
       MapPublicIpOnLaunch: false
       VpcId: !Ref Vpc
@@ -369,14 +369,14 @@ Resources:
             # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
             APT_RETRY="-o Acquire::Retries=5"
 
-            # Stop Ubuntu's boot-time apt/dpkg jobs so they can't hold the dpkg lock while we install packages. 
-            # Otherwise they race with this UserData and cause locking failures.
-            systemctl mask --now \
-              apt-daily.timer apt-daily-upgrade.timer \
-              apt-daily.service apt-daily-upgrade.service \
-              unattended-upgrades.service packagekit.service || true
+            # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
+            # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+            sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
+              /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 
-            # Finish any transaction interrupted by the masking above.
+            # Finish any transaction interrupted before we start installing.
             dpkg --configure -a
 
             # Enable IP forwarding — without this, the kernel drops packets routed from
@@ -579,14 +579,14 @@ Resources:
             # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
             APT_RETRY="-o Acquire::Retries=5"
 
-            # Stop Ubuntu's boot-time apt/dpkg jobs so they can't hold the dpkg lock while we install packages. 
-            # Otherwise they race with this UserData and cause locking failures.
-            systemctl mask --now \
-              apt-daily.timer apt-daily-upgrade.timer \
-              apt-daily.service apt-daily-upgrade.service \
-              unattended-upgrades.service packagekit.service || true
+            # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
+            # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+            sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
+              /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 
-            # Finish any transaction interrupted by the masking above.
+            # Finish any transaction interrupted before we start installing.
             dpkg --configure -a
 
             apt-get $APT_RETRY update -y

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -882,8 +882,8 @@ test-suites:
   proxy:
     test_proxy.py::test_proxy:
       dimensions:
-        - regions: ["ap-southeast-5"] # c5 instance type is not available in ap-southeast-5
-          instances: ["m6i.xlarge"]
+        - regions: [{{ c5_xlarge_CAPACITY_RESERVATION_4_INSTANCES_2_HOURS_NOPG_OS_X86_6 }}]
+          instances: ["c5.xlarge"]
           oss: [{{ OS_X86_6 }}]
           schedulers: ["slurm"]
   pyxis:

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -170,6 +170,7 @@ def _get_instance_type_parameters():  # noqa: C901
             # Get GPU instance details in batches of 100
             all_gpu_list = list(all_gpu_instances)
             gpu_instances = []
+            fractional_gpu_instances = set()
             paginator = ec2_client.get_paginator("describe_instance_types")
             # DescribeInstanceType API Limit of 100 instances
             batch_size = 100
@@ -178,6 +179,9 @@ def _get_instance_type_parameters():  # noqa: C901
                 gpu_instance_type_batch = all_gpu_list[i : i + batch_size]  # noqa: E203
                 for page in paginator.paginate(InstanceTypes=gpu_instance_type_batch):
                     for instance_type in page["InstanceTypes"]:
+                        if _is_fractional_gpu_instance_type(instance_type):
+                            fractional_gpu_instances.add(instance_type["InstanceType"])
+                            continue
                         if _is_nvidia_gpu_instance_type(instance_type):
                             if instance_type.get("GpuInfo").get("Gpus")[0].get(
                                 "Count"
@@ -193,9 +197,14 @@ def _get_instance_type_parameters():  # noqa: C901
                             else:
                                 gpu_instances.append(instance_type["InstanceType"])
 
-            logging.info(f"Selected GPU instance types: {gpu_instances}")
+            xlarge_instances -= fractional_gpu_instances
+
             xlarge_sorted = sorted(xlarge_instances)
             gpu_sorted = sorted(gpu_instances)
+
+            logging.info(f"Selected .xlarge instance types: {xlarge_sorted}")
+            logging.info(f"Selected GPU instance types: {gpu_sorted}")
+
             today_number = (date.today() - date(2020, 1, 1)).days
             for index, _ in enumerate(xlarge_sorted):
                 instance_type = xlarge_sorted[(today_number + index) % len(xlarge_sorted)]
@@ -231,6 +240,17 @@ def _is_nvidia_gpu_instance_type(instance_type):
     """
     gpu = next(iter((instance_type.get("GpuInfo") or {}).get("Gpus") or []), {})
     return gpu.get("Manufacturer") == "NVIDIA" and (gpu.get("Count") or 0) >= 1
+
+
+def _is_fractional_gpu_instance_type(instance_type):
+    """
+    Return True if the instance type exposes a fractional NVIDIA GPU (e.g. g6f, gr6f).
+
+    Fractional-GPU instances report an NVIDIA GPU in GpuInfo with a Count of 0 (a slice of a
+    physical GPU), unlike full-GPU instances which report a Count of 1 or more.
+    """
+    gpu = next(iter((instance_type.get("GpuInfo") or {}).get("Gpus") or []), {})
+    return gpu.get("Manufacturer") == "NVIDIA" and (gpu.get("Count") or 0) < 1
 
 
 def _is_current_instance_type_generation(excluded_instance_type_prefixes, instance_type):

--- a/tests/integration-tests/tests/proxy/test_proxy.py
+++ b/tests/integration-tests/tests/proxy/test_proxy.py
@@ -37,7 +37,7 @@ def proxy_stack_factory(region, request, cfn_stacks_factory, az_id):
     """
     proxy_stack_template_path = "../../cloudformation/proxy/proxy.yaml"
 
-    def _create_proxy_stack(enable_build_image_proxy=False):
+    def _create_proxy_stack(enable_build_image_proxy, instance_type):
         with open(proxy_stack_template_path) as proxy_stack_template:
             template_body = proxy_stack_template.read()
 
@@ -52,7 +52,7 @@ def proxy_stack_factory(region, request, cfn_stacks_factory, az_id):
                 )
             else:
                 stack_name = generate_stack_name("integ-tests-proxy", request.config.getoption("stackname_suffix"))
-                private_subnet_az = (
+                subnet_az = (
                     get_az_id_to_az_name_map(region, request.config.getoption("credential")).get(az_id, "")
                     if az_id
                     else ""
@@ -68,8 +68,8 @@ def proxy_stack_factory(region, request, cfn_stacks_factory, az_id):
                         "ParameterKey": "EnableBuildImageProxy",
                         "ParameterValue": "true" if enable_build_image_proxy else "false",
                     },
-                    {"ParameterKey": "InstanceType", "ParameterValue": "t3.medium"},
-                    {"ParameterKey": "PrivateSubnetAvailabilityZone", "ParameterValue": private_subnet_az},
+                    {"ParameterKey": "InstanceType", "ParameterValue": instance_type},
+                    {"ParameterKey": "AvailabilityZone", "ParameterValue": subnet_az},
                 ]
                 capabilities = ["CAPABILITY_IAM"]
                 tags = [{"Key": "parallelcluster:integ-tests-proxy-stack", "Value": "proxy"}]
@@ -88,8 +88,8 @@ def proxy_stack_factory(region, request, cfn_stacks_factory, az_id):
 
     stacks = []
 
-    def _factory(enable_build_image_proxy=False):
-        stack = _create_proxy_stack(enable_build_image_proxy)
+    def _factory(enable_build_image_proxy=False, instance_type="c5.xlarge"):
+        stack = _create_proxy_stack(enable_build_image_proxy, instance_type)
         stacks.append(stack)
         return stack
 
@@ -107,8 +107,8 @@ def get_instance_public_ip(instance_id, region):
     return instance.get("PublicIpAddress")
 
 
-@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
-def test_proxy(pcluster_config_reader, proxy_stack_factory, clusters_factory, scheduler_commands_factory):
+@pytest.mark.usefixtures("region", "os", "scheduler")
+def test_proxy(instance, pcluster_config_reader, proxy_stack_factory, clusters_factory, scheduler_commands_factory):
     """
     Test the creation and functionality of a Cluster using a proxy environment.
 
@@ -118,7 +118,7 @@ def test_proxy(pcluster_config_reader, proxy_stack_factory, clusters_factory, sc
     3. Submit a sleep job to the cluster and verify it completes successfully.
     4. Check Internet access by trying to access google.com
     """
-    proxy_stack = proxy_stack_factory()
+    proxy_stack = proxy_stack_factory(instance_type=instance)
     proxy_address = proxy_stack.cfn_outputs["ProxyAddress"]
     subnet_with_proxy = proxy_stack.cfn_outputs["PrivateSubnet"]
     proxy_instance_id = proxy_stack.cfn_resources.get("Proxy")

--- a/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
+++ b/tests/integration-tests/tests/proxy/test_proxy/test_proxy/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
           Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
-          MaxCount: 5
+          MaxCount: 1
       Networking:
         SubnetIds:
           - {{ subnet_with_proxy }}


### PR DESCRIPTION
### Description of changes
Stabilize test_proxy.
     1. use dynamic capacity reservation to reduce the risk of ICE.
     2. reduce the number of compute nodes to the strictly required ones.
     3. reduce the risk of dpkg locking failure by disabling boot-time apt jobs.

### Tests

SUCCESS

```
test-suites:
    proxy:
      test_proxy.py::test_proxy:
        dimensions:
          - regions: [{{ c5_xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_rhel9 }}]
            instances: ["c5.xlarge"]
            oss: ["rhel8", "rhel9"]
            schedulers: ["slurm"]
          - regions: [{{ c5_xlarge_CAPACITY_RESERVATION_20_INSTANCES_2_HOURS_NOPG_ubuntu2404 }}]
            instances: ["c5.xlarge"]
            oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
            schedulers: ["slurm"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
