### PR TITLE
[Integ test] Modify test_efa to verify EFA with FsxLustre tutorial

### DIFF
--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -233,13 +233,7 @@ Resources:
         - !Ref SubnetOne
     Type: 'AWS::FSx::FileSystem'
 
-  # EFA-enabled FSxLustre
-  # Per the FSx EFA-enabled security groups doc, EFA-enabled FSx Lustre uses TWO security groups that
-  # authorize traffic BY SECURITY-GROUP ID (a 0.0.0.0/0 CIDR rule does NOT satisfy EFA):
-  #   - File-system SG: all traffic to/from the client SG AND to/from itself (self-referencing).
-  #   - Client SG:      all traffic to/from the file-system SG (no self-referencing rule required).
-  # A group cannot reference another (or itself) inline at creation, so the rules are separate
-  # AWS::EC2::SecurityGroup{Ingress,Egress} resources.
+  # EFA-enabled FSxLustre: client and file-system SGs authorizing each other by security-group ID, per
   # https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html#fsx-vpc-security-groups
   EfaFsxLustreClientSecurityGroup:
     Condition: CreateEfaFsxLustre

--- a/cloudformation/storage/storage-stack.yaml
+++ b/cloudformation/storage/storage-stack.yaml
@@ -30,6 +30,10 @@ Metadata:
           - FsxLustreImportPath
           - FsxLustreExportPath
       - Label:
+          default: EFA-enabled FSx Lustre
+        Parameters:
+          - CreateEfaFsxLustre
+      - Label:
           default: FSx ONTAP
         Parameters:
           - CreateFsxOntap
@@ -97,6 +101,15 @@ Parameters:
     Type: String
     Default: 'true'
     AllowedValues: ['true', 'false']
+  CreateEfaFsxLustre:
+    Description: >-
+      True to create an EFA-enabled FSx Lustre file system (PERSISTENT_2 with EfaEnabled and a
+      self-referencing security group required by EFA's SRD data plane); False otherwise. Defaults to
+      False because EFA-enabled FSx Lustre requires a much larger minimum capacity than the plain
+      FSx Lustre resource and is only needed by the EFA-for-Lustre tests.
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
   CreateFsxOntap:
     Description: True to create the FSx ONTAP resources; False otherwise.
     Type: String
@@ -123,6 +136,7 @@ Conditions:
     - !Equals [!Ref CreateEfs, 'true']
     - !Not [!Equals [!Ref SubnetThree, '']]
   CreateFsxLustre: !Equals [!Ref CreateFsxLustre, 'true']
+  CreateEfaFsxLustre: !Equals [!Ref CreateEfaFsxLustre, 'true']
   HasFsxLustreImportPath: !Not [!Equals [!Ref FsxLustreImportPath, '']]
   HasFsxLustreExportPath: !Not [!Equals [!Ref FsxLustreExportPath, '']]
   CreateFsxOntap: !Equals [!Ref CreateFsxOntap, 'true']
@@ -132,6 +146,7 @@ Conditions:
     - !Not [!Equals [!Ref CreateEbs, 'true']]
     - !Not [!Equals [!Ref CreateEfs, 'true']]
     - !Not [!Equals [!Ref CreateFsxLustre, 'true']]
+    - !Not [!Equals [!Ref CreateEfaFsxLustre, 'true']]
     - !Not [!Equals [!Ref CreateFsxOntap, 'true']]
     - !Not [!Equals [!Ref CreateFsxOpenZfs, 'true']]
     - !Not [!Equals [!Ref CreateFileCache, 'true']]
@@ -217,6 +232,91 @@ Resources:
       SubnetIds:
         - !Ref SubnetOne
     Type: 'AWS::FSx::FileSystem'
+
+  # EFA-enabled FSxLustre
+  # Per the FSx EFA-enabled security groups doc, EFA-enabled FSx Lustre uses TWO security groups that
+  # authorize traffic BY SECURITY-GROUP ID (a 0.0.0.0/0 CIDR rule does NOT satisfy EFA):
+  #   - File-system SG: all traffic to/from the client SG AND to/from itself (self-referencing).
+  #   - Client SG:      all traffic to/from the file-system SG (no self-referencing rule required).
+  # A group cannot reference another (or itself) inline at creation, so the rules are separate
+  # AWS::EC2::SecurityGroup{Ingress,Egress} resources.
+  # https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html#fsx-vpc-security-groups
+  EfaFsxLustreClientSecurityGroup:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Allow traffic for the EFA-enabled FSx Lustre client
+      VpcId: !Ref Vpc
+  EfaFsxLustreFileSystemSecurityGroup:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Allow traffic for the EFA-enabled FSx Lustre file system
+      VpcId: !Ref Vpc
+  # Client SG: admit all traffic to/from the file-system SG (self-referencing not required for the client).
+  EfaFsxLustreClientSecurityGroupIngress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreClientSecurityGroup.GroupId
+      IpProtocol: '-1'
+      SourceSecurityGroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+  EfaFsxLustreClientSecurityGroupEgress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreClientSecurityGroup.GroupId
+      IpProtocol: '-1'
+      DestinationSecurityGroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+  # File-system SG: admit all traffic from BOTH the client SG and itself (self-referencing), ingress and egress.
+  EfaFsxLustreFileSystemSecurityGroupIngress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+      IpProtocol: '-1'
+      SourceSecurityGroupId: !GetAtt EfaFsxLustreClientSecurityGroup.GroupId
+  EfaFsxLustreFileSystemSecurityGroupSelfIngress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+      IpProtocol: '-1'
+      SourceSecurityGroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+  EfaFsxLustreFileSystemSecurityGroupEgress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+      IpProtocol: '-1'
+      DestinationSecurityGroupId: !GetAtt EfaFsxLustreClientSecurityGroup.GroupId
+  EfaFsxLustreFileSystemSecurityGroupSelfEgress:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      GroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+      IpProtocol: '-1'
+      DestinationSecurityGroupId: !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId
+  EfaFsxLustreFileSystem:
+    Condition: CreateEfaFsxLustre
+    Type: 'AWS::FSx::FileSystem'
+    Properties:
+      FileSystemType: LUSTRE
+      # EFA-enabled FSx Lustre requires PERSISTENT_2. We use the highest throughput tier (1000 MB/s/TiB),
+      # whose EFA-enabled minimum capacity is 4800 GiB, to keep the file system as small (and cheap) as
+      # possible. AUTOMATIC metadata keeps the metadata server FSx-managed (it stays on TCP by design; only
+      # the data/OSS targets ride EFA).
+      LustreConfiguration:
+        DeploymentType: PERSISTENT_2
+        PerUnitStorageThroughput: 1000
+        EfaEnabled: true
+        MetadataConfiguration:
+          Mode: AUTOMATIC
+      SecurityGroupIds:
+        - !Ref EfaFsxLustreFileSystemSecurityGroup
+      StorageCapacity: 4800
+      SubnetIds:
+        - !Ref SubnetOne
 
   # FSx ONTAP
   FsxOntapFileSystem:
@@ -581,6 +681,12 @@ Outputs:
     Value: !If [ CreateEfs, !Ref EfsFileSystem, '' ]
   FsxLustreFsId:
     Value: !If [ CreateFsxLustre, !Ref FsxLustreFileSystem, '']
+  EfaFsxLustreFsId:
+    Value: !If [ CreateEfaFsxLustre, !Ref EfaFsxLustreFileSystem, '']
+  EfaFsxLustreClientSecurityGroupId:
+    Value: !If [ CreateEfaFsxLustre, !GetAtt EfaFsxLustreClientSecurityGroup.GroupId, '']
+  EfaFsxLustreFileSystemSecurityGroupId:
+    Value: !If [ CreateEfaFsxLustre, !GetAtt EfaFsxLustreFileSystemSecurityGroup.GroupId, '']
   FsxOntapVolumeId:
     Value: !If [ CreateFsxOntap, !Ref StorageVirtualMachineVolume, '']
   FsxOpenZfsVolumeId:

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -508,6 +508,17 @@ class SlurmCommands(SchedulerCommands):
         self.wait_job_completed(job_id)
         self.assert_job_succeeded(job_id)
 
+    def submit_command_and_get_output(self, job_command_args):
+        """Submit a command, assert the job succeeded, and return the job's stdout.
+
+        Reads back `slurm-<job_id>.out`, which sbatch writes to the job's submit directory.
+        """
+        result = self.submit_command(**job_command_args)
+        job_id = self.assert_job_submitted(result.stdout)
+        self.wait_job_completed(job_id)
+        self.assert_job_succeeded(job_id)
+        return self._remote_command_executor.run_remote_command(f"cat slurm-{job_id}.out").stdout
+
     def get_partition_state(self, partition):
         """Get the state of the partition."""
         return self._remote_command_executor.run_remote_command(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -692,7 +692,13 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
 
 
 def _test_fsx_read_write(scheduler_commands, remote_command_executor, mount_dir, partition=None):
-    """Assert a basic write/read round-trip to the mounted FSx file system succeeds."""
+    """Assert a write to the mounted FSx file system is visible to a subsequent read.
+
+    This is POSIX read-after-write visibility, not proof the bytes reached the servers: the write is
+    buffered and a marker this small is far below any writeback trigger, so the read may well be served
+    from the client page cache. Deliberate -- _test_lustre_data_rail is what exercises the wire. What
+    this catches is a mount that is present but unusable: EIO, read-only, out of space, bad permissions.
+    """
     logging.info("Testing basic write/read to the mounted FSx file system")
 
     marker = "hello-efa-fsx-lustre"

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -282,6 +282,9 @@ def test_efa(
         "pcluster-efa-fsx-lustre-client-tutorial.sh",
     )
 
+    # Gates the OnNodeStart FSx EFA setup: it unloads the Lustre/LNet stack, which is pointless where no @efa
+    # net can come up.
+    supports_efa_for_fsx = _supports_efa_for_fsx(instance, os)
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(
         head_node_instance=head_node_instance,
@@ -292,6 +295,7 @@ def test_efa(
         fsx_fs_id=fsx_fs_id,
         fsx_efa_security_group_id=efa_fsx_security_group_id,
         bucket_name=bucket_name,
+        supports_efa_for_fsx=supports_efa_for_fsx,
     )
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
@@ -338,13 +342,8 @@ def test_efa(
             assert_that(num_errors, description=f"{num_errors}/{num_tests} libfabric tests got errors").is_equal_to(0)
             assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
 
-    # EFA-for-Lustre validation (folded in from the standalone test_efa_enabled_fsx_lustre). This test runs on
-    # every EFA instance, but only Nitro v4+ instances on a supported OS can actually carry Lustre traffic over
-    # @efa (see _supports_efa_for_fsx). Either way the data path is measured the same way -- send_count deltas
-    # across bulk direct I/O -- and only the expected rail flips, so the EFA v1 instances guard against a
-    # half-configured client instead of being skipped. The mount must work either way, so the read/write check
-    # is unconditional.
-    supports_efa_for_fsx = _supports_efa_for_fsx(instance, os)
+    # EFA-for-Lustre validation. Only instances that ran the FSx client setup can carry Lustre over @efa; the
+    # rest ride @tcp. The data path is measured the same way either way, and the mount must work on both.
     with soft_assertions():
         if supports_efa_for_fsx:
             _test_efa_fsx_device_count(
@@ -635,9 +634,8 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     logging.info("Testing that bulk Lustre data rides the @%s rail", expected_net)
 
     # NOTE: submit_command wraps this in sbatch --wrap='...', so the command must contain no single quotes.
-    # oflag=direct is load-bearing; we test before/after counter delta.
-    # Buffered writes could sit in cache and turn into RPCs after the second lnetctl net show -v sample,
-    # so a healthy client would show efa_delta ≈ 0. O_DIRECT guarantees the 4 GiB becomes bulk RPCs inside the measurement window.
+    # oflag=direct is load-bearing: buffered writes could turn into RPCs after the second sample, leaving a
+    # healthy client with efa_delta ~ 0.
     io_out = _submit_and_get_output(
         scheduler_commands,
         remote_command_executor,
@@ -702,7 +700,7 @@ def _test_fsx_read_write(scheduler_commands, remote_command_executor, mount_dir,
     rw_out = _submit_and_get_output(
         scheduler_commands,
         remote_command_executor,
-        f"echo '{marker}' > {test_file} && sync && cat {test_file}",
+        f"echo '{marker}' > {test_file} && cat {test_file}",
         partition,
     )
     logging.info("FSx write/read output:\n%s", rw_out)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -41,8 +41,8 @@ FSX_MOUNT_DIR = "/fsx"
 FSX_EFA_COUNTER_TEST_MIB = 4096
 FSX_EFA_MIN_SEND_COUNT = FSX_EFA_COUNTER_TEST_MIB // 2
 
-# EFA interfaces the FSx setup binds, for the families where filter_efa_non_gds() drops the GDS-reserved
-# devices (p5.48xlarge exposes 32, binds 8). Instances absent from this map bind all of them.
+# EFA interfaces the FSx setup binds on the families where it binds only a subset (p5.48xlarge exposes 32,
+# binds 8). Instances absent from this map bind all of them.
 # https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html#add-efa-interfaces
 FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE = {
     "p6-b300.48xlarge": 16,
@@ -162,18 +162,13 @@ def _supports_efa_for_fsx(instance, os):
 def _expected_efa_bound_devices(instance, region):
     """Return the number of EFA interfaces the FSx-for-Lustre setup is expected to bind on ``instance``.
 
-    Instance types listed in FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE bind the curated (lower) count,
-    because the setup script's filter_efa_non_gds() reserves some devices for GDS. For every other
-    instance type that filter is a no-op -- it returns the full EFA device list -- so the setup binds
-    every EFA interface the instance has, which EC2 reports as NetworkInfo.EfaInfo.MaximumEfaInterfaces
-    (8 on trn1.32xlarge, 1 on single-EFA-interface types).
+    Instance types listed in FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE bind that (lower) count; every other
+    instance type binds all the EFA interfaces it has, which EC2 reports as
+    NetworkInfo.EfaInfo.MaximumEfaInterfaces (1 on single-EFA-interface types).
 
     NOTE: the FSx doc's prose says instances outside its table bind "2 for other instances with multiple
-    network cards", which contradicts the script's own filter_efa_non_gds(). We assert what the script
-    does; the contradiction is raised with the FSx team separately.
-
-    EFA-for-Lustre is not p-family specific; any EFA-capable instance binds at least one interface, so
-    this returns a value for every EFA instance.
+    network cards", which does not match what the setup script actually binds. We assert the observed
+    behaviour; the contradiction is raised with the FSx team separately.
     """
     curated = FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE.get(instance)
     if curated is not None:
@@ -518,9 +513,9 @@ def _submit_and_get_output(scheduler_commands, remote_command_executor, command,
 def _test_efa_fsx_device_count(scheduler_commands, remote_command_executor, region, instance, partition=None):
     """Assert LNet binds the expected number of EFA devices (regression guard for the under-bind bug).
 
-    The expected count is what the setup script binds by design, not the hardware EFA-device count: the
-    curated FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE value for the GDS-filtered p-families, otherwise EC2's
-    MaximumEfaInterfaces. Lustre silently falls back to TCP on any unbound device.
+    The expected count is what the setup binds by design, not the hardware EFA-device count -- see
+    _expected_efa_bound_devices. An unbound device carries no Lustre traffic, so an under-bind costs
+    bandwidth without failing anything visibly.
     """
     logging.info("Testing that LNet binds the expected number of EFA devices for FSx")
 
@@ -618,14 +613,18 @@ def _sum_send_counts_by_net(lnet_verbose_out):
 def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_dir, expect_efa, partition=None):
     """Assert which LNet rail carries bulk Lustre data: @efa when ``expect_efa``, else @tcp.
 
-    Sums per-NI `send_count` per LNet net type, writes FSX_EFA_COUNTER_TEST_MIB of direct I/O, sums again,
-    and asserts on the deltas. The measurement is identical either way; only the expectation flips:
+    Sums per-NI `send_count` per LNet net type, writes FSX_EFA_COUNTER_TEST_MIB, sums again, and asserts on
+    the deltas. The measurement is identical either way; only the expectation flips:
 
     * ``expect_efa``: @efa must gain at least FSX_EFA_MIN_SEND_COUNT sends and gain more than @tcp. Metadata
       RPCs and pings ride @tcp by design, so this is an ordering, not `tcp_delta == 0`.
     * otherwise: @tcp must gain at least FSX_EFA_MIN_SEND_COUNT sends and @efa must gain exactly none. No
       @efa net comes up on these nodes, so there is no efa NI to accumulate sends -- an exact assertion is
       available here, unlike in the @efa direction.
+
+    A plain buffered write is enough, and neither oflag=direct nor a trailing sync is needed: Lustre's
+    per-OSC dirty budget (~3.4 MB grant, 1 MiB max_brw_size) is far below this size, so the data flushes as
+    it goes. Measured on c6gn.16xlarge/alinux2023: buffered efa=4098 vs direct efa=4097.
 
     Counters rather than the import: the import's connection nid does not reliably tell us which transport
     carries the data, so do not assert on `osc.*.import`.
@@ -634,15 +633,13 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     logging.info("Testing that bulk Lustre data rides the @%s rail", expected_net)
 
     # NOTE: submit_command wraps this in sbatch --wrap='...', so the command must contain no single quotes.
-    # oflag=direct is load-bearing: buffered writes could turn into RPCs after the second sample, leaving a
-    # healthy client with efa_delta ~ 0.
     io_out = _submit_and_get_output(
         scheduler_commands,
         remote_command_executor,
         (
             "sudo lnetctl net show -v; echo ===IO_BOUNDARY===; "
             f"dd if=/dev/zero of={mount_dir}/efa_counter_test.$(hostname) "
-            f"bs=1M count={FSX_EFA_COUNTER_TEST_MIB} oflag=direct; sync; "
+            f"bs=1M count={FSX_EFA_COUNTER_TEST_MIB}; "
             "sudo lnetctl net show -v"
         ),
         partition,
@@ -654,7 +651,7 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     efa_delta = after.get("efa", 0) - before.get("efa", 0)
     tcp_delta = after.get("tcp", 0) - before.get("tcp", 0)
     logging.info(
-        "LNet send_count deltas over %s MiB of direct I/O: efa=%s tcp=%s (before=%s, after=%s)",
+        "LNet send_count deltas over %s MiB: efa=%s tcp=%s (before=%s, after=%s)",
         FSX_EFA_COUNTER_TEST_MIB,
         efa_delta,
         tcp_delta,
@@ -667,7 +664,7 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
         expected_delta,
         description=(
             f"only {expected_delta} LNet sends landed on @{expected_net} over {FSX_EFA_COUNTER_TEST_MIB} MiB "
-            f"of direct I/O (efa={efa_delta}, tcp={tcp_delta}); bulk Lustre data is not riding the "
+            f"of I/O (efa={efa_delta}, tcp={tcp_delta}); bulk Lustre data is not riding the "
             f"@{expected_net} rail"
         ),
     ).is_greater_than_or_equal_to(FSX_EFA_MIN_SEND_COUNT)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -33,13 +33,14 @@ from tests.common.utils import (
     run_system_analyzer,
     wait_process_completion,
 )
+from tests.storage.storage_common import verify_directory_correctly_shared
 
 FSX_MOUNT_DIR = "/fsx"
 
-# Lustre's max_brw_size is 1 MiB, so a 4 GiB direct write is ~4096 bulk RPCs; require half on @efa to leave
-# headroom for RPC coalescing.
-FSX_EFA_COUNTER_TEST_MIB = 4096
-FSX_EFA_MIN_SEND_COUNT = FSX_EFA_COUNTER_TEST_MIB // 2
+# Lustre's max_brw_size is 1 MiB, so a 4 GiB write is ~4096 bulk RPCs; where bulk of data goes through
+# the rail under test.
+FSX_IO_TEST_MIB = 4096
+FSX_MIN_SEND_COUNT = FSX_IO_TEST_MIB // 2
 
 # EFA interfaces the FSx setup binds on the families where it binds only a subset (p5.48xlarge exposes 32,
 # binds 8). Instances absent from this map bind all of them.
@@ -56,7 +57,7 @@ FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE = {
 # EFA for FSx for Lustre needs more than plain EFA support: the client must be a Nitro v4 (or later)
 # instance -- the generation that introduced RDMA over EFA -- and the trn2 family is explicitly excluded.
 # Nitro v3 (EFA v1) instances still get an EFA device and pass every other EFA check in this test, but
-# LNet cannot bring up an @efa network on them, so their Lustre traffic stays on @tcp. EC2 exposes no
+# LNet cannot bring up an efa network on them, so their Lustre traffic stays on tcp. EC2 exposes no
 # Nitro-version field, so this has to be a hand-maintained list; enumerating the *unsupported* families is
 # far shorter (and less churn-prone) than listing every Nitro v4+ EFA type.
 # https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
@@ -84,7 +85,7 @@ EFA_V1_NITRO_V3_FAMILIES = {
 EFA_FSX_UNSUPPORTED_FAMILIES = EFA_V1_NITRO_V3_FAMILIES | {"trn2", "trn2u"}
 
 # EFA for FSx for Lustre is only supported on these client OSes: AL2023, RHEL 9.5+, and Ubuntu 22.04+
-# on kernel 6.8+. RHEL 8 and Rocky are not supported, so on those the client stays on @tcp even on an
+# on kernel 6.8+. RHEL 8 and Rocky are not supported, so on those the client stays on tcp even on an
 # otherwise-capable instance. See "Configuring EFA clients" in the FSx for Lustre guide.
 EFA_FSX_SUPPORTED_OSES = {"alinux2023", "rhel9", "ubuntu2204", "ubuntu2404"}
 
@@ -150,10 +151,10 @@ def _try_reserve_head_node_instance(region, az_id, architecture, os):
 
 
 def _supports_efa_for_fsx(instance, os):
-    """Return True if ``instance``/``os`` can carry FSx for Lustre traffic over @efa.
+    """Return True if ``instance``/``os`` can carry FSx for Lustre traffic over efa.
 
     Requires a Nitro v4+ instance (RDMA over EFA, excluding trn2) AND a supported client OS. Anything
-    else keeps its EFA device -- and passes the plain EFA checks -- but its Lustre mount rides @tcp.
+    else keeps its EFA device -- and passes the plain EFA checks -- but its Lustre mount rides tcp.
     """
     family = instance.split(".")[0]
     return family not in EFA_FSX_UNSUPPORTED_FAMILIES and os in EFA_FSX_SUPPORTED_OSES
@@ -262,13 +263,10 @@ def test_efa(
             logging.warn(message)
             pytest.skip(message)
 
-    # Provision the EFA-enabled FSx Lustre file system and its two cross-referencing EFA security groups
-    # (client + file system) via the shared external-shared-storage CloudFormation stack. EFA for Lustre
-    # works on any EFA-capable instance (the setup binds a per-instance-type number of EFA interfaces --
-    # see _expected_efa_bound_devices), so this runs for every EFA instance, not just p*. The cluster
-    # attaches the client SG, which cross-references the file-system SG, so EFA's SRD path (authorized by
-    # SG membership) is permitted between compute nodes and the file system. The OnNodeStart script (staged
-    # in S3) runs the official FSx EFA-Lustre client setup on each node.
+    # EFA-enabled FSx Lustre plus the two cross-referencing EFA security groups (client + file system),
+    # provisioned via the shared storage stack. The OnNodeStart script staged in S3 runs the official FSx
+    # EFA client setup on each node, per the tutorial:
+    # https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-efa-enabled-fsx-lustre.html
     fsx_fs_id, efa_fsx_security_group_id = _provision_efa_fsx_stack(region, request, vpc_stack, cfn_stacks_factory)
 
     bucket_name = request.getfixturevalue("s3_bucket_factory")()
@@ -277,7 +275,7 @@ def test_efa(
         "pcluster-efa-fsx-lustre-client-tutorial.sh",
     )
 
-    # Gates the OnNodeStart FSx EFA setup: it unloads the Lustre/LNet stack, which is pointless where no @efa
+    # Gates the OnNodeStart FSx EFA setup: it unloads the Lustre/LNet stack, which is pointless where no efa
     # net can come up.
     supports_efa_for_fsx = _supports_efa_for_fsx(instance, os)
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
@@ -337,8 +335,8 @@ def test_efa(
             assert_that(num_errors, description=f"{num_errors}/{num_tests} libfabric tests got errors").is_equal_to(0)
             assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
 
-    # EFA-for-Lustre validation. Only instances that ran the FSx client setup can carry Lustre over @efa; the
-    # rest ride @tcp. The data path is measured the same way either way, and the mount must work on both.
+    # EFA-for-Lustre validation. Only instances that ran the FSx client setup can carry Lustre over efa; the
+    # rest ride tcp. The data path is measured the same way either way, and the mount must work on both.
     with soft_assertions():
         if supports_efa_for_fsx:
             _test_efa_fsx_device_count(
@@ -360,7 +358,9 @@ def test_efa(
             expect_efa=supports_efa_for_fsx,
             partition="efa-enabled",
         )
-        _test_fsx_read_write(scheduler_commands, remote_command_executor, FSX_MOUNT_DIR, partition="efa-enabled")
+        verify_directory_correctly_shared(
+            remote_command_executor, FSX_MOUNT_DIR, scheduler_commands, partitions=["efa-enabled"]
+        )
 
 
 def _test_efa_eni_configuration(cluster, region):
@@ -543,7 +543,7 @@ def _test_efa_fsx_device_count(scheduler_commands, remote_command_executor, regi
 # Read-only LNet state commands, as (label, command) pairs. Between them they show every NID the node knows:
 # the local NIs and their bound devices, the peer table with each peer's rails, the mount target NID, and the
 # PCI address of each EFA device -- enough to tell which peer NIDs are served by something and how a real
-# @efa NID is derived from its device (<host IP octet 3>.<octet 4>.<PCI bus>.<PCI devfn>@efa).
+# efa NID is derived from its device (<host IP octet 3>.<octet 4>.<PCI bus>.<PCI devfn>, on net efa).
 # The osc imports are captured for diagnostics only: an import's connection nid does not reliably tell us
 # which transport carries the data (under Multi-Rail, ptlrpc connects to the peer's primary nid and LNet
 # picks the rail beneath it), so nothing asserts on it -- _test_lustre_data_rail measures the rail instead.
@@ -611,16 +611,16 @@ def _sum_send_counts_by_net(lnet_verbose_out):
 
 
 def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_dir, expect_efa, partition=None):
-    """Assert which LNet rail carries bulk Lustre data: @efa when ``expect_efa``, else @tcp.
+    """Assert which LNet rail carries bulk Lustre data: efa when ``expect_efa``, else tcp.
 
-    Sums per-NI `send_count` per LNet net type, writes FSX_EFA_COUNTER_TEST_MIB, sums again, and asserts on
+    Sums per-NI `send_count` per LNet net type, writes FSX_IO_TEST_MIB, sums again, and asserts on
     the deltas. The measurement is identical either way; only the expectation flips:
 
-    * ``expect_efa``: @efa must gain at least FSX_EFA_MIN_SEND_COUNT sends and gain more than @tcp. Metadata
-      RPCs and pings ride @tcp by design, so this is an ordering, not `tcp_delta == 0`.
-    * otherwise: @tcp must gain at least FSX_EFA_MIN_SEND_COUNT sends and @efa must gain exactly none. No
-      @efa net comes up on these nodes, so there is no efa NI to accumulate sends -- an exact assertion is
-      available here, unlike in the @efa direction.
+    * ``expect_efa``: efa must gain at least FSX_MIN_SEND_COUNT sends and gain more than tcp. Metadata
+      RPCs and pings ride tcp by design, so this is an ordering, not `tcp_delta == 0`.
+    * otherwise: tcp must gain at least FSX_MIN_SEND_COUNT sends and efa must gain exactly none. No
+      efa net comes up on these nodes, so there is no efa NI to accumulate sends -- an exact assertion is
+      available here, unlike in the efa direction.
 
     A plain buffered write is enough, and neither oflag=direct nor a trailing sync is needed: Lustre's
     per-OSC dirty budget (~3.4 MB grant, 1 MiB max_brw_size) is far below this size, so the data flushes as
@@ -639,7 +639,7 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
         (
             "sudo lnetctl net show -v; echo ===IO_BOUNDARY===; "
             f"dd if=/dev/zero of={mount_dir}/efa_counter_test.$(hostname) "
-            f"bs=1M count={FSX_EFA_COUNTER_TEST_MIB}; "
+            f"bs=1M count={FSX_IO_TEST_MIB}; "
             "sudo lnetctl net show -v"
         ),
         partition,
@@ -652,7 +652,7 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     tcp_delta = after.get("tcp", 0) - before.get("tcp", 0)
     logging.info(
         "LNet send_count deltas over %s MiB: efa=%s tcp=%s (before=%s, after=%s)",
-        FSX_EFA_COUNTER_TEST_MIB,
+        FSX_IO_TEST_MIB,
         efa_delta,
         tcp_delta,
         before,
@@ -663,11 +663,11 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     assert_that(
         expected_delta,
         description=(
-            f"only {expected_delta} LNet sends landed on @{expected_net} over {FSX_EFA_COUNTER_TEST_MIB} MiB "
+            f"only {expected_delta} LNet sends landed on @{expected_net} over {FSX_IO_TEST_MIB} MiB "
             f"of I/O (efa={efa_delta}, tcp={tcp_delta}); bulk Lustre data is not riding the "
             f"@{expected_net} rail"
         ),
-    ).is_greater_than_or_equal_to(FSX_EFA_MIN_SEND_COUNT)
+    ).is_greater_than_or_equal_to(FSX_MIN_SEND_COUNT)
 
     if expect_efa:
         assert_that(
@@ -678,7 +678,7 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
             ),
         ).is_greater_than(tcp_delta)
     else:
-        # No @efa net comes up on these nodes, so any send on it means LNet configured a rail it cannot use.
+        # No efa net comes up on these nodes, so any send on it means LNet configured a rail it cannot use.
         assert_that(
             efa_delta,
             description=(
@@ -686,25 +686,3 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
                 "over EFA; an @efa rail was configured and used unexpectedly"
             ),
         ).is_equal_to(0)
-
-
-def _test_fsx_read_write(scheduler_commands, remote_command_executor, mount_dir, partition=None):
-    """Assert a write to the mounted FSx file system is visible to a subsequent read.
-
-    This is POSIX read-after-write visibility, not proof the bytes reached the servers: the write is
-    buffered and a marker this small is far below any writeback trigger, so the read may well be served
-    from the client page cache. Deliberate -- _test_lustre_data_rail is what exercises the wire. What
-    this catches is a mount that is present but unusable: EIO, read-only, out of space, bad permissions.
-    """
-    logging.info("Testing basic write/read to the mounted FSx file system")
-
-    marker = "hello-efa-fsx-lustre"
-    test_file = f"{mount_dir}/efa_fsx_lustre_test.txt"
-    rw_out = _submit_and_get_output(
-        scheduler_commands,
-        remote_command_executor,
-        f"echo '{marker}' > {test_file} && cat {test_file}",
-        partition,
-    )
-    logging.info("FSx write/read output:\n%s", rw_out)
-    assert_that(rw_out).contains(marker)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -269,15 +269,15 @@ def test_efa(
     # https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-efa-enabled-fsx-lustre.html
     fsx_fs_id, efa_fsx_security_group_id = _provision_efa_fsx_stack(region, request, vpc_stack, cfn_stacks_factory)
 
-    bucket_name = request.getfixturevalue("s3_bucket_factory")()
-    boto3.resource("s3", region_name=region).Bucket(bucket_name).upload_file(
-        str(test_datadir / "pcluster-efa-fsx-lustre-client-tutorial.sh"),
-        "pcluster-efa-fsx-lustre-client-tutorial.sh",
-    )
-
-    # Gates the OnNodeStart FSx EFA setup: it unloads the Lustre/LNet stack, which is pointless where no efa
-    # net can come up.
     supports_efa_for_fsx = _supports_efa_for_fsx(instance, os)
+    bucket_name = None
+    if supports_efa_for_fsx:
+        bucket_name = request.getfixturevalue("s3_bucket_factory")()
+        boto3.resource("s3", region_name=region).Bucket(bucket_name).upload_file(
+            str(test_datadir / "pcluster-efa-fsx-lustre-client-tutorial.sh"),
+            "pcluster-efa-fsx-lustre-client-tutorial.sh",
+        )
+
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(
         head_node_instance=head_node_instance,
@@ -339,9 +339,7 @@ def test_efa(
     # rest ride tcp. The data path is measured the same way either way, and the mount must work on both.
     with soft_assertions():
         if supports_efa_for_fsx:
-            _test_efa_fsx_device_count(
-                scheduler_commands, remote_command_executor, region, instance, partition="efa-enabled"
-            )
+            _test_efa_fsx_device_count(scheduler_commands, region, instance, partition="efa-enabled")
         else:
             logging.info(
                 "Instance %s on %s does not support EFA for FSx for Lustre (needs Nitro v4+ and one of %s); "
@@ -350,13 +348,9 @@ def test_efa(
                 os,
                 sorted(EFA_FSX_SUPPORTED_OSES),
             )
-        _log_lnet_state(scheduler_commands, remote_command_executor, partition="efa-enabled")
+        _log_lnet_state(scheduler_commands, partition="efa-enabled")
         _test_lustre_data_rail(
-            scheduler_commands,
-            remote_command_executor,
-            FSX_MOUNT_DIR,
-            expect_efa=supports_efa_for_fsx,
-            partition="efa-enabled",
+            scheduler_commands, FSX_MOUNT_DIR, expect_efa=supports_efa_for_fsx, partition="efa-enabled"
         )
         verify_directory_correctly_shared(
             remote_command_executor, FSX_MOUNT_DIR, scheduler_commands, partitions=["efa-enabled"]
@@ -495,22 +489,7 @@ def _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, p
     assert_that(result.stdout).does_not_contain("SHM transfer will be disabled because of ptrace protection")
 
 
-def _submit_and_get_output(scheduler_commands, remote_command_executor, command, partition):
-    """Submit a command on an EFA compute node, wait for it, and return the job's captured stdout.
-
-    The command runs as a Slurm job on ``partition`` (the EFA-enabled compute queue), so all EFA/Lustre
-    probing happens on a compute node, not the head node. The job's stdout is written by Slurm to
-    ``slurm-<job_id>.out`` in the submitting user's home (shared with the head node), which we then read
-    from the head node.
-    """
-    result = scheduler_commands.submit_command(command, partition=partition)
-    job_id = scheduler_commands.assert_job_submitted(result.stdout)
-    scheduler_commands.wait_job_completed(job_id)
-    scheduler_commands.assert_job_succeeded(job_id)
-    return remote_command_executor.run_remote_command(f"cat slurm-{job_id}.out").stdout
-
-
-def _test_efa_fsx_device_count(scheduler_commands, remote_command_executor, region, instance, partition=None):
+def _test_efa_fsx_device_count(scheduler_commands, region, instance, partition=None):
     """Assert LNet binds the expected number of EFA devices (regression guard for the under-bind bug).
 
     The expected count is what the setup binds by design, not the hardware EFA-device count -- see
@@ -522,11 +501,8 @@ def _test_efa_fsx_device_count(scheduler_commands, remote_command_executor, regi
     expected_efa_devices = _expected_efa_bound_devices(instance, region)
     logging.info("Instance type %s is expected to bind %s EFA interface(s) for FSx", instance, expected_efa_devices)
 
-    lnet_out = _submit_and_get_output(
-        scheduler_commands,
-        remote_command_executor,
-        "sudo lnetctl net show --net efa",
-        partition,
+    lnet_out = scheduler_commands.submit_command_and_get_output(
+        {"command": "sudo lnetctl net show --net efa", "partition": partition}
     )
     logging.info("lnetctl net show --net efa output:\n%s", lnet_out)
     # Each bound EFA interface appears as an "interfaces:" entry in the lnetctl output.
@@ -574,7 +550,7 @@ def _lnet_diagnostic_script():
     return "; ".join(f"echo ==== {label} ====; {command} || true" for label, command in _LNET_DIAGNOSTIC_COMMANDS)
 
 
-def _log_lnet_state(scheduler_commands, remote_command_executor, partition=None):
+def _log_lnet_state(scheduler_commands, partition=None):
     """Log the compute node's LNet/NID state. Pure observability: makes no assertions and changes no state.
 
     Runs as its own job rather than being folded into another test's job, because _LNET_DIAGNOSTIC_COMMANDS
@@ -585,11 +561,8 @@ def _log_lnet_state(scheduler_commands, remote_command_executor, partition=None)
 
     # NOTE: submit_command wraps this in sbatch --wrap='...', so the commands must contain no single quotes
     # (a nested single quote would close the wrap early).
-    lnet_state = _submit_and_get_output(
-        scheduler_commands,
-        remote_command_executor,
-        _lnet_diagnostic_script(),
-        partition,
+    lnet_state = scheduler_commands.submit_command_and_get_output(
+        {"command": _lnet_diagnostic_script(), "partition": partition}
     )
     logging.info("LNet state:\n%s", lnet_state)
 
@@ -610,7 +583,7 @@ def _sum_send_counts_by_net(lnet_verbose_out):
     return totals
 
 
-def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_dir, expect_efa, partition=None):
+def _test_lustre_data_rail(scheduler_commands, mount_dir, expect_efa, partition=None):
     """Assert which LNet rail carries bulk Lustre data: efa when ``expect_efa``, else tcp.
 
     Sums per-NI `send_count` per LNet net type, writes FSX_IO_TEST_MIB, sums again, and asserts on
@@ -633,16 +606,16 @@ def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_di
     logging.info("Testing that bulk Lustre data rides the @%s rail", expected_net)
 
     # NOTE: submit_command wraps this in sbatch --wrap='...', so the command must contain no single quotes.
-    io_out = _submit_and_get_output(
-        scheduler_commands,
-        remote_command_executor,
-        (
-            "sudo lnetctl net show -v; echo ===IO_BOUNDARY===; "
-            f"dd if=/dev/zero of={mount_dir}/efa_counter_test.$(hostname) "
-            f"bs=1M count={FSX_IO_TEST_MIB}; "
-            "sudo lnetctl net show -v"
-        ),
-        partition,
+    io_out = scheduler_commands.submit_command_and_get_output(
+        {
+            "command": (
+                "sudo lnetctl net show -v; echo ===IO_BOUNDARY===; "
+                f"dd if=/dev/zero of={mount_dir}/efa_counter_test.$(hostname) "
+                f"bs=1M count={FSX_IO_TEST_MIB}; "
+                "sudo lnetctl net show -v"
+            ),
+            "partition": partition,
+        }
     )
     logging.info(f"Output of bulk Lustre data on efa {io_out}")
     before_out, _, after_out = io_out.partition("===IO_BOUNDARY===")

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -10,14 +10,18 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import os
+import re
 from datetime import datetime, timedelta, timezone
 
 import boto3
 import pytest
 import xmltodict
 from assertpy import assert_that, soft_assertions
+from cfn_stacks_factory import CfnStack
+from constants import REPOSITORY_ROOT
 from remote_command_executor import RemoteCommandExecutor
-from utils import get_compute_nodes_instance_ids, get_instance_info
+from utils import generate_stack_name, get_compute_nodes_instance_ids, get_instance_info
 
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.mpi_common import _test_mpi
@@ -29,6 +33,60 @@ from tests.common.utils import (
     run_system_analyzer,
     wait_process_completion,
 )
+
+FSX_MOUNT_DIR = "/fsx"
+
+# Lustre's max_brw_size is 1 MiB, so a 4 GiB direct write is ~4096 bulk RPCs; require half on @efa to leave
+# headroom for RPC coalescing.
+FSX_EFA_COUNTER_TEST_MIB = 4096
+FSX_EFA_MIN_SEND_COUNT = FSX_EFA_COUNTER_TEST_MIB // 2
+
+# EFA interfaces the FSx setup binds, for the families where filter_efa_non_gds() drops the GDS-reserved
+# devices (p5.48xlarge exposes 32, binds 8). Instances absent from this map bind all of them.
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html#add-efa-interfaces
+FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE = {
+    "p6-b300.48xlarge": 16,
+    "p6e-gb200.36xlarge": 8,
+    "p6-b200.48xlarge": 8,
+    "p5en.48xlarge": 8,
+    "p5e.48xlarge": 8,
+    "p5.48xlarge": 8,
+}
+
+# EFA for FSx for Lustre needs more than plain EFA support: the client must be a Nitro v4 (or later)
+# instance -- the generation that introduced RDMA over EFA -- and the trn2 family is explicitly excluded.
+# Nitro v3 (EFA v1) instances still get an EFA device and pass every other EFA check in this test, but
+# LNet cannot bring up an @efa network on them, so their Lustre traffic stays on @tcp. EC2 exposes no
+# Nitro-version field, so this has to be a hand-maintained list; enumerating the *unsupported* families is
+# far shorter (and less churn-prone) than listing every Nitro v4+ EFA type.
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
+EFA_V1_NITRO_V3_FAMILIES = {
+    "c5n",
+    "dl1",
+    "dl2q",
+    "g4dn",
+    "g5",
+    "i3en",
+    "inf1",
+    "m5dn",
+    "m5n",
+    "m5zn",
+    "p3dn",
+    "p4d",
+    "p4de",
+    "r5dn",
+    "r5n",
+    "vt1",
+    "x2iezn",
+}
+# trn2/trn2u are Nitro v5 but explicitly excluded from EFA-for-Lustre support by the FSx doc.
+EFA_FSX_UNSUPPORTED_FAMILIES = EFA_V1_NITRO_V3_FAMILIES | {"trn2", "trn2u"}
+
+# EFA for FSx for Lustre is only supported on these client OSes: AL2023, RHEL 9.5+, and Ubuntu 22.04+
+# on kernel 6.8+. RHEL 8 and Rocky are not supported, so on those the client stays on @tcp even on an
+# otherwise-capable instance. See "Configuring EFA clients" in the FSx for Lustre guide.
+EFA_FSX_SUPPORTED_OSES = {"alinux2023", "rhel9", "ubuntu2204", "ubuntu2404"}
 
 # Candidate head node instance types for when compute is p* or hpc* (one per family).
 HEAD_NODE_CANDIDATES_X86 = [
@@ -91,6 +149,86 @@ def _try_reserve_head_node_instance(region, az_id, architecture, os):
     return None
 
 
+def _supports_efa_for_fsx(instance, os):
+    """Return True if ``instance``/``os`` can carry FSx for Lustre traffic over @efa.
+
+    Requires a Nitro v4+ instance (RDMA over EFA, excluding trn2) AND a supported client OS. Anything
+    else keeps its EFA device -- and passes the plain EFA checks -- but its Lustre mount rides @tcp.
+    """
+    family = instance.split(".")[0]
+    return family not in EFA_FSX_UNSUPPORTED_FAMILIES and os in EFA_FSX_SUPPORTED_OSES
+
+
+def _expected_efa_bound_devices(instance, region):
+    """Return the number of EFA interfaces the FSx-for-Lustre setup is expected to bind on ``instance``.
+
+    Instance types listed in FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE bind the curated (lower) count,
+    because the setup script's filter_efa_non_gds() reserves some devices for GDS. For every other
+    instance type that filter is a no-op -- it returns the full EFA device list -- so the setup binds
+    every EFA interface the instance has, which EC2 reports as NetworkInfo.EfaInfo.MaximumEfaInterfaces
+    (8 on trn1.32xlarge, 1 on single-EFA-interface types).
+
+    NOTE: the FSx doc's prose says instances outside its table bind "2 for other instances with multiple
+    network cards", which contradicts the script's own filter_efa_non_gds(). We assert what the script
+    does; the contradiction is raised with the FSx team separately.
+
+    EFA-for-Lustre is not p-family specific; any EFA-capable instance binds at least one interface, so
+    this returns a value for every EFA instance.
+    """
+    curated = FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE.get(instance)
+    if curated is not None:
+        return curated
+    efa_info = get_instance_info(instance, region)["NetworkInfo"].get("EfaInfo") or {}
+    return efa_info.get("MaximumEfaInterfaces", 1)
+
+
+def _provision_efa_fsx_stack(region, request, vpc_stack, cfn_stacks_factory):
+    """Provision (or reuse) the external-shared-storage stack's EFA-enabled FSx Lustre + EFA security groups.
+
+    Reuses the shared storage-stack.yaml CloudFormation template (the same one the update tests use)
+    rather than creating FSx/SGs by hand: it enables only the EFA-FSx resources -- an EfaEnabled
+    PERSISTENT_2 file system plus the two cross-referencing EFA security groups (client + file system,
+    authorizing each other by SG-ID, since SRD is authorized by SG membership, not by CIDR) -- all placed
+    in the compute-node subnet/AZ. When --external-shared-storage-stack-name is supplied, that pre-existing
+    stack is reused instead of creating a new one. Cleanup is handled by cfn_stacks_factory. Returns
+    (fsx_fs_id, client_security_group_id) from the stack outputs; the client SG rides the cluster and the
+    file-system SG (cross-referencing it) rides the file system.
+    """
+    existing_stack_name = request.config.getoption("external_shared_storage_stack_name")
+    if existing_stack_name:
+        stack = CfnStack(name=existing_stack_name, region=region, template=None)
+    else:
+        # The FSx file system must live in the same AZ (subnet) as the compute nodes for EFA to work.
+        compute_subnet_id = vpc_stack.get_private_subnet()
+        compute_subnet_az = boto3.resource("ec2", region_name=region).Subnet(compute_subnet_id).availability_zone
+        params = [
+            {"ParameterKey": "Vpc", "ParameterValue": vpc_stack.cfn_outputs["VpcId"]},
+            {"ParameterKey": "SubnetOne", "ParameterValue": compute_subnet_id},
+            # EbsVolumeAz is a required parameter even though we create no EBS; pass the compute subnet's AZ.
+            {"ParameterKey": "EbsVolumeAz", "ParameterValue": compute_subnet_az},
+            # Enable ONLY the EFA-FSx resources; everything else in the storage stack is off.
+            {"ParameterKey": "CreateEbs", "ParameterValue": "false"},
+            {"ParameterKey": "CreateEfs", "ParameterValue": "false"},
+            {"ParameterKey": "CreateFsxLustre", "ParameterValue": "false"},
+            {"ParameterKey": "CreateEfaFsxLustre", "ParameterValue": "true"},
+            {"ParameterKey": "CreateFsxOntap", "ParameterValue": "false"},
+            {"ParameterKey": "CreateFsxOpenZfs", "ParameterValue": "false"},
+            {"ParameterKey": "CreateFileCache", "ParameterValue": "false"},
+        ]
+        template_path = os.path.join(REPOSITORY_ROOT, "cloudformation/storage/storage-stack.yaml")
+        with open(template_path, encoding="utf-8") as template_file:
+            template = template_file.read()
+        stack = CfnStack(
+            name=generate_stack_name("integ-tests-efa-fsx-storage", request.config.getoption("stackname_suffix")),
+            region=region,
+            parameters=params,
+            template=template,
+            capabilities=["CAPABILITY_IAM"],
+        )
+        cfn_stacks_factory.create_stack(stack)
+    return stack.cfn_outputs["EfaFsxLustreFsId"], stack.cfn_outputs["EfaFsxLustreClientSecurityGroupId"]
+
+
 @pytest.mark.usefixtures("flags")
 def test_efa(
     os,
@@ -104,6 +242,7 @@ def test_efa(
     scheduler_commands_factory,
     request,
     vpc_stack,
+    cfn_stacks_factory,
 ):
     """
     Test all EFA Features.
@@ -116,8 +255,8 @@ def test_efa(
         head_node_instance = _try_reserve_head_node_instance(region, az_id, architecture, os)
     max_queue_size = 2
     capacity_reservation_id = None
-    # p6 family instances need capacity blocks and so placement group is set to false
-    capacity_block_instance_type = instance.startswith("p6")
+    # p5 and p6 family instances need capacity blocks, and so placement group is set to false.
+    capacity_block_instance_type = instance.startswith("p5") or instance.startswith("p6")
     placement_group_enabled = not capacity_block_instance_type
     if capacity_block_instance_type:
         capacity_reservations_ids = get_capacity_reservation_id(request, instance, region, max_queue_size, os)
@@ -128,12 +267,31 @@ def test_efa(
             logging.warn(message)
             pytest.skip(message)
 
+    # Provision the EFA-enabled FSx Lustre file system and its two cross-referencing EFA security groups
+    # (client + file system) via the shared external-shared-storage CloudFormation stack. EFA for Lustre
+    # works on any EFA-capable instance (the setup binds a per-instance-type number of EFA interfaces --
+    # see _expected_efa_bound_devices), so this runs for every EFA instance, not just p*. The cluster
+    # attaches the client SG, which cross-references the file-system SG, so EFA's SRD path (authorized by
+    # SG membership) is permitted between compute nodes and the file system. The OnNodeStart script (staged
+    # in S3) runs the official FSx EFA-Lustre client setup on each node.
+    fsx_fs_id, efa_fsx_security_group_id = _provision_efa_fsx_stack(region, request, vpc_stack, cfn_stacks_factory)
+
+    bucket_name = request.getfixturevalue("s3_bucket_factory")()
+    boto3.resource("s3", region_name=region).Bucket(bucket_name).upload_file(
+        str(test_datadir / "pcluster-efa-fsx-lustre-client-tutorial.sh"),
+        "pcluster-efa-fsx-lustre-client-tutorial.sh",
+    )
+
     slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(
         head_node_instance=head_node_instance,
         max_queue_size=max_queue_size,
         capacity_reservation_id=capacity_reservation_id,
         placement_group_enabled=placement_group_enabled,
+        fsx_mount_dir=FSX_MOUNT_DIR,
+        fsx_fs_id=fsx_fs_id,
+        fsx_efa_security_group_id=efa_fsx_security_group_id,
+        bucket_name=bucket_name,
     )
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
@@ -179,6 +337,36 @@ def test_efa(
             ).is_equal_to(0)
             assert_that(num_errors, description=f"{num_errors}/{num_tests} libfabric tests got errors").is_equal_to(0)
             assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
+
+    # EFA-for-Lustre validation (folded in from the standalone test_efa_enabled_fsx_lustre). This test runs on
+    # every EFA instance, but only Nitro v4+ instances on a supported OS can actually carry Lustre traffic over
+    # @efa (see _supports_efa_for_fsx). Either way the data path is measured the same way -- send_count deltas
+    # across bulk direct I/O -- and only the expected rail flips, so the EFA v1 instances guard against a
+    # half-configured client instead of being skipped. The mount must work either way, so the read/write check
+    # is unconditional.
+    supports_efa_for_fsx = _supports_efa_for_fsx(instance, os)
+    with soft_assertions():
+        if supports_efa_for_fsx:
+            _test_efa_fsx_device_count(
+                scheduler_commands, remote_command_executor, region, instance, partition="efa-enabled"
+            )
+        else:
+            logging.info(
+                "Instance %s on %s does not support EFA for FSx for Lustre (needs Nitro v4+ and one of %s); "
+                "asserting the Lustre mount falls back to @tcp instead",
+                instance,
+                os,
+                sorted(EFA_FSX_SUPPORTED_OSES),
+            )
+        _log_lnet_state(scheduler_commands, remote_command_executor, partition="efa-enabled")
+        _test_lustre_data_rail(
+            scheduler_commands,
+            remote_command_executor,
+            FSX_MOUNT_DIR,
+            expect_efa=supports_efa_for_fsx,
+            partition="efa-enabled",
+        )
+        _test_fsx_read_write(scheduler_commands, remote_command_executor, FSX_MOUNT_DIR, partition="efa-enabled")
 
 
 def _test_efa_eni_configuration(cluster, region):
@@ -311,3 +499,211 @@ def _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, p
     scheduler_commands.assert_job_succeeded(job_id)
     result = remote_command_executor.run_remote_command("cat /shared/fi_info.out")
     assert_that(result.stdout).does_not_contain("SHM transfer will be disabled because of ptrace protection")
+
+
+def _submit_and_get_output(scheduler_commands, remote_command_executor, command, partition):
+    """Submit a command on an EFA compute node, wait for it, and return the job's captured stdout.
+
+    The command runs as a Slurm job on ``partition`` (the EFA-enabled compute queue), so all EFA/Lustre
+    probing happens on a compute node, not the head node. The job's stdout is written by Slurm to
+    ``slurm-<job_id>.out`` in the submitting user's home (shared with the head node), which we then read
+    from the head node.
+    """
+    result = scheduler_commands.submit_command(command, partition=partition)
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    return remote_command_executor.run_remote_command(f"cat slurm-{job_id}.out").stdout
+
+
+def _test_efa_fsx_device_count(scheduler_commands, remote_command_executor, region, instance, partition=None):
+    """Assert LNet binds the expected number of EFA devices (regression guard for the under-bind bug).
+
+    The expected count is what the setup script binds by design, not the hardware EFA-device count: the
+    curated FSX_EFA_BOUND_DEVICES_BY_INSTANCE_TYPE value for the GDS-filtered p-families, otherwise EC2's
+    MaximumEfaInterfaces. Lustre silently falls back to TCP on any unbound device.
+    """
+    logging.info("Testing that LNet binds the expected number of EFA devices for FSx")
+
+    expected_efa_devices = _expected_efa_bound_devices(instance, region)
+    logging.info("Instance type %s is expected to bind %s EFA interface(s) for FSx", instance, expected_efa_devices)
+
+    lnet_out = _submit_and_get_output(
+        scheduler_commands,
+        remote_command_executor,
+        "sudo lnetctl net show --net efa",
+        partition,
+    )
+    logging.info("lnetctl net show --net efa output:\n%s", lnet_out)
+    # Each bound EFA interface appears as an "interfaces:" entry in the lnetctl output.
+    bound_efa_interfaces = lnet_out.count("interfaces:")
+    assert_that(
+        bound_efa_interfaces,
+        description=(
+            f"LNet bound {bound_efa_interfaces} EFA interface(s) but {instance} is expected to bind "
+            f"{expected_efa_devices}; Lustre would fall back to TCP on the unbound devices"
+        ),
+    ).is_equal_to(expected_efa_devices)
+
+
+# Read-only LNet state commands, as (label, command) pairs. Between them they show every NID the node knows:
+# the local NIs and their bound devices, the peer table with each peer's rails, the mount target NID, and the
+# PCI address of each EFA device -- enough to tell which peer NIDs are served by something and how a real
+# @efa NID is derived from its device (<host IP octet 3>.<octet 4>.<PCI bus>.<PCI devfn>@efa).
+# The osc imports are captured for diagnostics only: an import's connection nid does not reliably tell us
+# which transport carries the data (under Multi-Rail, ptlrpc connects to the peer's primary nid and LNet
+# picks the rail beneath it), so nothing asserts on it -- _test_lustre_data_rail measures the rail instead.
+_LNET_DIAGNOSTIC_COMMANDS = (
+    ("lustre mounts", "grep lustre /proc/mounts"),
+    ("osc imports", 'sudo lctl get_param "osc.*.import"'),
+    ("lctl list_nids", "sudo lctl list_nids"),
+    ("lnetctl net show -v", "sudo lnetctl net show -v"),
+    ("lnetctl peer show -v", "sudo lnetctl peer show -v"),
+    ("lnetctl global show", "sudo lnetctl global show"),
+    ("lnetctl route show", "sudo lnetctl route show"),
+    ("lnetctl stats show", "sudo lnetctl stats show"),
+    ("host addresses", "ip -o -4 addr show"),
+    (
+        "efa device pci addresses",
+        "for dev in /sys/class/infiniband/*; do echo $dev pci=$(readlink -f $dev/device); done",
+    ),
+)
+
+
+def _lnet_diagnostic_script():
+    """Return a shell snippet dumping every read-only LNet/NID command under a ==== <label> ==== marker.
+
+    Failures are tolerated: a net or route may legitimately be absent, and this is diagnostic output, not an
+    assertion. Contains no `lnetctl ping` -- a ping inserts a peer entry for whatever NID it targets, even
+    when it fails, so running one here would corrupt the very state we are trying to observe.
+    """
+    return "; ".join(f"echo ==== {label} ====; {command} || true" for label, command in _LNET_DIAGNOSTIC_COMMANDS)
+
+
+def _log_lnet_state(scheduler_commands, remote_command_executor, partition=None):
+    """Log the compute node's LNet/NID state. Pure observability: makes no assertions and changes no state.
+
+    Runs as its own job rather than being folded into another test's job, because _LNET_DIAGNOSTIC_COMMANDS
+    includes `lnetctl net show -v` and _test_lustre_data_rail sums send_count from exactly that output on each
+    side of its I/O boundary -- an extra copy in that job would corrupt its delta math.
+    """
+    logging.info("Collecting LNet state from an EFA compute node")
+
+    # NOTE: submit_command wraps this in sbatch --wrap='...', so the commands must contain no single quotes
+    # (a nested single quote would close the wrap early).
+    lnet_state = _submit_and_get_output(
+        scheduler_commands,
+        remote_command_executor,
+        _lnet_diagnostic_script(),
+        partition,
+    )
+    logging.info("LNet state:\n%s", lnet_state)
+
+
+def _sum_send_counts_by_net(lnet_verbose_out):
+    """Sum the per-NI send_count statistics per LNet net type from `lnetctl net show -v` output."""
+    totals = {}
+    net_type = None
+    for line in lnet_verbose_out.splitlines():
+        net_match = re.match(r"\s*- net type:\s*(\S+)", line)
+        if net_match:
+            net_type = net_match.group(1)
+            totals.setdefault(net_type, 0)
+            continue
+        send_match = re.match(r"\s*send_count:\s*(\d+)", line)
+        if send_match and net_type:
+            totals[net_type] += int(send_match.group(1))
+    return totals
+
+
+def _test_lustre_data_rail(scheduler_commands, remote_command_executor, mount_dir, expect_efa, partition=None):
+    """Assert which LNet rail carries bulk Lustre data: @efa when ``expect_efa``, else @tcp.
+
+    Sums per-NI `send_count` per LNet net type, writes FSX_EFA_COUNTER_TEST_MIB of direct I/O, sums again,
+    and asserts on the deltas. The measurement is identical either way; only the expectation flips:
+
+    * ``expect_efa``: @efa must gain at least FSX_EFA_MIN_SEND_COUNT sends and gain more than @tcp. Metadata
+      RPCs and pings ride @tcp by design, so this is an ordering, not `tcp_delta == 0`.
+    * otherwise: @tcp must gain at least FSX_EFA_MIN_SEND_COUNT sends and @efa must gain exactly none. No
+      @efa net comes up on these nodes, so there is no efa NI to accumulate sends -- an exact assertion is
+      available here, unlike in the @efa direction.
+
+    Counters rather than the import: the import's connection nid does not reliably tell us which transport
+    carries the data, so do not assert on `osc.*.import`.
+    """
+    expected_net = "efa" if expect_efa else "tcp"
+    logging.info("Testing that bulk Lustre data rides the @%s rail", expected_net)
+
+    # NOTE: submit_command wraps this in sbatch --wrap='...', so the command must contain no single quotes.
+    # oflag=direct is load-bearing; we test before/after counter delta.
+    # Buffered writes could sit in cache and turn into RPCs after the second lnetctl net show -v sample,
+    # so a healthy client would show efa_delta ≈ 0. O_DIRECT guarantees the 4 GiB becomes bulk RPCs inside the measurement window.
+    io_out = _submit_and_get_output(
+        scheduler_commands,
+        remote_command_executor,
+        (
+            "sudo lnetctl net show -v; echo ===IO_BOUNDARY===; "
+            f"dd if=/dev/zero of={mount_dir}/efa_counter_test.$(hostname) "
+            f"bs=1M count={FSX_EFA_COUNTER_TEST_MIB} oflag=direct; sync; "
+            "sudo lnetctl net show -v"
+        ),
+        partition,
+    )
+    logging.info(f"Output of bulk Lustre data on efa {io_out}")
+    before_out, _, after_out = io_out.partition("===IO_BOUNDARY===")
+    before = _sum_send_counts_by_net(before_out)
+    after = _sum_send_counts_by_net(after_out)
+    efa_delta = after.get("efa", 0) - before.get("efa", 0)
+    tcp_delta = after.get("tcp", 0) - before.get("tcp", 0)
+    logging.info(
+        "LNet send_count deltas over %s MiB of direct I/O: efa=%s tcp=%s (before=%s, after=%s)",
+        FSX_EFA_COUNTER_TEST_MIB,
+        efa_delta,
+        tcp_delta,
+        before,
+        after,
+    )
+
+    expected_delta = efa_delta if expect_efa else tcp_delta
+    assert_that(
+        expected_delta,
+        description=(
+            f"only {expected_delta} LNet sends landed on @{expected_net} over {FSX_EFA_COUNTER_TEST_MIB} MiB "
+            f"of direct I/O (efa={efa_delta}, tcp={tcp_delta}); bulk Lustre data is not riding the "
+            f"@{expected_net} rail"
+        ),
+    ).is_greater_than_or_equal_to(FSX_EFA_MIN_SEND_COUNT)
+
+    if expect_efa:
+        assert_that(
+            efa_delta,
+            description=(
+                f"@tcp carried more LNet sends ({tcp_delta}) than @efa ({efa_delta}) during bulk I/O; "
+                "Lustre appears to have fallen back to TCP"
+            ),
+        ).is_greater_than(tcp_delta)
+    else:
+        # No @efa net comes up on these nodes, so any send on it means LNet configured a rail it cannot use.
+        assert_that(
+            efa_delta,
+            description=(
+                f"{efa_delta} LNet sends landed on @efa during bulk I/O, but this node cannot carry Lustre "
+                "over EFA; an @efa rail was configured and used unexpectedly"
+            ),
+        ).is_equal_to(0)
+
+
+def _test_fsx_read_write(scheduler_commands, remote_command_executor, mount_dir, partition=None):
+    """Assert a basic write/read round-trip to the mounted FSx file system succeeds."""
+    logging.info("Testing basic write/read to the mounted FSx file system")
+
+    marker = "hello-efa-fsx-lustre"
+    test_file = f"{mount_dir}/efa_fsx_lustre_test.txt"
+    rw_out = _submit_and_get_output(
+        scheduler_commands,
+        remote_command_executor,
+        f"echo '{marker}' > {test_file} && sync && cat {test_file}",
+        partition,
+    )
+    logging.info("FSx write/read output:\n%s", rw_out)
+    assert_that(rw_out).contains(marker)

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+# OnNodeStart wrapper for the "Creating a cluster with an EFA-enabled FSx Lustre" tutorial:
+# https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-efa-enabled-fsx-lustre.html
+#
+# It downloads the OFFICIAL FSx "configure-efa-fsx-lustre-client" package straight from the FSx
+# for Lustre documentation endpoint and runs its setup.sh, exactly as documented in "Configuring
+# EFA clients": https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
+# We author no EFA/LNet logic here; setup.sh (from the official package) is the source of truth.
+set -euo pipefail
+
+cd /tmp
+curl -O https://docs.aws.amazon.com/fsx/latest/LustreGuide/samples/configure-efa-fsx-lustre-client.zip
+unzip -o configure-efa-fsx-lustre-client.zip
+cd configure-efa-fsx-lustre-client
+
+# Configure the FSx Lustre client to use EFA.
+sudo ./setup.sh

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
@@ -18,12 +18,25 @@
 # for Lustre documentation endpoint and runs its setup.sh, exactly as documented in "Configuring
 # EFA clients": https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 # We author no EFA/LNet logic here; setup.sh (from the official package) is the source of truth.
+# Attached as OnNodeStart only where EFA for Lustre is supported (see pcluster.config.yaml).
 set -euo pipefail
 
 cd /tmp
 curl -O https://docs.aws.amazon.com/fsx/latest/LustreGuide/samples/configure-efa-fsx-lustre-client.zip
 unzip -o configure-efa-fsx-lustre-client.zip
 cd configure-efa-fsx-lustre-client
+
+# setup.sh sets the libcfs `cpu_npartitions` module option, which only applies at module insert time, so it
+# has to be the one that inserts libcfs. The AMI loads lnet at boot, leaving libcfs resident with its
+# default 2 partitions, and setup.sh then binds only 2 EFA devices. See V2331124295.
+# Safe here: OnNodeStart runs before any shared storage is mounted, and setup.sh reinserts the stack.
+# TODO: Revert the unloading of modules once configure-efa-fsx-lustre-client.zip handles module loading
+echo "Unloading the boot-loaded Lustre/LNet stack so setup.sh owns the libcfs module insert"
+sudo lnetctl lnet unconfigure || true
+sudo lustre_rmmod || sudo modprobe -r kefalnd ksocklnd lustre lnet libcfs || true
+if lsmod | grep -q "^libcfs"; then
+  echo "WARNING: libcfs is still loaded; setup.sh will ignore cpu_npartitions and under-bind EFA devices." >&2
+fi
 
 # Configure the FSx Lustre client to use EFA.
 sudo ./setup.sh

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster-efa-fsx-lustre-client-tutorial.sh
@@ -26,10 +26,8 @@ curl -O https://docs.aws.amazon.com/fsx/latest/LustreGuide/samples/configure-efa
 unzip -o configure-efa-fsx-lustre-client.zip
 cd configure-efa-fsx-lustre-client
 
-# setup.sh sets the libcfs `cpu_npartitions` module option, which only applies at module insert time, so it
-# has to be the one that inserts libcfs. The AMI loads lnet at boot, leaving libcfs resident with its
-# default 2 partitions, and setup.sh then binds only 2 EFA devices. See V2331124295.
-# Safe here: OnNodeStart runs before any shared storage is mounted, and setup.sh reinserts the stack.
+# libcfs applies setup.sh's `cpu_npartitions` only at insert time, so unless setup.sh does the insert only
+# 2 EFA devices bind (V2331124295). Safe: nothing is mounted yet and setup.sh reinserts the stack.
 # TODO: Revert the unloading of modules once configure-efa-fsx-lustre-client.zip handles module loading
 echo "Unloading the boot-loaded Lustre/LNet stack so setup.sh owns the libcfs module insert"
 sudo lnetctl lnet unconfigure || true

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -41,10 +41,10 @@ Scheduling:
       CustomActions:
         OnNodeStart:
           Script: s3://{{ bucket_name }}/pcluster-efa-fsx-lustre-client-tutorial.sh
-      {% endif %}
       Iam:
         S3Access:
           - BucketName: {{ bucket_name }}
+      {% endif %}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -37,7 +37,7 @@ Scheduling:
           Efa:
             Enabled: true
       {% if supports_efa_for_fsx %}
-      # Unsupported instances/OSes skip the FSx EFA setup and mount the same file system over @tcp.
+      # Unsupported instances/OSes skip the FSx EFA setup and mount the same file system over tcp.
       CustomActions:
         OnNodeStart:
           Script: s3://{{ bucket_name }}/pcluster-efa-fsx-lustre-client-tutorial.sh

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -5,6 +5,8 @@ HeadNode:
   Networking:
     SubnetId: {{ public_subnet_id }}
     ElasticIp: true
+    AdditionalSecurityGroups:
+      - {{ fsx_efa_security_group_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -24,6 +26,8 @@ Scheduling:
           {% if placement_group_enabled and capacity_reservation_framework_placement_group %}Name: {{ capacity_reservation_framework_placement_group }}{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
+        AdditionalSecurityGroups:
+          - {{ fsx_efa_security_group_id }}
       ComputeResources:
         - Name: efa-enabled-i1
           InstanceType: {{ instance }}
@@ -32,7 +36,18 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
+      CustomActions:
+        OnNodeStart:
+          Script: s3://{{ bucket_name }}/pcluster-efa-fsx-lustre-client-tutorial.sh
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
 SharedStorage:
   - MountDir: /shared
     Name: name1
     StorageType: Ebs
+  - MountDir: {{ fsx_mount_dir }}
+    Name: fsx-efa
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      FileSystemId: {{ fsx_fs_id }}

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -36,9 +36,12 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
+      {% if supports_efa_for_fsx %}
+      # Unsupported instances/OSes skip the FSx EFA setup and mount the same file system over @tcp.
       CustomActions:
         OnNodeStart:
           Script: s3://{{ bucket_name }}/pcluster-efa-fsx-lustre-client-tutorial.sh
+      {% endif %}
       Iam:
         S3Access:
           - BucketName: {{ bucket_name }}


### PR DESCRIPTION
### Description of changes
* Modify test_efa to test tutorial https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-efa-enabled-fsx-lustre.html
 * Run EFA with FSxL tutorail only when  supported OS and Instance type are being used
* Provision EFA FSx Lustre via shared storage stack
* Dump LNet state for future debugging
* Assert Lustre rides EFA by LNet send counters, not the import paramters; write 4 GiB of direct I/O to the mount, sum again, then require efa to gain at least half the expected bulk RPCs and more than tcp gained. Metadata RPCs and pings ride tcp by design, so the second check is an ordering rather than tcp_delta == 0.
* All the Nics for trn1.32xlareg instance are supposed to be bound unlike what Fsx specifies in their doc https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html#add-efa-interfaces


### Tests
* Integ test with https://github.com/aws/aws-parallelcluster-cookbook/pull/3267
```  
efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: [{{ c6gn_16xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_OS_ARM_0 }}]
          instances: ["c6gn.16xlarge"] # Single Nic
          oss: [{{ OS_ARM_0 }}]
          schedulers: ["slurm"]
        - regions: ["usw2-az4"]
          schedulers: ["slurm"]
          oss: ["ubuntu2404"]
          instances: ["trn1.32xlarge"] # Multi Nic
        - regions: [{{ c5n_18xlarge_CAPACITY_RESERVATION_2_INSTANCES_1_HOURS_YESPG_OS_X86_0 }}]
          instances: ["c5n.18xlarge"]  # No support for efa+FsxL feature
          oss: [{{ OS_X86_0 }}]
          schedulers: ["slurm"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
