### PR TITLE
[Test] Stabilize test_build_image_no_internet.

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -366,13 +366,18 @@ Resources:
 
             BUILD_IMAGE_PROXY="${EnableBuildImageProxy}"
 
-            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
-            APT_RETRY="-o Acquire::Retries=5"
+            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches),
+            # plus a lock timeout so apt-get waits for a boot-time apt/unattended-upgrade process
+            # (holding /var/lib/dpkg/lock-frontend) to release, instead of failing immediately.
+            # Acquire::Retries only covers network fetches, not the dpkg lock.
+            APT_RETRY="-o Acquire::Retries=5 -o DPkg::Lock::Timeout=300"
 
             # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
             # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            # unattended-upgrades.service is a separate boot unit (not driven by apt-daily.timer), so it
+            # is disabled explicitly too — otherwise it can hold the dpkg lock during our apt-get install.
             flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
-              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service unattended-upgrades.service || true
             sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
               /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 
@@ -596,13 +601,18 @@ Resources:
 
             BUILD_IMAGE_PROXY="${EnableBuildImageProxy}"
 
-            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
-            APT_RETRY="-o Acquire::Retries=5"
+            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches),
+            # plus a lock timeout so apt-get waits for a boot-time apt/unattended-upgrade process
+            # (holding /var/lib/dpkg/lock-frontend) to release, instead of failing immediately.
+            # Acquire::Retries only covers network fetches, not the dpkg lock.
+            APT_RETRY="-o Acquire::Retries=5 -o DPkg::Lock::Timeout=300"
 
             # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
             # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            # unattended-upgrades.service is a separate boot unit (not driven by apt-daily.timer), so it
+            # is disabled explicitly too — otherwise it can hold the dpkg lock during our apt-get install.
             flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
-              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service unattended-upgrades.service || true
             sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
               /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -568,6 +568,14 @@ Resources:
             set -o pipefail
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+            # Resolve this instance's ID via IMDSv2, for troubleshooting. Never fails: echoes
+            # "unknown" if the metadata lookup does not succeed.
+            function get_instance_id() {
+              local token
+              token=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300" || true)
+              curl -sf -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id || echo "unknown"
+            }
+
             # Signal the success/failure to the wait condition.
             function signal() {
               curl -X PUT -H "Content-Type:" \
@@ -580,7 +588,8 @@ Resources:
               rc=$?
               trap - EXIT
               if [ "$rc" -ne 0 ]; then
-                signal FAILURE "ProxyClient UserData failed before signaling verification" || true
+                INSTANCE_ID=$(get_instance_id)
+                signal FAILURE "ProxyClient (instance ${!INSTANCE_ID}) UserData failed before signaling verification" || true
               fi
             }
             trap signal_failure EXIT

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -128,7 +128,9 @@ def test_build_image_no_internet(
         chef_cookbook=s3_artifacts["chef_cookbook"],
         node_package=s3_artifacts["node_package"],
         install_http_proxy_address=install_http_proxy_address,
+        update_os_packages=str(feature_flags["update_os_packages"]).lower(),
         enable_nvidia=str(enable_nvidia).lower(),
+        enable_lustre_client=str(feature_flags["enable_lustre_client"]).lower(),
     )
 
     image = images_factory(image_id, image_config, region)

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -74,7 +74,7 @@ def _get_base_ami(region, os, architecture):
         # Use official AMIs. First stage AMIs must not be used as parent image in this test.
         base_ami = retrieve_latest_ami(region, os, ami_type="official", architecture=architecture)
         update_os_packages = True
-        if os in ["ubuntu2204", "rhel9", "ubuntu2404"]:
+        if os in ["rhel9", "ubuntu2404"]:
             enable_lustre_client = False
     else:
         # Test vanilla AMIs.

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
@@ -12,7 +12,11 @@ Build:
     Iam:
         AdditionalIamPolicies:
             - Policy: arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess
+    UpdateOsPackages:
+        Enabled: {{ update_os_packages }}
     Installation:
+        LustreClient:
+            Enabled: {{ enable_lustre_client }}
         NvidiaSoftware:
             Enabled: {{ enable_nvidia }}
 


### PR DESCRIPTION
### Description of changes
Stabilize `test_build_image_no_internet`: align the build image config to the one used in `test_build_image` (with internet), where lustre installation is disabled on ubuntu2404. The test was not honoring this configuration because it missed the parameter to disable lustre. With this change we can drive the test to conclusion at the cost of not covering the case of ubu24 with lustre enabled. Now the test without internet covers the same of build-image with internet barring the proxied env.

Future improvements for `test_build_image_no_internet` and `test_build_image`: we must increase the coverage so that we cover all the combinations of update OS and Lustre instalation.

### Tests
ONGOING:

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
        # RHEL family (rhel8, rhel9) -> Red Hat Enterprise Linux reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel8", "rhel9"]
        # Non-RHEL family (alinux2023, ubuntu2204, ubuntu2404, rocky8, rocky9) -> Linux/UNIX reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_5_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
