### PR TITLE
[build-image] Refresh apt index and fail the build if kernel packages are missing

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -140,7 +140,13 @@ phases:
                 [[ $OS =~ rocky ]] && yum versionlock rocky-release rocky-repos
                 [[ $OS =~ rhel ]] && yum versionlock redhat-release
               else
-                apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
+                # Refresh the package index first: the index inherited from the base AMI can still
+                # reference package versions already rotated out of the pool, which fails the fetch.
+                apt-get -y update
+                if ! apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r); then
+                  echo "ERROR: failed to install kernel packages for $(uname -r)"
+                  exit {{ FailExitCode }}
+                fi
                 apt-mark hold linux-aws linux-base linux-headers-aws linux-image-aws linux-modules-extra-aws
               fi
               echo "Kernel version is $(uname -a)"


### PR DESCRIPTION
### Description of changes
PinVersion installs linux-headers/linux-modules-extra for the running kernel but ignored the exit code of apt-get.

The apt index could be outdated:
```
  E: Failed to fetch .../wireless-regdb_2025.10.07-0ubuntu1~24.04.1_all.deb
     404  Not Found
  E: Unable to fetch some archives, maybe run apt-get update or try with
     --fix-missing?
  CmdExecution: ExitCode 0
```
`apt` aborted the transaction, so linux-modules-extra was never installed, the step reported success.

Changes, limited to Ubuntu:
- run `apt-get update` before the install
- check the install exit code and abort the build with a clear message

### Tests
* Not done yet

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
