### PR TITLE
[Test] Stabilize bootstrap of proxy instance used for testing and facilitate troubleshooting

### DIFF
--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -366,13 +366,18 @@ Resources:
 
             BUILD_IMAGE_PROXY="${EnableBuildImageProxy}"
 
-            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
-            APT_RETRY="-o Acquire::Retries=5"
+            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches),
+            # plus a lock timeout so apt-get waits for a boot-time apt/unattended-upgrade process
+            # (holding /var/lib/dpkg/lock-frontend) to release, instead of failing immediately.
+            # Acquire::Retries only covers network fetches, not the dpkg lock.
+            APT_RETRY="-o Acquire::Retries=5 -o DPkg::Lock::Timeout=300"
 
             # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
             # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            # unattended-upgrades.service is a separate boot unit (not driven by apt-daily.timer), so it
+            # is disabled explicitly too — otherwise it can hold the dpkg lock during our apt-get install.
             flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
-              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service unattended-upgrades.service || true
             sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
               /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 
@@ -596,13 +601,18 @@ Resources:
 
             BUILD_IMAGE_PROXY="${EnableBuildImageProxy}"
 
-            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches).
-            APT_RETRY="-o Acquire::Retries=5"
+            # apt's built-in retry for transient fetch failures (e.g., Ubuntu mirror sync glitches),
+            # plus a lock timeout so apt-get waits for a boot-time apt/unattended-upgrade process
+            # (holding /var/lib/dpkg/lock-frontend) to release, instead of failing immediately.
+            # Acquire::Retries only covers network fetches, not the dpkg lock.
+            APT_RETRY="-o Acquire::Retries=5 -o DPkg::Lock::Timeout=300"
 
             # Disable Ubuntu's boot-time apt jobs (same used in ParallelCluster build-image component).
             # flock waits for any in-flight apt-daily, then we disable the units and unattended-upgrades.
+            # unattended-upgrades.service is a separate boot unit (not driven by apt-daily.timer), so it
+            # is disabled explicitly too — otherwise it can hold the dpkg lock during our apt-get install.
             flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock \
-              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service || true
+              systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service unattended-upgrades.service || true
             sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" \
               /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades || true
 

--- a/cloudformation/proxy/proxy.yaml
+++ b/cloudformation/proxy/proxy.yaml
@@ -568,6 +568,14 @@ Resources:
             set -o pipefail
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+            # Resolve this instance's ID via IMDSv2, for troubleshooting. Never fails: echoes
+            # "unknown" if the metadata lookup does not succeed.
+            function get_instance_id() {
+              local token
+              token=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300" || true)
+              curl -sf -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id || echo "unknown"
+            }
+
             # Signal the success/failure to the wait condition.
             function signal() {
               curl -X PUT -H "Content-Type:" \
@@ -580,7 +588,8 @@ Resources:
               rc=$?
               trap - EXIT
               if [ "$rc" -ne 0 ]; then
-                signal FAILURE "ProxyClient UserData failed before signaling verification" || true
+                INSTANCE_ID=$(get_instance_id)
+                signal FAILURE "ProxyClient (instance ${!INSTANCE_ID}) UserData failed before signaling verification" || true
               fi
             }
             trap signal_failure EXIT


### PR DESCRIPTION
### Description of changes
Improvement to the bootstrap of proxy infra used for testing:
1. stabilized bootstrap by preventing failure caused by dpkg locking
2. facilitate troubleshooting by surfacing the broken instance id in the failure message reported by the test. 

### Tests
Executed the following tests, which all succeeded the bootstrap of the proxy infrastructure.
```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
        # RHEL family (rhel8, rhel9) -> Red Hat Enterprise Linux reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel8", "rhel9"]
        # Non-RHEL family (alinux2023, ubuntu2204, ubuntu2404, rocky8, rocky9) -> Linux/UNIX reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_5_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
