### PR TITLE
[Test] In the proxy template, allowlist EPEL mirrors dynamically to prevent failures in test_build_image_no_internet.

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -459,6 +459,17 @@ Resources:
             ^d1uj6qtbmh3dt5\.cloudfront\.net
             \.aws\.ce\.redhat\.com
             FILTER
+
+              # EPEL mirrors rotate per request and can't be pinned statically, so resolve
+              # the mirrorlist here and allowlist every host it returns.
+              for RELEASEVER in 8 9; do
+                for ARCH in x86_64 aarch64; do
+                  curl -s --retry 5 "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-$RELEASEVER&arch=$ARCH" \
+                    | awk -F/ '/^https?:/ {print $3}'
+                done
+              done | sort -u | while read -r EPEL_HOST; do
+                echo "^$(echo "$EPEL_HOST" | sed 's/\./\\./g')\$" >> /etc/tinyproxy/filter
+              done
             fi
 
             /etc/init.d/tinyproxy restart
@@ -595,6 +606,33 @@ Resources:
               echo "==> Testing HTTPS proxy (same as build instance uses via https_proxy env var)"
               https_proxy="http://${ProxyPrivateIp}:${ProxyPort}" curl -v -o /dev/null https://api.snapcraft.io/v2/snaps/info/core 2>&1 || exit 1
               echo "==> HTTPS transparent proxy test passed"
+
+              # Verify the proxy allowlisted every EPEL mirror the mirrorlist returns.
+              # Fail only on a proxy denial (allowlist gap), not on a mirror being down.
+              echo "==> Validating EPEL mirror allowlisting through the proxy"
+              PROXY="http://${ProxyPrivateIp}:${ProxyPort}"
+              DENIED=""
+              for RELEASEVER in 8 9; do
+                MIRRORS=$(https_proxy="$PROXY" http_proxy="$PROXY" curl -s --retry 5 \
+                  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-$RELEASEVER&arch=x86_64")
+                for URL in $MIRRORS; do
+                  case "$URL" in http*) ;; *) continue ;; esac
+                  BASE=$(echo "$URL" | sed 's#/*$#/#')
+                  RESP=$(https_proxy="$PROXY" http_proxy="$PROXY" curl -sS -v --retry 2 -o /dev/null "$BASE"repodata/repomd.xml 2>&1 || true)
+                  if echo "$RESP" | grep -qiE 'code 403 from proxy after CONNECT|has been filtered|Access denied'; then
+                    echo "==> DENIED by proxy (EPEL $RELEASEVER mirror not allowlisted): $URL"
+                    DENIED="$DENIED $URL"
+                  else
+                    echo "==> Allowed by proxy (EPEL $RELEASEVER): $URL"
+                  fi
+                done
+              done
+              if [ -n "$DENIED" ]; then
+                echo "==> ERROR: the proxy denied EPEL mirrors that should have been allowlisted:$DENIED"
+                exit 1
+              fi
+              echo "==> EPEL mirror allowlisting validated for all mirrors"
+
               echo "==> Signaling success"
               signal SUCCESS "Proxy verification passed"
             else

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -62,7 +62,7 @@ def _get_base_ami(region, os, architecture):
     Returns (base_ami, feature_flags) where feature_flags is a dict with keys:
       enable_nvidia, update_os_packages, enable_lustre_client.
     """
-    enable_nvidia = os not in ["ubuntu2404"]
+    enable_nvidia = True
     update_os_packages = os in ["alinux2023", "rocky9"]
     enable_lustre_client = True
 
@@ -102,7 +102,11 @@ def test_build_image_no_internet(
     request,
 ):
     """Test build image in a private subnet with no internet access, only VPC endpoints and a proxy for OS repos."""
-    base_ami, _ = _get_base_ami(region, os, architecture)
+    base_ami, feature_flags = _get_base_ami(region, os, architecture)
+    # Enable NVIDIA installation so the offline NVIDIA/imex install path is exercised through the
+    # proxy. It is disabled for the Deep Learning AMI parent, which already ships the driver (the
+    # nvidia_install recipe skips the whole stack when the driver is already present).
+    enable_nvidia = feature_flags["enable_nvidia"]
 
     # Create proxy stack with build-image mode enabled
     no_internet_proxy_stack = proxy_stack_factory(enable_build_image_proxy=True)
@@ -124,6 +128,7 @@ def test_build_image_no_internet(
         chef_cookbook=s3_artifacts["chef_cookbook"],
         node_package=s3_artifacts["node_package"],
         install_http_proxy_address=install_http_proxy_address,
+        enable_nvidia=str(enable_nvidia).lower(),
     )
 
     image = images_factory(image_id, image_config, region)

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
@@ -12,6 +12,9 @@ Build:
     Iam:
         AdditionalIamPolicies:
             - Policy: arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess
+    Installation:
+        NvidiaSoftware:
+            Enabled: {{ enable_nvidia }}
 
 DevSettings:
     TerminateInstanceOnFailure: True


### PR DESCRIPTION
### Description of changes

1. In the proxy template used by tests, allowlist EPEL mirrors dynamically to prevent failures in test_build_image_no_internet. This is what a user would do to support the build-image in proxied environments. The proxy configuration is also validated by the proxy client, which verifies that every mirror is allowlisted.
In this way the build instance can reach whichever EPEL mirror it is assigned.
2. in `test_build_image_no_internet `, enable Nvidia installation  for all OSs, except when DLAMI is used. In this way we can use this test to validate the nvidia installation.

### Tests
* SUCCESS manually deployed the proxy stack in personal account and validated that all the mirrors returned by the mirrorlist are now reachable.
* SUCCESS (verified that NVIDIA was enabled on all tests but the one using DLAMI)

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
        # RHEL family (rhel8, rhel9) -> Red Hat Enterprise Linux reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel8", "rhel9"]
        # Non-RHEL family (alinux2023, ubuntu2204, ubuntu2404, rocky8, rocky9) -> Linux/UNIX reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_5_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
