### PR TITLE
[Test] Add to test RCA analysis: system messages and system journal.

### DIFF
--- a/tests/integration-tests/diagnosis_utils.py
+++ b/tests/integration-tests/diagnosis_utils.py
@@ -28,6 +28,8 @@ RCA_LOG_FILES = [
     "/var/log/parallelcluster/slurmctld.log",
 ]
 RCA_HEAD_NODE_CONSOLE_OUTPUT = "HeadNode Console Output"
+RCA_JOURNALCTL = "Journal"
+CMD_JOURNALCTL_ERRORS = "sudo journalctl -b -p err --no-pager"
 PATTERN_GENERIC_FAILURE = r"error|fail|fatal|exception|critical"
 PATTERN_CHEF_ERROR = r"(ERROR|FATAL):"
 PATTERN_ICE_ERROR = r"InsufficientInstanceCapacity.*?sufficient\s+(\S+)\s+capacity"
@@ -43,6 +45,11 @@ PATTERN_CHEF_CLIENT_LOG_BLOCK = re.compile(
     r"[^\n]*BEGIN CHEF-CLIENT\.LOG[^\n]*.*?[^\n]*END CHEF-CLIENT\.LOG[^\n]*",
     re.DOTALL,
 )
+
+
+def system_messages_log(os):
+    """Return the system messages log path for the given OS: syslog on Ubuntu, messages elsewhere."""
+    return "/var/log/syslog" if os.startswith("ubuntu") else "/var/log/messages"
 
 
 def retrieve_console_errors(region, instance_id):
@@ -78,6 +85,26 @@ def retrieve_console_errors(region, instance_id):
     except Exception as e:
         logging.warning("Exception retrieving console output: %s", e)
         return f"Failed to retrieve console output: {e}"
+
+
+def retrieve_journalctl_errors(rce, num_errors=200):
+    """
+    Retrieve error-priority (>= err) lines from the systemd journal for the current boot.
+
+    Bootstrap failures often abort a service before it starts because one of its dependencies
+    failed (e.g. nfs-server.service reporting "A dependency job ... failed"). The reason lives
+    only in the systemd journal, not in any of RCA_LOG_FILES.
+
+    Requires SSH access to the head node and sudo to read the system journal.
+
+    :param rce: Remote command executor instance.
+    :param num_errors: Max journal error lines to keep.
+    :return: Journal error lines, or a message if none found / retrieval failed.
+    """
+    result = rce.run_remote_command(CMD_JOURNALCTL_ERRORS, raise_on_error=True, log_error=False)
+    if not result.stdout.strip():
+        return "No error found"
+    return "\n".join(result.stdout.strip().splitlines()[-num_errors:])
 
 
 def extract_ice_from_rca_details(rca_details):
@@ -121,7 +148,9 @@ def retrieve_rca_details(cluster, num_errors=10):
     rce = RemoteCommandExecutor(cluster)
 
     rca_details["SUMMARY"] = ["No root cause found"]
-    for log_path in RCA_LOG_FILES:
+    # Add the OS-specific system messages log.
+    log_files = RCA_LOG_FILES + [system_messages_log(cluster.os)]
+    for log_path in log_files:
         try:
             if log_path == "/var/log/chef-client.log":
                 matches = find_all_matches_in_log(rce, log_path, PATTERN_CHEF_ERROR, num_errors, case_sensitive=True)
@@ -130,6 +159,10 @@ def retrieve_rca_details(cluster, num_errors=10):
             rca_details[log_path] = "\n".join(matches) if matches else "No error found"
         except Exception as e:
             logging.warning("Failed to retrieve RCA details from log %s: %s", log_path, e)
+    try:
+        rca_details[RCA_JOURNALCTL] = retrieve_journalctl_errors(rce)
+    except Exception as e:
+        logging.warning("Failed to retrieve journalctl RCA details: %s", e)
 
     rce.close_connection()
 

--- a/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pre_install.sh
+++ b/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pre_install.sh
@@ -8,6 +8,9 @@ done
 
 case $# in
     3)
+        sudo mkdir -p /etc/systemd/system/nfs-mountd.service.d
+        printf '[Service]\nExecStartPre=/bin/false\n' | sudo tee /etc/systemd/system/nfs-mountd.service.d/inject-fail.conf
+        sudo systemctl daemon-reload
         exit 0
     ;;
     *)


### PR DESCRIPTION
### Description of changes
Add to test RCA analysis: system messages and system journal.
Now when the cluster creation fails, the RCA utility returns the errors from both system messages and system journal.

This analysis would be helpful to troubleshoot cluster creation failures caused by transient system service failing to start. A recent observation was on NFS service failing to start without any clue about the root cause.

### Tests
1. Manual verification: injected a failure into the NFS start and verified that the journalctl command is able to identify the root cause.
```
[root@ip-27-6-45-152 ~]# sudo systemctl stop nfs-server
[root@ip-27-6-45-152 ~]# sudo mkdir -p /etc/systemd/system/nfs-mountd.service.d
printf '[Service]\nExecStartPre=/bin/false\n' | \
  sudo tee /etc/systemd/system/nfs-mountd.service.d/inject-fail.conf
sudo systemctl daemon-reload
[Service]
ExecStartPre=/bin/false
[root@ip-27-6-45-152 ~]# sudo systemctl start nfs-server
A dependency job for nfs-server.service failed. See 'journalctl -xe' for details.

[root@ip-27-6-45-152 ~]# sudo journalctl -b -p err --no-pager
...
Sep 01 19:22:26 ip-27-6-45-152 systemd[1]: Failed to start nfs-mountd.service - NFS Mount Daemon.
```

2. SUCCESS Happy Path:
```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: [{{ US_EAST_1_INSTANCE_TYPE_0_xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_DCV_OS_X86_1__g5g_2xlarge_CAPACITY_RESERVATION_1_INSTANCES_1_HOURS_NOPG_DCV_OS_X86_1 }}]
          instances: [{{ US_EAST_1_INSTANCE_TYPE_0 }}.xlarge]
          oss: [{{ DCV_OS_X86_1 }}]
          schedulers: ["slurm"]
```

3. SUCCESS Unhappy Path:  Same integ test above but with injected failure to prove that the RCA automation is able to catch the error as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
