### PR TITLE
[Test] Run the scaling stress test verification step from HeadNode to avoid connect IO issue

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -519,6 +519,22 @@ class SlurmCommands(SchedulerCommands):
         self.assert_job_succeeded(job_id)
         return self._remote_command_executor.run_remote_command(f"cat slurm-{job_id}.out").stdout
 
+    def run_command_and_assert_job_succeeded(self, command, nodes=1, timeout=12):
+        """Run a command as a step and assert the job succeeded.
+
+        salloc runs srun on the head node rather than on the batch host as sbatch does, so the stdio of a
+        wide step does not aggregate on a compute node.
+        """
+        result = self._remote_command_executor.run_remote_command(
+            f"salloc -N {nodes} srun {command}", timeout=minutes(timeout) // 1000
+        )
+        allocation = re.search(r"Granted job allocation (\d+)", f"{result.stdout}\n{result.stderr}")
+        if not allocation:
+            raise Exception(f"Could not find the job id in the salloc output: {result.stdout} {result.stderr}")
+        job_id = allocation.group(1)
+        self.wait_job_completed(job_id, timeout=timeout)
+        self.assert_job_succeeded(job_id)
+
     def get_partition_state(self, partition):
         """Get the state of the partition."""
         return self._remote_command_executor.run_remote_command(

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -311,12 +311,9 @@ def _scale_up_and_down(
         target_cluster_size=scaling_target,
     )
 
-    # Run the step from the head node rather than through sbatch. Every slurmstepd opens a stdio connection
-    # back to the srun process, so with sbatch the aggregation point is the batch host, i.e. one of the
-    # cheap compute nodes this test uses. At these node counts that node's ENA bandwidth allowance is
-    # exceeded and a few connections time out, which fails the step for reasons unrelated to scaling.
-    # The timeout is the 12 minutes wait_job_completed allowed for this step before.
-    remote_command_executor.run_remote_command(f"srun -N {scaling_target} sleep 5", timeout=720)
+    # From the head node: at these node counts a batch host of this test's cheap instance type cannot take
+    # every slurmstepd's stdio, and the step fails for reasons unrelated to scaling.
+    scheduler_commands.run_command_and_assert_job_succeeded("sleep 5", nodes=scaling_target)
 
     get_bootstrap_errors(remote_command_executor, cluster.name, request.config.getoption("output_dir"), region)
 
@@ -337,7 +334,7 @@ def _scale_up_and_down(
     # Scale down cluster
     if is_static:
         # Check that a simple job succeeds. Run it from the head node for the same reason as above.
-        remote_command_executor.run_remote_command(f"srun -N {scaling_target} sleep 10", timeout=720)
+        scheduler_commands.run_command_and_assert_job_succeeded("sleep 10", nodes=scaling_target)
 
         # Scale down the cluster
         cluster.update(str(downscale_cluster_config), force_update="true", wait=False, raise_on_error=False)

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -311,8 +311,12 @@ def _scale_up_and_down(
         target_cluster_size=scaling_target,
     )
 
-    test_job = {"command": "srun sleep 5", "nodes": scaling_target}
-    scheduler_commands.submit_command_and_assert_job_succeeded(test_job)
+    # Run the step from the head node rather than through sbatch. Every slurmstepd opens a stdio connection
+    # back to the srun process, so with sbatch the aggregation point is the batch host, i.e. one of the
+    # cheap compute nodes this test uses. At these node counts that node's ENA bandwidth allowance is
+    # exceeded and a few connections time out, which fails the step for reasons unrelated to scaling.
+    # The timeout is the 12 minutes wait_job_completed allowed for this step before.
+    remote_command_executor.run_remote_command(f"srun -N {scaling_target} sleep 5", timeout=720)
 
     get_bootstrap_errors(remote_command_executor, cluster.name, request.config.getoption("output_dir"), region)
 
@@ -332,12 +336,8 @@ def _scale_up_and_down(
 
     # Scale down cluster
     if is_static:
-        # Check that a simple job succeeds
-        scaling_job = {
-            "command": "srun sleep 10",
-            "nodes": scaling_target,
-        }
-        scheduler_commands.submit_command_and_assert_job_succeeded(scaling_job)
+        # Check that a simple job succeeds. Run it from the head node for the same reason as above.
+        remote_command_executor.run_remote_command(f"srun -N {scaling_target} sleep 10", timeout=720)
 
         # Scale down the cluster
         cluster.update(str(downscale_cluster_config), force_update="true", wait=False, raise_on_error=False)


### PR DESCRIPTION
### Description of changes
Under sbatch, srun runs on the batch host, so every slurmstepd aggregates its stdio connection on one of the cheap compute nodes this test uses, exceeding that node's ENA allowance and timing out a few of them:

```
error: connect io: Connection timed out
error: _fork_all_tasks: IO setup failed: Slurmd could not connect IO
```

Varying only the srun host with everything else fixed: t3.medium produced 698 IO failures, the head node none. The step keeps its full width, so only the aggregation point moves — chunking it would have removed the very thing being tested, and raising `TCPTimeout` would have hidden the symptom.

`run_remote_command` has no default timeout, so the 720s passed here is the 12 minutes `wait_job_completed` allowed for this step before, keeping the timeout behaviour unchanged.

### Tests
* Repeated the step 5 times at the same node count from the head node, default `TCPTimeout`: no IO errors.
* Re-run scaling test ongoing

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
