### PR TITLE
[build-image] Don't fail the build if kernel packages are missing

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -143,10 +143,7 @@ phases:
                 # Refresh the package index first: the index inherited from the base AMI can still
                 # reference package versions already rotated out of the pool, which fails the fetch.
                 apt-get -y update
-                if ! apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r); then
-                  echo "ERROR: failed to install kernel packages for $(uname -r)"
-                  exit {{ FailExitCode }}
-                fi
+                apt-get -y install linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
                 apt-mark hold linux-aws linux-base linux-headers-aws linux-image-aws linux-modules-extra-aws
               fi
               echo "Kernel version is $(uname -a)"


### PR DESCRIPTION
### Description of changes
This commit partially revert https://github.com/aws/aws-parallelcluster/pull/7563, while keeping the `apt-get -y update` addition

This is to maximize compatibility with different Ubuntu versions. For example, [Ubuntu 24 with kernel 7 deprecated linux-modules-extra](https://discourse.ubuntu.com/t/kernel-development-release-cadence-and-deprecation-of-linux-modules-extra/65176)

### Tests
* Tests will run after the PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
