### PR TITLE
Fix cluster creation failure when login nodes are used and cloudwatch is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ CHANGELOG
   Amazon FSx service limit.
 
 **BUG FIXES**
+- Fix cluster creation failure when login nodes are used and CloudWatch logging is disabled.
 - Fix sporadic S3 bucket creation failure (for buckets named `parallelcluster-*-v1-do-not-delete`) when multiple
   create-cluster commands run simultaneously in the same region.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -198,7 +198,7 @@ class Pool(Construct):
                     "hosted_zone": (str(self._cluster_hosted_zone.ref) if self._cluster_hosted_zone else ""),
                     "dcv_enabled": "login_node" if self._pool.has_dcv_enabled else "false",
                     "dcv_port": self._pool.dcv.port if self._pool.dcv else "NONE",
-                    "log_group_name": self._log_group.log_group_name,
+                    "log_group_name": self._log_group.log_group_name if self._config.is_cw_logging_enabled else "NONE",
                     "log_rotation_enabled": "true" if self._config.is_log_rotation_enabled else "false",
                     "pool_name": self._pool.name,
                     "node_type": "LoginNode",

--- a/cli/tests/pcluster/templates/test_login_nodes_stack.py
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack.py
@@ -116,19 +116,23 @@ def test_login_nodes_cw_logging_disabled(mocker):
         },
         "Scheduling": {
             "Scheduler": "slurm",
-            "SlurmQueues": [{
-                "Name": "queue1",
-                "ComputeResources": [{"Name": "cr1", "InstanceType": "c4.xlarge", "MinCount": 0, "MaxCount": 10}],
-                "Networking": {"SubnetIds": ["subnet-12345678"]},
-            }],
+            "SlurmQueues": [
+                {
+                    "Name": "queue1",
+                    "ComputeResources": [{"Name": "cr1", "InstanceType": "c4.xlarge", "MinCount": 0, "MaxCount": 10}],
+                    "Networking": {"SubnetIds": ["subnet-12345678"]},
+                }
+            ],
         },
         "LoginNodes": {
-            "Pools": [{
-                "Name": "login",
-                "InstanceType": "t3.micro",
-                "Count": 1,
-                "Networking": {"SubnetIds": ["subnet-12345678"]},
-            }]
+            "Pools": [
+                {
+                    "Name": "login",
+                    "InstanceType": "t3.micro",
+                    "Count": 1,
+                    "Networking": {"SubnetIds": ["subnet-12345678"]},
+                }
+            ]
         },
         "Monitoring": {"Logs": {"CloudWatch": {"Enabled": False}}},
     }

--- a/cli/tests/pcluster/templates/test_login_nodes_stack.py
+++ b/cli/tests/pcluster/templates/test_login_nodes_stack.py
@@ -99,3 +99,43 @@ def render_join(elem: dict):
         else:
             raise ValueError("Found unsupported item type while rendering Fn::Join")
     return sep.join(rendered_body)
+
+
+def test_login_nodes_cw_logging_disabled(mocker):
+    """Verify login nodes template renders when CloudWatch logging is disabled."""
+    mock_aws_api(mocker)
+    mock_bucket_object_utils(mocker)
+
+    input_yaml = {
+        "Region": "us-east-1",
+        "Image": {"Os": "alinux2023"},
+        "HeadNode": {
+            "InstanceType": "t3.micro",
+            "Networking": {"SubnetId": "subnet-12345678"},
+            "Ssh": {"KeyName": "ec2-key-name"},
+        },
+        "Scheduling": {
+            "Scheduler": "slurm",
+            "SlurmQueues": [{
+                "Name": "queue1",
+                "ComputeResources": [{"Name": "cr1", "InstanceType": "c4.xlarge", "MinCount": 0, "MaxCount": 10}],
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+            }],
+        },
+        "LoginNodes": {
+            "Pools": [{
+                "Name": "login",
+                "InstanceType": "t3.micro",
+                "Count": 1,
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+            }]
+        },
+        "Monitoring": {"Logs": {"CloudWatch": {"Enabled": False}}},
+    }
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+    # This would raise AttributeError: 'NoneType' object has no attribute 'log_group_name'
+    # if the guard in login_nodes_stack.py is missing.
+    CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )


### PR DESCRIPTION
### Description of changes
* Fix cluster creation error when login nodes are used and cloudwatch is disabled
* Before this fix the following error occured:
```
pcluster create-cluster --cluster-name test --cluster-configuration cluster-config.yaml
{
  "message": "'NoneType' object has no attribute 'log_group_name'"
}
```
* This adds the same guard already used for queues: https://github.com/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/queues_stack.py#L264-L266
* Unit test verifies that template can be rendered is cloudwatch is disabled but login nodes are used.

### Tests
* Test cluster creation passed
Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
