### PR TITLE
[Test] Exclude a1 instance type family from tests

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -364,7 +364,9 @@ ULTRASERVER_CAPACITY_BLOCK_ALLOWED_SIZE_DICT = {
 CAPACITY_BLOCK_INACTIVE_STATES = ["scheduled", "payment-pending", "assessing", "delayed"]
 
 # Older generation instance types
+# This constant is only used by test code
 EXCLUDED_INSTANCE_TYPE_PREFIXES = (
+    "a1",  # a1 is based on Graviton 1 which is not supported by the newer version of Amazon Linux 2023
     "m1",
     "m2",
     "m3",


### PR DESCRIPTION
### Description of changes
Exclude a1 instance type family from tests as it is based on Graviton 1 which is not supported by the latest version of AL2023.

when A1 instance type is used with AL2023, the cluster creation fails the head node bootstrap with the error:

```
Fatal glibc error: This version of Amazon Linux requires a newer ARM64 processor
                   compliant with at least ARM architecture 8.2-a with Cryptographic
                   extensions. On EC2 this is Graviton 2 or later.
[    1.581422] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
```

#### Further Improvement
The constant `EXCLUDED_INSTANCE_TYPE_PREFIXES ` lists all the instance type we want to exclude from our testing. Despite it is used only for testing purposes it is defined in the product code, which is a bad practice. Will do the refactoring in a follow up activity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
