### PR TITLE
[Validators] Fix error message returned by validator `ExistingFsxNetworkingValidator` when Fsx has no ENI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ CHANGELOG
 - Improve `export-logs` user experience by parallelizing download to reduce run time, 
   adding progress reporting, and supporting running on deleted clusters.
 
+**BUG FIXES**
+- Fixed issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, 
+the validator fails with a clear error message instead of a generic `NoneType` error.
+
 3.16.0
 ------
 

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -391,7 +391,7 @@ class FsxStorageInfo:
     @property
     def network_interface_ids(self):
         """Return network interface ids of the file system."""
-        return self.file_storage_info.get("NetworkInterfaceIds")
+        return self.file_storage_info.get("NetworkInterfaceIds", [])
 
     @property
     def subnet_ids(self):

--- a/cli/tests/pcluster/aws/test_fsx.py
+++ b/cli/tests/pcluster/aws/test_fsx.py
@@ -13,12 +13,29 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.aws.aws_api import AWSApi
+from pcluster.aws.aws_resources import FsxStorageInfo
 from tests.utils import MockedBoto3Request
 
 
 @pytest.fixture()
 def boto3_stubber_path():
     return "pcluster.aws.common.boto3"
+
+
+@pytest.mark.parametrize(
+    "file_storage_info, expected_network_interface_ids",
+    [
+        # NetworkInterfaceIds present: return them as-is.
+        ({"NetworkInterfaceIds": ["eni-12345678", "eni-23456789"]}, ["eni-12345678", "eni-23456789"]),
+        # NetworkInterfaceIds explicitly empty: return the empty list.
+        ({"NetworkInterfaceIds": []}, []),
+        # NetworkInterfaceIds omitted (e.g. storage not yet AVAILABLE): must default to [] rather than None,
+        # otherwise callers iterating/extending over it fail with a generic "NoneType is not iterable" error.
+        ({}, []),
+    ],
+)
+def test_fsx_storage_info_network_interface_ids(file_storage_info, expected_network_interface_ids):
+    assert_that(FsxStorageInfo(file_storage_info).network_interface_ids).is_equal_to(expected_network_interface_ids)
 
 
 def get_describe_file_systems_mocked_request(fsxs, lifecycle):


### PR DESCRIPTION
### Description of changes
Fixed issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, the validator fails with a clear error message instead of a generic `NoneType` error.


### UX

To validate the scenario I am triggering the pcluster update-cluster to mount an external FSx that does not have the ENI attached yet (it is still creating).

#### Before the fix

```
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ExistingFsxNetworkingValidator",
      "message": "'NoneType' object is not iterable"
    },
```

#### After the fix

```
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ExistingFsxNetworkingValidator",
      "message": "Unable to validate FSx security groups. The given FSx file storage 'fs-09ae44abbca688213' doesn't have Elastic Network Interfaces attached to it."
    }
  ],
```

### Tests
1. Manually tested (see UX above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
