### PR TITLE
[integ-tests] Increase the number of instances reserved for build image test

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -139,11 +139,11 @@ test-suites:
           oss: [{{ OS_X86_3 }}]
     test_createami.py::test_build_image:
       dimensions:
-        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_3_HOURS_NOPG_rhel9 }}]
+        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_6_INSTANCES_3_HOURS_NOPG_rhel9 }}] # Each test requires 3 instances (1 head node + 2 compute nodes)
           instances: ["g4dn.2xlarge"]
           oss: {{ RHEL_OS_X86 }}
           schedulers: ["slurm"]
-        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_10_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
+        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_15_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
           instances: ["g4dn.2xlarge"]
           oss: {{ NO_RHEL_OS_X86 }}
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -81,11 +81,11 @@ test-suites:
           oss: ["alinux2023"]
     test_createami.py::test_build_image:
       dimensions:
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_4_INSTANCES_3_HOURS_NOPG_rhel9 }} ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_6_INSTANCES_3_HOURS_NOPG_rhel9 }} ]  # Each test requires 3 instances (1 head node + 2 compute nodes)
           instances: [ "g4dn.2xlarge" ]
           oss: {{ RHEL_OS_X86 }}
           schedulers: [ "slurm" ]
-        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_10_INSTANCES_3_HOURS_NOPG_ubuntu2404 }} ]
+        - regions: [ {{ g4dn_2xlarge_CAPACITY_RESERVATION_15_INSTANCES_3_HOURS_NOPG_ubuntu2404 }} ]
           instances: [ "g4dn.2xlarge" ]
           oss: {{ NO_RHEL_OS_X86 }}
           schedulers: [ "slurm" ]


### PR DESCRIPTION
### Description of changes
https://github.com/aws/aws-parallelcluster/blame/develop/tests/integration-tests/tests/createami/test_createami.py#L282 shows that each test requires 3 instances


### Tests
* Tests will run after PR is merged

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
