### PR TITLE
[BuildImage] Support build-image with UpdateOs=Enabled in proxied environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Add support for Python 3.14 in the pcluster CLI.
 
 **BUG FIXES**
+- Fix `build-image` with `UpdateOs` enabled failing in proxied environments.
 - Fixed issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, 
 the validator fails with a clear error message instead of a generic `NoneType` error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix `build-image` with `UpdateOs` enabled failing in proxied environments.
-- Fixed issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, 
+- Fix issue with validator `ExistingFsxNetworkingValidator` so that, when a shared storage does not return network interfaces, 
 the validator fails with a clear error message instead of a generic `NoneType` error.
 
 3.16.1

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -95,6 +95,68 @@ phases:
                 fi
               fi
 
+      - name: CreatingJsonFile
+        action: CreateFile
+        inputs:
+          - path: /etc/parallelcluster/image_dna.json
+            content: |
+              ${CfnParamChefDnaJson}
+            overwrite: true
+
+      # Configure the proxy for isolated (no-internet) builds, matching the setup_proxy.rb cookbook recipe.
+      - name: ConfigureProxy
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              PROXY_ENV_FILE=/etc/parallelcluster/pcluster_proxy_env.sh
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              REGION=${AWS::Region}
+              # Parse the proxy address without jq (jq is installed later, over the proxy).
+              PROXY=$(sed -n 's/.*"install_http_proxy_address"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /etc/parallelcluster/image_dna.json | head -n1)
+
+              # stdout is consumed as a step output (the env-file path), so every informational
+              # message goes to stderr and only the path is written to stdout.
+              if [ -z "${!PROXY}" ]; then
+                echo "No install_http_proxy_address set; skipping proxy configuration." >&2
+                exit 0
+              fi
+              if ! [[ ${!PROXY} =~ ^https?://[^/:]+:[0-9]+/?$ ]]; then
+                echo "Invalid install_http_proxy_address '${!PROXY}'. Expected format: http(s)://host:port." >&2
+                exit {{ FailExitCode }}
+              fi
+
+              # aws_domain: China / US-ISO / US-ISOB / classic (see setup_proxy.rb).
+              case "${!REGION}" in
+                cn-*)      DOMAIN=amazonaws.com.cn ;;
+                us-iso-*)  DOMAIN=c2s.ic.gov ;;
+                us-isob-*) DOMAIN=sc2s.sgov.gov ;;
+                *)         DOMAIN=amazonaws.com ;;
+              esac
+              NO_PROXY="localhost,127.0.0.1,169.254.169.254,.s3.${!REGION}.${!DOMAIN},s3.${!REGION}.${!DOMAIN},.s3-${!REGION}.${!DOMAIN},s3-${!REGION}.${!DOMAIN},.s3.dualstack.${!REGION}.${!DOMAIN},s3.dualstack.${!REGION}.${!DOMAIN}"
+
+              echo "Configuring proxy: ${!PROXY}" >&2
+              {
+                echo "export http_proxy=${!PROXY}"
+                echo "export https_proxy=${!PROXY}"
+                echo "export HTTP_PROXY=${!PROXY}"
+                echo "export HTTPS_PROXY=${!PROXY}"
+                echo "export no_proxy=${!NO_PROXY}"
+                echo "export NO_PROXY=${!NO_PROXY}"
+              } > ${!PROXY_ENV_FILE}
+
+              # snapd uses its own HTTP client (not the transparent proxy); without this an apt
+              # upgrade that triggers snap (e.g. the Firefox transitional package) holds the dpkg
+              # lock and hangs.
+              if [[ ${!PLATFORM} == DEBIAN ]] && [ -e /run/snapd.socket ]; then
+                snap set system proxy.http="${!PROXY}"
+                snap set system proxy.https="${!PROXY}"
+              fi
+
+              # Emit the env-file path as this step's output.
+              echo "${!PROXY_ENV_FILE}"
+
       - name: DisableUnattendedUpgrades
         action: ExecuteBash
         inputs:
@@ -102,6 +164,8 @@ phases:
             - |
               set -x
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              PROXY_ENV='{{ build.ConfigureProxy.outputs.stdout }}'
+              [ -f "${!PROXY_ENV}" ] && . "${!PROXY_ENV}"
 
               if [[ ${!PLATFORM} == DEBIAN ]]; then
                 # wait for completion of os updates performed by cloud-init
@@ -121,6 +185,8 @@ phases:
               set -x
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              PROXY_ENV='{{ build.ConfigureProxy.outputs.stdout }}'
+              [ -f "${!PROXY_ENV}" ] && . "${!PROXY_ENV}"
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y install jq
@@ -136,14 +202,6 @@ phases:
             - |
               set -x
               echo ${AWS::Region}
-
-      - name: CreatingJsonFile
-        action: CreateFile
-        inputs:
-          - path: /etc/parallelcluster/image_dna.json
-            content: |
-              ${CfnParamChefDnaJson}
-            overwrite: true
 
       - name: DisableKernelUpdate
         action: ExecuteBash
@@ -171,6 +229,8 @@ phases:
 
               if [[ ${!DISABLE_KERNEL_UPDATE} == true ]]; then
                 if [[ ${!PLATFORM} == RHEL ]]; then
+                  PROXY_ENV='{{ build.ConfigureProxy.outputs.stdout }}'
+                  [ -f "${!PROXY_ENV}" ] && . "${!PROXY_ENV}"
                   yum install -y yum-plugin-versionlock
                   # listing all the packages because wildcard does not work as expected
                   yum versionlock ${!KERNEL_PACKAGES_PREFIX} ${!KERNEL_PACKAGES_PREFIX}-core ${!KERNEL_PACKAGES_PREFIX}-modules
@@ -193,6 +253,8 @@ phases:
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
               PLATFORM='{{ build.PlatformName.outputs.stdout }}'
               DISABLE_KERNEL_UPDATE='{{ build.DisableKernelUpdate.outputs.stdout }}'
+              PROXY_ENV='{{ build.ConfigureProxy.outputs.stdout }}'
+              [ -f "${!PROXY_ENV}" ] && . "${!PROXY_ENV}"
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y update
@@ -266,6 +328,15 @@ phases:
         maxAttempts: 2
         inputs:
             delaySeconds: 10
+
+      - name: Cleanup
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              PROXY_ENV='{{ build.ConfigureProxy.outputs.stdout }}'
+              if [ -n "${!PROXY_ENV}" ]; then rm -f "${!PROXY_ENV}"; fi
 
   - name: validate
     steps:

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -130,6 +130,7 @@ def test_build_image_no_internet(
         install_http_proxy_address=install_http_proxy_address,
         enable_nvidia=str(enable_nvidia).lower(),
         enable_lustre_client=str(feature_flags["enable_lustre_client"]).lower(),
+        update_os_packages=str(feature_flags["update_os_packages"]).lower(),
     )
 
     image = images_factory(image_id, image_config, region)

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_no_internet/image.config.yaml
@@ -12,6 +12,8 @@ Build:
     Iam:
         AdditionalIamPolicies:
             - Policy: arn:{{ partition }}:iam::aws:policy/AmazonS3ReadOnlyAccess
+    UpdateOsPackages:
+        Enabled: {{ update_os_packages }}
     Installation:
         LustreClient:
             Enabled: {{ enable_lustre_client }}


### PR DESCRIPTION
### Description of changes
Support build-image with UpdateOs enabled in proxied environments.

With this fix we now execute the proxy configuration in the ImageBuilder component update_and_reboot.yaml.
The proxy config steps mimic what we already do in the dedicated cookbook recipe.

#### Alternative approaches
As an alternative approach we could invoke the cookbook recipe to setup the proxy. In this way we would have the logic to configure the proxy in a single place. However, I am not doing it here because this would break the following two rules we have always complied with:
1. update&reboot component must not depend on any cookbook artifact. This rule can be revised b/c 
2. we do not call internal recipes. this is a weak argument b/c we could anyways create a new entrypoint just to configure the proxy.

### Tests
ONGOING

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
        # RHEL family (rhel8, rhel9) -> Red Hat Enterprise Linux reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel8", "rhel9"]
        # Non-RHEL family (alinux2023, ubuntu2204, ubuntu2404, rocky8, rocky9) -> Linux/UNIX reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_5_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
