### PR TITLE
[Test] Extend AZ allowlisting.

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -34,26 +34,18 @@ from tests.common.utils import retrieve_latest_ami
 AVAILABLE_AVAILABILITY_ZONE = {
     # c5.xlarge is not supported in use1-az3
     "us-east-1": ["use1-az1", "use1-az2", "use1-az4", "use1-az6", "use1-az5"],
-    # c5.xlarge is not supported in apse2-az3
-    "ap-southeast-2": ["apse2-az1", "apse2-az2"],
-    # FSx for Luster is not supported in apne1-az1
-    "ap-northeast-1": ["apne1-az4", "apne1-az2"],
-    # c5.xlarge is not supported in apse1-az3
-    "ap-southeast-1": ["apse1-az2", "apse1-az1"],
-    # NAT Gateway not available in sae1-az2 , c5n.18xlarge is not supported in sae1-az3
-    "sa-east-1": ["sae1-az1"],
-    # m6g.xlarge instances not available in euw1-az3
-    "eu-west-1": ["euw1-az1", "euw1-az2"],
+    "ap-southeast-2": ["apse2-az1", "apse2-az2", "apse2-az3"],
+    "ap-northeast-1": ["apne1-az4", "apne1-az2", "apne1-az1"],
+    "ap-southeast-1": ["apse1-az2", "apse1-az1", "apse1-az3"],
+    "sa-east-1": ["sae1-az1", "sae1-az2", "sae1-az3"],
+    "eu-west-1": ["euw1-az1", "euw1-az2", "euw1-az3"],
     # c5.xlarge is not supported in eu-west-2d (euw2-az4)
     "eu-west-2": ["euw2-az1", "euw2-az2", "euw2-az3"],
-    # io2 EBS volumes not available in cac1-az4
+    # g4dn/g5 are not supported in ca-central-1d (cac1-az4)
     "ca-central-1": ["cac1-az1", "cac1-az2"],
-    # instance can only be launch in placement group in eun1-az2
-    "eu-north-1": ["eun1-az2"],
-    # g3.8xlarge is not supported in euc1-az1
-    "eu-central-1": ["euc1-az2", "euc1-az3"],
-    # FSx not available in cnn1-az4
-    "cn-north-1": ["cnn1-az1", "cnn1-az2"],
+    "eu-north-1": ["eun1-az1", "eun1-az2", "eun1-az3"],
+    "eu-central-1": ["euc1-az2", "euc1-az3", "euc1-az1"],
+    "cn-north-1": ["cnn1-az1", "cnn1-az2", "cnn1-az4"],
     # Should only consider supported AZs
     "us-isob-east-1": ["usibe1-az2", "usibe1-az3"],
     "us-iso-east-1": ["usie1-az1", "usie1-az2"],


### PR DESCRIPTION
### Description of changes

Extend AZ allowlisting used for tests as the reason for denylisting those are not valid anymore.
We want to extend not only to have a better coverage, but also because we should never have regions with just one AZ as some test require to have more than one AZ.

* apse2-az3: c5.xlarge is now supported
* apne1-az1: FSx is now supported
* apse1-az3: c5.xlarge is now supported
* sae1-az2: NAT GW is now supported
* sae1-az3: c5n.18xlarge is now supported
* euw1-az3: m6g is now supported
* eun1-az2, eun1-az3: launching in PG is now supported
* euc1-az1: g3.8xlarge not needed anymore
* cnn1-az4: FSx is now supported

### Tests
* Manually verified that the reasons why the AZs were excluded are not valid anymore.
* SUCCESS test to verify essential features are functional on those AZs

```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions:
            - "apse2-az3"
            - "apse1-az3"
            - "sae1-az2"
            - "sae1-az3"
            - "euw1-az3"
          instances:
            - "c5.xlarge"
          oss:
            - "alinux2023"
          schedulers:
            - "slurm"
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions:
            - "apne1-az1"
            - "cnn1-az4"
          instances:
            - "c5.xlarge"
          oss:
            - "alinux2023"
          schedulers:
            - "slurm"
  networking:
    test_placement_group.py::test_placement_group:
      dimensions:
        - regions:
            - "eun1-az2"
            - "eun1-az3"
          instances:
            - "c5.xlarge"
          oss:
            - "alinux2023"
          schedulers:
            - "slurm"
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
