### PR TITLE
[Test] Double the MPI ring job timeout to absorb cold cluster starts for stabilizing test_efa

### DIFF
--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -45,8 +45,10 @@ def _test_mpi(
         interactive_command = f"module load {mpi_module} && srun --mpi=pmix -N {num_computes} ring"
         remote_command_executor.run_remote_command(interactive_command)
 
-    # Historically, we assumed a timeout of 20 seconds with 48 slots per instance.
-    timeout = max(math.ceil((20.0 / 48.0) * slots_per_instance), 20)
+    # Historically, we assumed a timeout of 20 seconds with 48 slots per instance. Doubled since the
+    # first MPI launch on freshly booted nodes pays cold page cache and EBS first-touch costs that on
+    # their own can outlast the historical value.
+    timeout = max(math.ceil((40.0 / 48.0) * slots_per_instance), 40)
 
     if partition:
         # submit script using additional files


### PR DESCRIPTION
### Description of changes
The timeout handed to mpi_submit_openmpi.sh was 20 seconds on 48-slot instances, which left no headroom over the observed runtime. The first MPI launch in a freshly created cluster reads its binaries and libraries from an EBS root volume whose blocks are still lazy-loading from the AMI snapshot, inflating that one launch by an order of magnitude and making `test_efa` fail on grounds that have nothing to do with EFA.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
