### PR TITLE
[Test] test_multi_az_fsx: use flexible instance types to prevent the risk of ICEs and instance types not being supported.

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
@@ -21,7 +21,9 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           MaxCount: 1
       Networking:
@@ -34,7 +36,9 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           MaxCount: 1
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
@@ -21,7 +21,9 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           MaxCount: 1
       Networking:
@@ -34,7 +36,9 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           Instances:
-            - InstanceType: {{ instance }}
+            {% for instance_type in flexible_instance_types %}
+            - InstanceType: {{ instance_type }}
+            {% endfor %}
           MinCount: 1
           MaxCount: 1
       Networking:


### PR DESCRIPTION
### Description of changes
In test_multi_az_fsx: use flexible instance types to prevent the risk of ICEs and instance types not being supported.

### Tests
SUCCESS

```
test-suites:
  storage:
    test_fsx_lustre.py::test_multi_az_fsx:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ LUSTRE_OS_X86_1 }}]
          schedulers: ["slurm"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
