### PR TITLE
[Test] Stabilize test_osu by confirming a failing collective before failing the test

### DIFF
--- a/tests/integration-tests/tests/common/data/osu/osu_collective_submit_intelmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_collective_submit_intelmpi.sh
@@ -4,6 +4,7 @@ set -e
 BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 NUM_OF_PROCESSES={{ num_of_processes }}
+REPETITIONS={{ repetitions }}
 
 module load intelmpi
 export I_MPI_DEBUG=10
@@ -21,4 +22,6 @@ env
 
 # Run collective benchmark. The collective operations are close to what a real application looks like.
 # -np total number of processes to run (all vCPUs * N compute nodes), divided by 2 if multithreading is disabled
-mpirun -bootstrap=slurm -np ${NUM_OF_PROCESSES} /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out
+for _ in $(seq ${REPETITIONS}); do
+  mpirun -bootstrap=slurm -np ${NUM_OF_PROCESSES} /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}
+done > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/common/data/osu/osu_collective_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_collective_submit_openmpi.sh
@@ -4,6 +4,7 @@ set -e
 BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 NUM_OF_PROCESSES={{ num_of_processes }}
+REPETITIONS={{ repetitions }}
 
 module load openmpi
 
@@ -11,4 +12,6 @@ env
 
 # Run collective benchmark. The collective operations are close to what a real application looks like.
 # -np total number of processes to run (all vCPUs * N compute nodes), divided by 2 if multithreading is disabled
-mpirun -np ${NUM_OF_PROCESSES} /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}  > /shared/${BENCHMARK_NAME}.out
+for _ in $(seq ${REPETITIONS}); do
+  mpirun -np ${NUM_OF_PROCESSES} /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}
+done > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/common/osu_common.py
+++ b/tests/integration-tests/tests/common/osu_common.py
@@ -53,6 +53,7 @@ def run_individual_osu_benchmark(  # noqa C901
     submission_script_template_path=None,
     rendered_template_path=None,
     timeout=None,
+    repetitions=1,
 ):
     """
     Run the given OSU benchmark.
@@ -71,6 +72,8 @@ def run_individual_osu_benchmark(  # noqa C901
     :param submission_script_template_path: string, override default path for source submission script template
     :param rendered_template_path: string, override destination path when rendering submission script template
     :param timeout: int, maximum number of minutes to wait for job to complete
+    :param repetitions: int, how many times to run the benchmark inside the same job. The caller reduces the
+                        repetitions to their median per packet size
     :return: string, stdout of the benchmark job
     """
     logging.info(f"Running OSU benchmark {OSU_BENCHMARK_VERSION}: {benchmark_name} for {mpi_version}")
@@ -94,6 +97,7 @@ def run_individual_osu_benchmark(  # noqa C901
         num_of_processes=slots,
         num_of_processes_per_node=slots_per_instance,
         network_interfaces_count=network_interfaces_count,
+        repetitions=repetitions,
     )
 
     def submit_job():

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -12,6 +12,7 @@
 import logging
 import re
 import statistics
+from operator import itemgetter
 
 import pytest
 from assertpy import assert_that
@@ -327,12 +328,35 @@ def _measurements_per_packet_size(benchmark_name, output):
     return by_size
 
 
+def _osu_result(benchmark_name, by_size, select):
+    """Shape the selected measurement of each packet size the way a single run reports it."""
+    if benchmark_name == "osu_barrier":
+        return str(select(by_size[None])) if by_size[None] else None
+    return [(packet_size, str(int(select(values)))) for packet_size, values in by_size.items()]
+
+
 def _reduce_osu_output(benchmark_name, output):
     """Parse the benchmark output, reducing repeated measurements of the same packet size to their median."""
     by_size = _measurements_per_packet_size(benchmark_name, output)
-    if benchmark_name == "osu_barrier":
-        return str(statistics.median(by_size[None])) if by_size[None] else None
-    return [(packet_size, str(int(statistics.median(values)))) for packet_size, values in by_size.items()]
+    return _osu_result(benchmark_name, by_size, statistics.median)
+
+
+def _push_osu_measurements(benchmark_name, output, instance, os, mpi_version, num_instances):
+    """Record every repetition, not only the median the verdict is taken on.
+
+    The spike that caused the re-measurement only exists in the repetition it happened in, so
+    recording just the median would drop the one signal a later investigation needs.
+    """
+    by_size = _measurements_per_packet_size(benchmark_name, output)
+    repetitions = {len(values) for values in by_size.values()}
+    count = next(iter(repetitions)) if len(repetitions) == 1 else 0
+    if count:
+        results = [_osu_result(benchmark_name, by_size, itemgetter(repetition)) for repetition in range(count)]
+    else:
+        # Nothing was measured, or the repetitions are ragged and cannot be told apart.
+        results = [_osu_result(benchmark_name, by_size, statistics.median)]
+    for result in results:
+        push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os, mpi_version, num_instances)
 
 
 def _warn_on_missing_repetitions(benchmark_name, output, expected):
@@ -364,7 +388,7 @@ def _check_osu_benchmarks_results(
     evaluation_output = ""
     result = _reduce_osu_output(benchmark_name, output)
     if report:
-        push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os, mpi_version, num_instances)
+        _push_osu_measurements(benchmark_name, output, instance, os, mpi_version, num_instances)
     baseline_file_path = test_datadir / "osu_benchmarks" / "results" / os / instance / mpi_version / benchmark_name
     if baseline_file_path.exists():
         with open(str(baseline_file_path), encoding="utf-8") as baseline_file:

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import re
+import statistics
 
 import pytest
 from assertpy import assert_that
@@ -29,6 +30,11 @@ from tests.common.utils import (
 
 # We collected OSU benchmarks results for these instance types
 OSU_BENCHMARKS_INSTANCES = ["c5n.18xlarge", "p5en.48xlarge", "p6-b200.48xlarge"]
+
+# Collectives have a sparse transient tail: on nodes that are otherwise healthy a single measurement
+# occasionally spikes by an order of magnitude at the small packet sizes and is clean again straight
+# after, so a persistent regression still fails while a one-off spike does not.
+CONFIRMATION_REPETITIONS = 2
 
 
 @pytest.mark.flaky(reruns=0)
@@ -204,7 +210,8 @@ def _test_osu_benchmarks_collective(
         # All to all benchmark has time complexity of O(n^2) where n is the number of instances.
         # We run it for small clusters.
         benchmark_names.append("osu_alltoall")
-    for benchmark_name in benchmark_names:
+
+    def measure(benchmark_name, repetitions=1):
         _, output = run_individual_osu_benchmark(
             mpi_version,
             benchmark_group,
@@ -216,12 +223,23 @@ def _test_osu_benchmarks_collective(
             slots_per_instance,
             network_interfaces_count,
             test_datadir,
-            timeout=24 + num_instances * 0.1,
+            repetitions=repetitions,
+            timeout=24 + repetitions * num_instances * 0.1,
         )
-        failure_mask = _check_osu_benchmarks_results(
-            test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output
+        return output
+
+    def check(benchmark_name, output, report=True):
+        return _check_osu_benchmarks_results(
+            test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output, report
         )
-        if _has_failure_cluster(failure_mask):
+
+    for benchmark_name in benchmark_names:
+        output = measure(benchmark_name)
+        if _has_failure_cluster(check(benchmark_name, output, report=False)):
+            logging.info(f"{mpi_version} - {benchmark_name} exceeded the baseline, measuring again to confirm")
+            output += measure(benchmark_name, repetitions=CONFIRMATION_REPETITIONS)
+            _warn_on_missing_repetitions(benchmark_name, output, 1 + CONFIRMATION_REPETITIONS)
+        if _has_failure_cluster(check(benchmark_name, output)):
             failed_benchmarks.append(f"{mpi_version}-{benchmark_name}")
 
     return failed_benchmarks
@@ -298,68 +316,101 @@ def _test_osu_benchmarks_multiple_bandwidth(
     assert_that(float(max_bandwidth)).is_greater_than(expected_bandwidth)
 
 
+def _measurements_per_packet_size(benchmark_name, output):
+    """Group the measurements found in the output by packet size, keeping every repetition."""
+    if benchmark_name == "osu_barrier":
+        # osu_barrier outputs only a single latency value without packet size
+        return {None: [float(match) for match in re.findall(r"^\s+(\d+\.\d+)\s*$", output, re.MULTILINE)]}
+    by_size = {}
+    for packet_size, value in re.findall(r"(\d+)\s+(\d+)\.", output):
+        by_size.setdefault(packet_size, []).append(int(value))
+    return by_size
+
+
+def _reduce_osu_output(benchmark_name, output):
+    """Parse the benchmark output, reducing repeated measurements of the same packet size to their median."""
+    by_size = _measurements_per_packet_size(benchmark_name, output)
+    if benchmark_name == "osu_barrier":
+        return str(statistics.median(by_size[None])) if by_size[None] else None
+    return [(packet_size, str(int(statistics.median(values)))) for packet_size, values in by_size.items()]
+
+
+def _warn_on_missing_repetitions(benchmark_name, output, expected):
+    """A missing repetition would silently weaken the median the verdict is taken on."""
+    counts = {len(values) for values in _measurements_per_packet_size(benchmark_name, output).values()}
+    if counts != {expected}:
+        logging.warning(
+            f"{benchmark_name} was expected to report {expected} measurements per packet size, got {sorted(counts)}"
+        )
+
+
 def _check_osu_benchmarks_results(
-    test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output
+    test_datadir, output_dir, os, instance, mpi_version, benchmark_name, num_instances, output, report=True
 ):
-    logging.info(output)
-    write_file(
-        dirname=f"{output_dir}/osu-results",
-        filename=f"{os}-{instance}-{mpi_version}-{benchmark_name}.out",
-        content=output,
-    )
+    """Evaluate the measurement against the baseline.
+
+    A benchmark that is measured again is evaluated twice, so report=False suppresses everything
+    but the verdict and only the output the verdict is finally taken from gets reported.
+    """
+    if report:
+        logging.info(output)
+        write_file(
+            dirname=f"{output_dir}/osu-results",
+            filename=f"{os}-{instance}-{mpi_version}-{benchmark_name}.out",
+            content=output,
+        )
     # Check avg latency for all packet sizes
     failure_mask = []
     evaluation_output = ""
-    if benchmark_name == "osu_barrier":
-        # osu_barrier outputs only a single latency value without packet size
-        match = re.search(r"^\s+(\d+\.\d+)\s*$", output, re.MULTILINE)
-        result = match.group(1)
-    else:
-        result = re.findall(r"(\d+)\s+(\d+)\.", output)
-    push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os, mpi_version, num_instances)
+    result = _reduce_osu_output(benchmark_name, output)
+    if report:
+        push_result_to_dynamodb(f"OSU_{benchmark_name}", result, instance, os, mpi_version, num_instances)
     baseline_file_path = test_datadir / "osu_benchmarks" / "results" / os / instance / mpi_version / benchmark_name
     if baseline_file_path.exists():
+        with open(str(baseline_file_path), encoding="utf-8") as baseline_file:
+            baseline = baseline_file.read()
         for packet_size, value in result:
-            with open(str(baseline_file_path), encoding="utf-8") as result:
-                previous_result_match = re.search(rf"{packet_size}\s+(\d+)\.", result.read())
-                previous_result = previous_result_match.group(1) if previous_result_match else None
+            previous_result_match = re.search(rf"{packet_size}\s+(\d+)\.", baseline)
+            previous_result = previous_result_match.group(1) if previous_result_match else None
 
-                if previous_result is None:
-                    logging.warning(f"Previous result for {benchmark_name} with packet size {packet_size} not found")
-                    continue
+            if previous_result is None:
+                logging.warning(f"Previous result for {benchmark_name} with packet size {packet_size} not found")
+                continue
 
-                if benchmark_name == "osu_bibw":
-                    # Invert logic because osu_bibw is in MB/s
-                    tolerated_value = float(previous_result) - (float(previous_result) * 0.2)
-                    is_failure = int(value) < tolerated_value
-                else:
-                    multiplier = 0.3 if benchmark_name == "osu_latency" else 0.2
-                    tolerated_value = float(previous_result) + max(float(previous_result) * multiplier, 10)
+            if benchmark_name == "osu_bibw":
+                # Invert logic because osu_bibw is in MB/s
+                tolerated_value = float(previous_result) - (float(previous_result) * 0.2)
+                is_failure = int(value) < tolerated_value
+            else:
+                multiplier = 0.3 if benchmark_name == "osu_latency" else 0.2
+                tolerated_value = float(previous_result) + max(float(previous_result) * multiplier, 10)
 
-                    is_failure = int(value) > tolerated_value
+                is_failure = int(value) > tolerated_value
 
-                percentage_diff = (float(value) - float(tolerated_value)) / float(tolerated_value) * 100
+            percentage_diff = (float(value) - float(tolerated_value)) / float(tolerated_value) * 100
 
-                outcome = "DEGRADATION" if is_failure else "IMPROVEMENT"
+            outcome = "DEGRADATION" if is_failure else "IMPROVEMENT"
 
-                message = (
-                    f"{outcome} : {mpi_version} - {benchmark_name} - packet size {packet_size}: "
-                    f"tolerated: {tolerated_value}, current: {value}, percentage_diff: {percentage_diff}%"
-                )
+            message = (
+                f"{outcome} : {mpi_version} - {benchmark_name} - packet size {packet_size}: "
+                f"tolerated: {tolerated_value}, current: {value}, percentage_diff: {percentage_diff}%"
+            )
 
-                evaluation_output += f"\n{message}"
+            evaluation_output += f"\n{message}"
 
-                failure_mask.append(is_failure)
+            failure_mask.append(is_failure)
 
+            if report:
                 if is_failure:
                     logging.error(message)
                 else:
                     logging.info(message)
-        write_file(
-            dirname=f"{output_dir}/osu-results",
-            filename=f"{os}-{instance}-{mpi_version}-{benchmark_name}-evaluation.out",
-            content=evaluation_output,
-        )
+        if report:
+            write_file(
+                dirname=f"{output_dir}/osu-results",
+                filename=f"{os}-{instance}-{mpi_version}-{benchmark_name}-evaluation.out",
+                content=evaluation_output,
+            )
 
     return failure_mask
 


### PR DESCRIPTION
### Description of changes
27% of v3.16.0 CI runs have at least one failing OSU benchmark, concentrated in the 32-node c5n.18xlarge collectives. It is not a performance regression: on 38 fresh 32-instance draws, the first collective in a job intermittently spikes by an order of magnitude at the small packet sizes while the median of that same sweep stays at ~1.0x baseline, and it is gone from the next sweep on. The trip repeated on the immediately following sweep only once in twelve.

Measure once, as before. Only when the check trips, measure that benchmark twice more inside a single job on the same nodes and take the verdict on the median per packet size. Per-draw failure rate goes from 11/16 to 1/16, and the one that remains genuinely reproduced. Detection is unaffected: a uniform 1.25x, 1.30x or 1.50x regression injected into real sweeps is still caught 13 of 13 times.

Every repetition is recorded in the results table, not just the median. The verdict uses the median, but the spike that triggered the re-measurement only exists in the repetition it happened in, and that is the signal a future investigation would need. A re-measured benchmark therefore contributes three rows instead of one, each in the shape a single run produces, so the historical report is unaffected in shape and the two extra points are the clean ones.

The extra time is paid only on runs that trip, so 73% of runs are unchanged and the p95 is 11.9 min, almost all of it alltoall.

### Tests
* Confirmed a re-measured benchmark pushes one row per repetition and a single measurement still pushes one, using the captured cluster output; ragged output falls back to a single median row rather than inventing repetitions.
* Replayed the gate over 40 back-to-back sweeps on one unchanged cluster, and over 38 fresh 32-instance draws (301 sweeps). For intelmpi `osu_allreduce` the per-draw failure rate goes from 11/16 to 1/16; the one that remains reproduced on later sweeps. Injected uniform 1.25x, 1.30x and 1.50x regressions are still caught 13 of 13 times.
* Ongoing: a re-run of full `test_osu`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


