### PR TITLE
[Test] Cap OSU collective message size at 8K on burstable-network instances

### DIFF
--- a/tests/integration-tests/tests/common/data/osu/osu_collective_submit_intelmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_collective_submit_intelmpi.sh
@@ -5,6 +5,7 @@ BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 NUM_OF_PROCESSES={{ num_of_processes }}
 REPETITIONS={{ repetitions }}
+OSU_OPTIONS="{{ osu_options }}"
 
 module load intelmpi
 export I_MPI_DEBUG=10
@@ -23,5 +24,5 @@ env
 # Run collective benchmark. The collective operations are close to what a real application looks like.
 # -np total number of processes to run (all vCPUs * N compute nodes), divided by 2 if multithreading is disabled
 for _ in $(seq ${REPETITIONS}); do
-  mpirun -bootstrap=slurm -np ${NUM_OF_PROCESSES} /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}
+  mpirun -bootstrap=slurm -np ${NUM_OF_PROCESSES} /shared/intelmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME} ${OSU_OPTIONS}
 done > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/common/data/osu/osu_collective_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/osu/osu_collective_submit_openmpi.sh
@@ -5,6 +5,7 @@ BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 NUM_OF_PROCESSES={{ num_of_processes }}
 REPETITIONS={{ repetitions }}
+OSU_OPTIONS="{{ osu_options }}"
 
 module load openmpi
 
@@ -13,5 +14,5 @@ env
 # Run collective benchmark. The collective operations are close to what a real application looks like.
 # -np total number of processes to run (all vCPUs * N compute nodes), divided by 2 if multithreading is disabled
 for _ in $(seq ${REPETITIONS}); do
-  mpirun -np ${NUM_OF_PROCESSES} /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}
+  mpirun -np ${NUM_OF_PROCESSES} /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME} ${OSU_OPTIONS}
 done > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/common/osu_common.py
+++ b/tests/integration-tests/tests/common/osu_common.py
@@ -54,6 +54,7 @@ def run_individual_osu_benchmark(  # noqa C901
     rendered_template_path=None,
     timeout=None,
     repetitions=1,
+    max_message_size=None,
 ):
     """
     Run the given OSU benchmark.
@@ -74,6 +75,8 @@ def run_individual_osu_benchmark(  # noqa C901
     :param timeout: int, maximum number of minutes to wait for job to complete
     :param repetitions: int, how many times to run the benchmark inside the same job. The caller reduces the
                         repetitions to their median per packet size
+    :param max_message_size: int, largest message size in bytes the benchmark is run with (OSU -m option).
+                             None keeps the OSU default. Only honored by the collective templates
     :return: string, stdout of the benchmark job
     """
     logging.info(f"Running OSU benchmark {OSU_BENCHMARK_VERSION}: {benchmark_name} for {mpi_version}")
@@ -98,6 +101,7 @@ def run_individual_osu_benchmark(  # noqa C901
         num_of_processes_per_node=slots_per_instance,
         network_interfaces_count=network_interfaces_count,
         repetitions=repetitions,
+        osu_options=f"-m :{max_message_size}" if max_message_size else "",
     )
 
     def submit_job():

--- a/tests/integration-tests/tests/performance_tests/test_osu.py
+++ b/tests/integration-tests/tests/performance_tests/test_osu.py
@@ -37,6 +37,9 @@ OSU_BENCHMARKS_INSTANCES = ["c5n.18xlarge", "p5en.48xlarge", "p6-b200.48xlarge"]
 # after, so a persistent regression still fails while a one-off spike does not.
 CONFIRMATION_REPETITIONS = 2
 
+# Largest collective message size run on instance types with a burstable network.
+BURSTABLE_NETWORK_MAX_MESSAGE_SIZE = 8192
+
 
 @pytest.mark.flaky(reruns=0)
 def test_osu(
@@ -56,6 +59,7 @@ def test_osu(
     instance_info = get_instance_info(instance)
     instance_memory = instance_info["MemoryInfo"]["SizeInMiB"]
     instance_efa_supported = instance_info["NetworkInfo"]["EfaSupported"]
+    max_message_size = BURSTABLE_NETWORK_MAX_MESSAGE_SIZE if _has_burstable_network(instance_info) else None
     if instance_memory <= 16384:
         # For smaller instance types, run a large cluster. The head node needs to be large to handle the cluster.
         max_queue_size = 500
@@ -131,6 +135,7 @@ def test_osu(
                 num_instances=max_queue_size,
                 slots_per_instance=slots_per_instance,
                 partition="efa-enabled",
+                max_message_size=max_message_size,
             )
         )
     assert_that(benchmark_failures, description="Some OSU benchmarks are failing").is_empty()
@@ -149,6 +154,15 @@ def test_osu(
         )
 
     assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
+
+
+def _has_burstable_network(instance_info):
+    """Return True when the instance type's network bandwidth is burstable."""
+    network_info = instance_info.get("NetworkInfo", {})
+    cards = network_info.get("NetworkCards") or []
+    if any("BaselineBandwidthInGbps" in card and "PeakBandwidthInGbps" in card for card in cards):
+        return any(card.get("BaselineBandwidthInGbps", 0) < card.get("PeakBandwidthInGbps", 0) for card in cards)
+    return str(network_info.get("NetworkPerformance", "")).lower().startswith("up to")
 
 
 def _test_osu_benchmarks_pt2pt(
@@ -203,6 +217,7 @@ def _test_osu_benchmarks_collective(
     num_instances,
     slots_per_instance,
     partition=None,
+    max_message_size=None,
 ):
     failed_benchmarks = []
     benchmark_group = "collective"
@@ -226,6 +241,7 @@ def _test_osu_benchmarks_collective(
             test_datadir,
             repetitions=repetitions,
             timeout=24 + repetitions * num_instances * 0.1,
+            max_message_size=max_message_size,
         )
         return output
 


### PR DESCRIPTION
### Description of changes
On 500 x c5.xlarge the collectives above 8K are bandwidth bound and run above the instance's 1.25 Gbps network baseline, so the result tracks EC2 burst credits rather than the software under test. In the perf history, those tests show most noises, and don't give clear signals of performance degradation

### Tests
* test_osu has been passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
