### PR TITLE
[Test] In build-image tests, select the parent AMI by most recent version and creation date.

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -13,6 +13,7 @@ import logging
 import os
 import pathlib
 import random
+import re
 import string
 import time
 import uuid
@@ -48,6 +49,10 @@ GPU_JOB_SCRIPT = pathlib.Path(__file__).parent / "data/gpu_job.sh"
 
 RHEL_OWNERS = ["309956199498", "841258680906", "219670896067"]
 
+# Matches the Red Hat "RHEL-<major>.<minor>[.<patch>]" AMI naming (e.g. RHEL-9.6.0_HVM-...),
+# used to sort RHEL AMIs by version and select the latest minor.
+RHEL_AMI_VERSION_REGEX = re.compile(r"RHEL-(\d+)\.(\d+)(?:\.(\d+))?")
+
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux2023": {"name": "al2023-ami-2023.*.*.*-kernel-6.1-*", "owners": ["amazon"]},
     # TODO: use marketplace AMI if possible
@@ -71,9 +76,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     },  # TODO add china and govcloud accounts
     "rhel8.9": {"name": "RHEL-8.9*_HVM-*", "owners": RHEL_OWNERS},
     "rocky8.9": {"name": "Rocky-8-EC2-Base-8.9*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
-    # Pin to the latest RHEL 9.8 as previous minor requires paid Extended Update Support (EUS) repo
-    # to install packages we need, such as kernel packages.
-    "rhel9": {"name": "RHEL-9.8*_HVM*", "owners": RHEL_OWNERS},
+    "rhel9": {"name": "RHEL-9.*_HVM*", "owners": RHEL_OWNERS},
     "rocky9": {"name": "Rocky-9-EC2-Base-9.*", "owners": ["792107900819"]},  # TODO add china and govcloud accounts
 }
 
@@ -195,8 +198,7 @@ def retrieve_latest_ami(
         images = []
         for page in page_iterator:
             images.extend(page["Images"])
-        # Sort on Creation date Desc
-        image_id = sorted(images, key=lambda x: x["CreationDate"], reverse=True)[0]["ImageId"]
+        image_id = _select_latest_image(images)["ImageId"]
         logging.info("Retrieved AMI: %s" % image_id)
         return image_id
     except ClientError as e:
@@ -208,6 +210,37 @@ def retrieve_latest_ami(
     except IndexError as e:
         LOGGER.critical("Error no ami retrieved: {0}".format(e))
         raise
+
+
+def _select_latest_image(images: list):
+    """Return the latest image from the provided list.
+
+    Prefers the highest version parsed from the AMI name, then the newest publish date within it.
+    Falls back to newest publish date alone when any AMI name cannot be parsed into a version.
+
+    We prioritize the latest minor version not only because we want to use fresh software, but also because
+    there are cases where using the latest minor is mandatory. For example, on RHEL older minors require to enable
+    the paid Extended Update Support (EUS) repo.
+    """
+    LOGGER.info("Selecting latest AMI among: %s", [(image["ImageId"], image["Name"]) for image in images])
+    # If the version cannot be parsed from the AMI name, the sorting falls back to creation date only.
+    return sorted(
+        images,
+        key=lambda image: (_parse_ami_version(image["Name"]) or (), image["CreationDate"]),
+        reverse=True,
+    )[0]
+
+
+def _parse_ami_version(ami_name: str):
+    """Extract the version tuple (e.g. (9, 6, 0)) from an AMI name, or None if it cannot be parsed."""
+    if ami_name.startswith("RHEL-"):
+        match = RHEL_AMI_VERSION_REGEX.search(ami_name)
+        if match:
+            version = tuple(int(part) for part in match.groups() if part is not None)
+            LOGGER.info("Parsed version from AMI name %s: %s", version, ami_name)
+            return version
+    LOGGER.warning("Could not parse version from AMI name %r", ami_name)
+    return None
 
 
 def _get_ami_for_os(ami_type, os, architecture="x86_64"):

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -49,9 +49,13 @@ GPU_JOB_SCRIPT = pathlib.Path(__file__).parent / "data/gpu_job.sh"
 
 RHEL_OWNERS = ["309956199498", "841258680906", "219670896067"]
 
-# Matches the Red Hat "RHEL-<major>.<minor>[.<patch>]" AMI naming (e.g. RHEL-9.6.0_HVM-...),
-# used to sort RHEL AMIs by version and select the latest minor.
-RHEL_AMI_VERSION_REGEX = re.compile(r"RHEL-(\d+)\.(\d+)(?:\.(\d+))?")
+# Regexes to extract a version from an AMI name
+#   RHEL: "RHEL-<major>.<minor>[.<patch>]"                 e.g. RHEL-9.6.0_HVM-...
+#   AL2023: "al2023-ami-<year>.<minor>.<build>.<revision>" e.g. al2023-ami-2023.12.20260817.0-kernel-6.1-x86_64
+AMI_NAME_PREFIX_TO_VERSION_REGEX = {
+    "RHEL-": re.compile(r"RHEL-(\d+)\.(\d+)(?:\.(\d+))?"),
+    "al2023-ami-": re.compile(r"al2023-ami-(\d+)\.(\d+)\.(\d+)\.(\d+)"),
+}
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux2023": {"name": "al2023-ami-2023.*.*.*-kernel-6.1-*", "owners": ["amazon"]},
@@ -233,12 +237,13 @@ def _select_latest_image(images: list):
 
 def _parse_ami_version(ami_name: str):
     """Extract the version tuple (e.g. (9, 6, 0)) from an AMI name, or None if it cannot be parsed."""
-    if ami_name.startswith("RHEL-"):
-        match = RHEL_AMI_VERSION_REGEX.search(ami_name)
-        if match:
-            version = tuple(int(part) for part in match.groups() if part is not None)
-            LOGGER.info("Parsed version from AMI name %s: %s", version, ami_name)
-            return version
+    for prefix, regex in AMI_NAME_PREFIX_TO_VERSION_REGEX.items():
+        if ami_name.startswith(prefix):
+            match = regex.search(ami_name)
+            if match:
+                version = tuple(int(part) for part in match.groups() if part is not None)
+                LOGGER.info("Parsed version from AMI name %s: %s", version, ami_name)
+                return version
     LOGGER.warning("Could not parse version from AMI name %r", ami_name)
     return None
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -49,12 +49,18 @@ GPU_JOB_SCRIPT = pathlib.Path(__file__).parent / "data/gpu_job.sh"
 
 RHEL_OWNERS = ["309956199498", "841258680906", "219670896067"]
 
-# Regexes to extract a version from an AMI name
-#   RHEL: "RHEL-<major>.<minor>[.<patch>]"                 e.g. RHEL-9.6.0_HVM-...
-#   AL2023: "al2023-ami-<year>.<minor>.<build>.<revision>" e.g. al2023-ami-2023.12.20260817.0-kernel-6.1-x86_64
+# Regexes to extract a version from an AMI name, keyed by the name prefix that identifies the naming
+# convention. Within a single query the distro release is fixed, so a trailing build/serial is enough
+# to order candidates and pick the latest.
+#   RHEL:   "RHEL-<major>.<minor>[.<patch>]"                    e.g. RHEL-9.6.0_HVM-...
+#   AL2023: "al2023-ami-<year>.<minor>.<build>.<revision>"      e.g. al2023-ami-2023.12.20260817.0-kernel-6.1-x86_64
+#   Ubuntu: "ubuntu-<codename>-<release>-<arch>-server-<serial>" e.g. ubuntu-noble-24.04-amd64-server-20260904
+#   Rocky:  "Rocky-<major>-EC2-Base-<major>.<minor>-<serial>"   e.g. Rocky-9-EC2-Base-9.6-20250601.0.x86_64
 AMI_NAME_PREFIX_TO_VERSION_REGEX = {
     "RHEL-": re.compile(r"RHEL-(\d+)\.(\d+)(?:\.(\d+))?"),
     "al2023-ami-": re.compile(r"al2023-ami-(\d+)\.(\d+)\.(\d+)\.(\d+)"),
+    "ubuntu/": re.compile(r"ubuntu-\w+-(\d+)\.(\d+)-\w+-server-(\d+)(?:\.(\d+))?"),
+    "Rocky-": re.compile(r"Rocky-\d+-EC2-Base-(\d+)\.(\d+)-(\d+)(?:\.(\d+))?"),
 }
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -202,8 +202,10 @@ def retrieve_latest_ami(
         images = []
         for page in page_iterator:
             images.extend(page["Images"])
-        image_id = _select_latest_image(images)["ImageId"]
-        logging.info("Retrieved AMI: %s" % image_id)
+        image = _select_latest_image(images)
+        image_id = image["ImageId"]
+        image_name = image["Name"]
+        logging.info("Retrieved AMI: %s (%s)" % (image_id, image_name))
         return image_id
     except ClientError as e:
         LOGGER.critical(e.response.get("Error").get("Message"))


### PR DESCRIPTION
### Description of changes
In build-image tests, select the parent AMI by most recent version and creation date.

Example: before this change we used to explicitly pin RHEL9.8 as parent image for testing to prevent failure caused by older minor versions, which require the paid EUS repo.

With this change the test will use the latest minor without the need to explicitly pin it. If the parsing of version from AMI name fails, the selection will select the most recent AMI by creation date as it is already doing.

### Tests
SUCCESS
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel9"]
          schedulers: [ "slurm" ]
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rocky9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rocky9"]
          schedulers: [ "slurm" ]
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_alinux2023 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023"]
          schedulers: [ "slurm" ]
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["ubuntu2404"]
          schedulers: [ "slurm" ]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
