### PR TITLE
[export-log] Fix false "No log events in the log group" error on log export

### DIFF
--- a/cli/src/pcluster/aws/logs.py
+++ b/cli/src/pcluster/aws/logs.py
@@ -49,7 +49,7 @@ class LogsClient(Boto3Client):
 
     @AWSExceptionHandler.handle_client_exception
     def filter_log_events(self, log_group_name, start_time=None, end_time=None, log_stream_name_prefix=None):
-        """Return the list of events included in a specific time window for a given group name."""
+        """Return the FilterLogEvents response for a specific time window for a given group name."""
         kwargs = {"logGroupName": log_group_name, "limit": 1}
         if start_time:
             kwargs["startTime"] = start_time
@@ -57,7 +57,7 @@ class LogsClient(Boto3Client):
             kwargs["endTime"] = end_time
         if log_stream_name_prefix:
             kwargs["logStreamNamePrefix"] = log_stream_name_prefix
-        return self._client.filter_log_events(**kwargs).get("events")
+        return self._client.filter_log_events(**kwargs)
 
     @AWSExceptionHandler.handle_client_exception
     def get_log_events(

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -137,13 +137,13 @@ class LogGroupTimeFiltersParser:
         if self.start_time >= self.end_time:
             raise FiltersParserError("Start time must be earlier than end time.")
 
-        event_in_window = AWSApi.instance().logs.filter_log_events(
+        response = AWSApi.instance().logs.filter_log_events(
             log_group_name=self._log_group_name,
             log_stream_name_prefix=log_stream_prefix,
             start_time=datetime_to_epoch(self.start_time),
             end_time=datetime_to_epoch(self.end_time),
         )
-        if not event_in_window:
+        if not response.get("events") and not response.get("nextToken"):
             raise FiltersParserError(
                 f"No log events in the log group {self._log_group_name} in interval starting "
                 f"at {self.start_time} and ending at {self.end_time}"

--- a/cli/tests/pcluster/models/test_cluster_resources.py
+++ b/cli/tests/pcluster/models/test_cluster_resources.py
@@ -66,7 +66,7 @@ class TestClusterLogsFiltersParser:
         assert_that(expected_filters_size).is_equal_to(len(logs_filters.filters_list))
 
     @pytest.mark.parametrize(
-        "filters, event_in_window, expected_error",
+        "filters, events, expected_error",
         [
             (
                 ["Name=private-dns-name,Values=ip-10-10-10-10", "Name=node-type,Values=HeadNode"],
@@ -80,7 +80,7 @@ class TestClusterLogsFiltersParser:
             ),
         ],
     )
-    def test_validate(self, mock_head_node, filters, event_in_window, expected_error):
+    def test_validate(self, mock_head_node, filters, events, expected_error):
         logs_filters = ClusterLogsFiltersParser(mock_head_node, filters)
 
         if expected_error:
@@ -152,11 +152,11 @@ class TestExportClusterLogsFiltersParser:
             assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
-        "attrs, event_in_window, expected_error",
+        "attrs, events, expected_error",
         [
             (
                 {"end_time": datetime.datetime(2020, 6, 2, tzinfo=datetime.timezone.utc)},
-                True,
+                {"events": [{"message": "event"}]},
                 "Start time must be earlier than end time",
             ),
             (
@@ -164,26 +164,24 @@ class TestExportClusterLogsFiltersParser:
                     "start_time": datetime.datetime(2021, 6, 7, tzinfo=datetime.timezone.utc),
                     "end_time": datetime.datetime(2021, 6, 2, tzinfo=datetime.timezone.utc),
                 },
-                True,
+                {"events": [{"message": "event"}]},
                 "Start time must be earlier than end time",
             ),
             (
                 {"end_time": datetime.datetime(2021, 7, 9, 22, 45, 22, tzinfo=datetime.timezone.utc)},
-                False,
+                {"events": []},
                 "No log events in the log group",
             ),
         ],
     )
-    def test_validate(self, mocker, mock_head_node, attrs, event_in_window, expected_error):
+    def test_validate(self, mocker, mock_head_node, attrs, events, expected_error):
         log_group_name = "log_group_name"
         creation_time_mock = 1623061001000
         mock_aws_api(mocker)
         describe_log_group_mock = mocker.patch(
             "pcluster.aws.logs.LogsClient.describe_log_group", return_value={"creationTime": creation_time_mock}
         )
-        filter_log_events_mock = mocker.patch(
-            "pcluster.aws.logs.LogsClient.filter_log_events", return_value=event_in_window
-        )
+        filter_log_events_mock = mocker.patch("pcluster.aws.logs.LogsClient.filter_log_events", return_value=events)
 
         export_logs_filters = ExportClusterLogsFiltersParser(
             mock_head_node,

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -83,11 +83,11 @@ class TestLogGrouptimeFiltersParser:
             assert_that(getattr(export_logs_filters, attr)).is_equal_to(expected_attrs.get(attr))  # noqa: B038
 
     @pytest.mark.parametrize(
-        "attrs, event_in_window, log_stream_prefix, expected_error",
+        "attrs, events, log_stream_prefix, expected_error",
         [
             (
                 {"end_time": datetime.datetime(2020, 6, 2, tzinfo=datetime.timezone.utc)},
-                True,
+                {"events": [{"message": "event"}]},
                 "test",
                 "Start time must be earlier than end time",
             ),
@@ -96,28 +96,26 @@ class TestLogGrouptimeFiltersParser:
                     "start_time": datetime.datetime(2020, 6, 7, tzinfo=datetime.timezone.utc),
                     "end_time": datetime.datetime(2020, 6, 2, tzinfo=datetime.timezone.utc),
                 },
-                True,
+                {"events": [{"message": "event"}]},
                 "test",
                 "Start time must be earlier than end time",
             ),
             (
                 {"end_time": datetime.datetime(2021, 7, 9, 22, 45, 22, tzinfo=datetime.timezone.utc)},
-                False,
+                {"events": []},
                 None,
                 "No log events in the log group",
             ),
         ],
     )
-    def test_validate(self, mocker, attrs, event_in_window, log_stream_prefix, expected_error):
+    def test_validate(self, mocker, attrs, events, log_stream_prefix, expected_error):
         log_group_name = "log_group_name"
         creation_time_mock = 1623061001000
         mock_aws_api(mocker)
         describe_log_group_mock = mocker.patch(
             "pcluster.aws.logs.LogsClient.describe_log_group", return_value={"creationTime": creation_time_mock}
         )
-        filter_log_events_mock = mocker.patch(
-            "pcluster.aws.logs.LogsClient.filter_log_events", return_value=event_in_window
-        )
+        filter_log_events_mock = mocker.patch("pcluster.aws.logs.LogsClient.filter_log_events", return_value=events)
 
         export_logs_filters = LogGroupTimeFiltersParser(
             log_group_name, attrs.get("start_time", None), attrs.get("end_time", None)
@@ -138,6 +136,28 @@ class TestLogGrouptimeFiltersParser:
             if "start_time" not in attrs:
                 describe_log_group_mock.assert_called_with(log_group_name)
                 assert_that(export_logs_filters.start_time).is_equal_to(creation_time_mock)
+
+    @pytest.mark.parametrize(
+        "filter_log_events_response",
+        [
+            {"events": [{"message": "event"}], "nextToken": "token"},
+            {"events": [], "nextToken": "token"},
+            {"nextToken": "token"},
+        ],
+        ids=["events_in_page", "empty_page_with_next_token", "page_without_events_key"],
+    )
+    def test_validate_accepts_incomplete_pagination(self, mocker, filter_log_events_response):
+        """An empty FilterLogEvents page is conclusive only when it comes back without a nextToken."""
+        mock_aws_api(mocker)
+        mocker.patch("pcluster.aws.logs.LogsClient.filter_log_events", return_value=filter_log_events_response)
+
+        time_parser = LogGroupTimeFiltersParser(
+            "log_group_name",
+            datetime.datetime(2021, 7, 1, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2021, 7, 9, tzinfo=datetime.timezone.utc),
+        )
+
+        time_parser.validate()
 
 
 class TestLogGroupTimeFiltersParser:


### PR DESCRIPTION
## Description of changes
Prior to this commit, validation error of "no log events" is triggered whenever the first FilterLogEvents call came back with an empty events list. FilterLogEvents is paginated, so a page can be empty even if more data is available in the next pages.

This commit triggers the validation error only if both events list and `nextTokens` are empty. Even though the existence of `nextTokens` doesn't guarantee the log is non-empty, this commit still makes a single API call for validation to avoid the validation logic call too many APIs to go through the logs.

### Tests
Manually tested the following:
1. Created a cluster on Aug 19
2. Export the log with `--start-time 2026-08-12T00:00:00Z --end-time 2026-08-20T00:00:00Z`. Logs are successfully exported. This was the case where the "no log events" error was falsely reported
3. Export the log with `--start-time 2026-08-12T00:00:00Z --end-time 2026-08-18T00:00:00Z`, "no log events" error was correctly reported

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
