### PR TITLE
Revert "DROPME Inject failure in cluster creation to validate RCA improvements

### DIFF
--- a/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pre_install.sh
+++ b/tests/integration-tests/tests/basic/test_essential_features/test_essential_features/pre_install.sh
@@ -8,9 +8,6 @@ done
 
 case $# in
     3)
-        sudo mkdir -p /etc/systemd/system/nfs-mountd.service.d
-        printf '[Service]\nExecStartPre=/bin/false\n' | sudo tee /etc/systemd/system/nfs-mountd.service.d/inject-fail.conf
-        sudo systemctl daemon-reload
         exit 0
     ;;
     *)


### PR DESCRIPTION
### Description of changes
Revert "DROPME Inject failure in cluster creation to validate RCA improvements
This reverts a failure injection commit afc80f30a41a5c29486a21a9f64f7e60ff86e751 introduced in https://github.com/aws/aws-parallelcluster/pull/7594 The commit was injecting a fialure in a test to validate the RCA and it must be removed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
