### PR TITLE
[Test] Move test_multiple_efs to ap-southeast-1

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -676,13 +676,14 @@ test-suites:
           schedulers: [ "slurm" ]
     # The checks performed in test_efs_same_az is similar to test_multiple_efs.
     # We should consider this when assigning dimensions to each test.
+    # This test must be executed in regions with 3+ AZs allowlisted.
     test_efs.py::test_multiple_efs:
       dimensions:
         - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [{{ OS_X86_2 }}]
           schedulers: ["slurm"]
-        - regions: [ "ca-central-1" ]
+        - regions: [ "ap-southeast-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: [{{ OS_ARM_2 }}]
           schedulers: [ "slurm" ]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -257,9 +257,10 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["rhel8"]
           schedulers: ["slurm"]
+    # This test must be executed in regions with 3+ AZs allowlisted
     test_efs.py::test_multiple_efs:
       dimensions:
-        - regions: [ "ca-central-1" ]
+        - regions: [ "ap-southeast-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["ubuntu2204"]
           schedulers: [ "slurm" ]


### PR DESCRIPTION
### Description of changes
Move test_multiple_efs to ap-southeast-1  as the test requires regions with 3+ allowlisted AZs.
ap-southeast-1 is the least used for testing.

### Tests
SUCCESS
```
{%- import 'common.jinja2' as common with context -%}
{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
---
test-suites:
  storage:
    test_efs.py::test_multiple_efs:
      dimensions:
        - regions: [ "ap-southeast-1" ]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: [{{ OS_ARM_2 }}]
          schedulers: [ "slurm" ]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
