### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           - Python 3.11 Tests
           - Python 3.12 Tests
           - Python 3.13 Tests
+          - Python 3.14 Tests
           - Python 3.10 Tests Coverage
           - Code Checks
           - CLI CloudFormation Templates Checks
@@ -63,6 +64,10 @@ jobs:
             python: '3.13'
             toxdir: cli
             toxenv: py313-nocov
+          - name: Python 3.14 Tests
+            python: '3.14'
+            toxdir: cli
+            toxenv: py314-nocov
           - name: Python 3.10 Tests Coverage
             python: '3.10'
             toxdir: cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 - Improve `export-logs` user experience by parallelizing download to reduce run time, 
   adding progress reporting, and supporting running on deleted clusters.
 
+**CHANGES**
+- Add support for Python 3.14 in the pcluster CLI.
+
 **BUG FIXES**
 - Fixed issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, 
 the validator fails with a clear error message instead of a generic `NoneType` error.

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -93,6 +93,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
     ],

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Set
 
+from pcluster.utils import event_loop
 from pcluster.validators.common import AsyncValidator, FailureLevel, ValidationResult, Validator, ValidatorContext
 from pcluster.validators.dev_settings_validators import ExtraChefAttributesValidator
 from pcluster.validators.iam_validators import AdditionalIamPolicyValidator
@@ -208,11 +209,9 @@ class Resource:
         # if they are taking too long to execute for a resource and its children since the use of
         # get_async_timed_validator_type_for allows to decorate only on single validator at a time and
         # does not cascade to child resources
-        return list(
-            itertools.chain.from_iterable(
-                asyncio.get_event_loop().run_until_complete(asyncio.gather(*self._validation_futures))
-            )
-        )
+        with event_loop() as loop:
+            validation_results = loop.run_until_complete(asyncio.gather(*self._validation_futures))
+        return list(itertools.chain.from_iterable(validation_results))
 
     def _nested_resources(self):
         nested_resources = []

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -23,6 +23,7 @@ import time
 import urllib
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from hashlib import sha256
 from importlib.metadata import version
 from importlib.resources import files  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
@@ -472,6 +473,29 @@ def batch_by_property_callback(items, property_callback: Callable[..., int], bat
             yield current_batch
 
 
+@contextmanager
+def event_loop():
+    """Provide an asyncio event loop, closing it on exit if this context created it.
+
+    This is required to support Python 3.14, where asyncio.get_event_loop() raises a RuntimeError
+    when there is no running loop instead of implicitly creating one. If a loop is already running
+    it is reused and left open (the caller does not own it); otherwise a new loop is created and
+    closed on exit to avoid leaking event loops.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        created = False
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        created = True
+    try:
+        yield loop
+    finally:
+        if created:
+            loop.close()
+
+
 class AsyncUtils:
     """Utility class for async functions."""
 
@@ -548,7 +572,7 @@ class AsyncUtils:
 
         @functools.wraps(func)
         async def wrapper(self, *args, **kwargs):
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 AsyncUtils._thread_pool_executor, lambda: func(self, *args, **kwargs)
             )
 

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import List
 
 from pcluster.aws.common import AWSClientError
+from pcluster.utils import event_loop
 
 ASYNC_TIMED_VALIDATORS_DEFAULT_TIMEOUT_SEC = 10
 
@@ -84,7 +85,8 @@ class AsyncValidator(Validator):
         super().__init__()
 
     def _validate(self, *arg, **kwargs):
-        asyncio.get_event_loop().run_until_complete(self._validate_async(*arg, **kwargs))
+        with event_loop() as loop:
+            loop.run_until_complete(self._validate_async(*arg, **kwargs))
         return self._failures
 
     async def execute_async(self, *arg, **kwargs) -> List[ValidationResult]:

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -548,7 +548,8 @@ class TestAsyncUtils(unittest.TestCase):
                 executions.append(FakeAsyncMethodProvider().async_method(i))
                 expected_results.append(i)
 
-        results = asyncio.get_event_loop().run_until_complete(asyncio.gather(*executions))
+        with utils.event_loop() as loop:
+            results = loop.run_until_complete(asyncio.gather(*executions))
 
         assert_that(expected_results).contains_sequence(*results)
         assert_that(unique_calls).is_equal_to(total_calls)

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{39,310,311,312,313}-{cov,nocov}
+    py{39,310,311,312,313,314}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 


### PR DESCRIPTION
### Description of changes
* Add support for Python 3.14 to the ParallelCluster CLI.
  1. Replace deprecated `asyncio.get_event_loop()` calls with a new utility function.
In Python 3.14, `get_event_loop()` raises `RuntimeError` when no event loop is running instead of implicitly creating one.
This is documented in Python official doc: https://docs.python.org/3.14/whatsnew/3.14.html#asyncio
  2. Add explicit support for Python 3.14.
  3. Enable unit tests for Python 3.14
  
### Tests
* Manually verified that the CLI works with Python 3.13 and 3.14
* Unit tests

### References
* Based off of: https://github.com/aws/aws-parallelcluster/pull/7149

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
